### PR TITLE
claude-code: update to 2.1.85

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -10,9 +10,9 @@ let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
-  version = "2.1.84",
-  amd64_sha256 = "c6872aa8db94f303bc6a4482664e40d3288dfc989c89ba268473ed32e3055878",
-  arm64_sha256 = "5c868174b44439e51c74ff084c306856c41779615250d5bbdaa5d10056362814",
+  version = "2.1.85",
+  amd64_sha256 = "ff0b23dba11c97a53386c61ebe47d46d768a8ad33f98c7d22186c9a63f179f4d",
+  arm64_sha256 = "b23709a394d1e3d977f9f3025bdaa1b1285715d10a48957e587952d8ef3a27f4",
 }
 in
 


### PR DESCRIPTION
## Summary
- Update claude-code package from 2.1.74 to 2.1.84
- Update amd64 and arm64 SHA256 hashes for the new version

## Test plan
- [ ] `minimal check --packages claude-code`
- [ ] `minimal --no-cache package claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)