### PR TITLE
Fix agent-browser missing Chromium shared libraries

### DIFF
--- a/packages/agent-browser/build.ncl
+++ b/packages/agent-browser/build.ncl
@@ -15,6 +15,7 @@ let alsa-lib = import "../alsa-lib/build.ncl" in
 let cairo = import "../cairo/build.ncl" in
 let cups = import "../cups/build.ncl" in
 let dbus = import "../dbus/build.ncl" in
+let eudev = import "../eudev/build.ncl" in
 let expat = import "../expat/build.ncl" in
 let fontconfig = import "../fontconfig/build.ncl" in
 let freetype = import "../freetype/build.ncl" in
@@ -67,6 +68,7 @@ let version = "0.15.1" in
     cairo,
     cups,
     dbus,
+    eudev,
     expat,
     fontconfig,
     freetype,

--- a/packages/at-spi2-core/build.ncl
+++ b/packages/at-spi2-core/build.ncl
@@ -37,7 +37,7 @@ let version = "2.54.2" in
   cmd = "./build.sh",
 
   outputs = {
-    libs = { glob = "usr/lib/libatspi.so*" } | OutputLib,
+    libs = { glob = "usr/lib/{libatspi,libatk-bridge-2.0}.so*" } | OutputLib,
     includes = { glob = "usr/include/at-spi*/**" } | OutputData,
     pkgconfigs = { glob = "usr/lib/pkgconfig/{atk-bridge*,atspi*}.pc" } | OutputData,
   },

--- a/packages/eudev/build.ncl
+++ b/packages/eudev/build.ncl
@@ -1,0 +1,55 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let gperf = import "../gperf/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+
+let version = "3.2.14" in
+{
+  name = "eudev",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/eudev-%{version}.tar.gz",
+      sha256 = "8da4319102f24abbf7fff5ce9c416af848df163b29590e666d334cc1927f006f",
+      extract = true,
+      strip_prefix = "eudev-%{version}",
+    } | Source,
+    base,
+    make,
+    gperf,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    libs = { glob = "usr/lib/libudev.so*" } | OutputLib,
+    includes = { glob = "usr/include/libudev.h" } | OutputData,
+    pkgconfig = { glob = "usr/lib/pkgconfig/libudev.pc" } | OutputData,
+  },
+  tests = {
+    smoketest =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "test -f /usr/lib/libudev.so.1"],
+        ],
+      } | Test,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "eudev-project",
+        repo = "eudev",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/eudev/build.sh
+++ b/packages/eudev/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr \
+            --disable-programs \
+            --disable-blkid \
+            --disable-selinux \
+            --disable-kmod \
+            --disable-manpages \
+            --disable-hwdb \
+            --disable-mtd_probe \
+            --disable-rule-generator \
+            --disable-static
+
+make -j$(nproc)
+make DESTDIR=$OUTPUT_DIR install


### PR DESCRIPTION
at-spi2-core's output glob only captured libatspi.so* but at-spi2-core 2.54.2 also builds libatk-bridge-2.0.so* (merged from at-spi2-atk). Widen the glob to capture both.

Add eudev package (3.2.14) providing libudev.so.1, built with --disable-programs for a minimal library-only build.

Add eudev to agent-browser runtime_deps. Together these fix the two missing libraries (libatk-bridge-2.0.so.0, libudev.so.1) that prevented Chromium from launching.