### PR TITLE
Update llama.cpp to b8651

### DIFF
--- a/packages/llama.cpp/build.ncl
+++ b/packages/llama.cpp/build.ncl
@@ -10,14 +10,14 @@ let hwdata = import "../hwdata/build.ncl" in
 let pciutils = import "../pciutils/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "b8041" in
+let version = "b8651" in
 {
   name = "llama.cpp",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/ggml-org/llama.cpp/%{version}.tar.gz",
-      sha256 = "3d3015ce8326b22024e8d833be996f82c6444b232a804b2b983bf6e57ba65a2e",
+      sha256 = "b88b0469a1d1cff4344b234b5e18ffc60be3ff3e0516b7d3116c3c605520afb2",
       extract = true,
       strip_prefix = "llama.cpp-%{version}",
     } | Source,


### PR DESCRIPTION
## Update llama.cpp `b8041` → `b8651`

**Source:** `github:ggml-org/llama.cpp`
**Release:** https://github.com/ggml-org/llama.cpp/releases/tag/b8651
**Changelog:** https://github.com/ggml-org/llama.cpp/compare/b8041...b8651

### Changes

| | Old | New |
|---|---|---|
| **Version** | `b8041` | `b8651` |
| **SHA256** | `3d3015ce83268322...` | `b88b0469a1d1cff4...` |
| **Size** | | 29.7 MB |
| **GCS** | | `gs://minimal-staging-archives/ggml-org/llama.cpp/b8651.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*