### PR TITLE
Update Go to 1.25.8, add pulumi-go harness

### DIFF
--- a/harnesses/pulumi-go/harness.ncl
+++ b/harnesses/pulumi-go/harness.ncl
@@ -9,17 +9,7 @@ harness {
     CGO_ENABLED = "0",
   },
 
-  build_cmds_cmd = [
-    "/bin/bash",
-    "-c",
-    m%"
-    # Install Pulumi Go SDK if not vendored
-    if [ ! -d vendor ] && grep -q 'github.com/pulumi/pulumi' go.mod 2>/dev/null; then
-      go mod download
-    fi
-    go build -trimpath -ldflags="-buildid=" ./...
-  "%
-  ],
+  build_cmd = "go build -trimpath -ldflags=\"-buildid=\" ./...",
 
   matches_project_if_any = [
     {

--- a/harnesses/pulumi-go/harness.ncl
+++ b/harnesses/pulumi-go/harness.ncl
@@ -1,0 +1,33 @@
+let { harness, .. } = import "minimal.ncl" in
+harness {
+  name = "pulumi-go",
+
+  build_packages = ["go", "binutils", "linux_headers"],
+  runtime_packages = ["pulumi"],
+
+  build_env_vars = {
+    CGO_ENABLED = "0",
+  },
+
+  build_cmds_cmd = [
+    "/bin/bash",
+    "-c",
+    m%"
+    # Install Pulumi Go SDK if not vendored
+    if [ ! -d vendor ] && grep -q 'github.com/pulumi/pulumi' go.mod 2>/dev/null; then
+      go mod download
+    fi
+    go build -trimpath -ldflags="-buildid=" ./...
+  "%
+  ],
+
+  matches_project_if_any = [
+    {
+      file_regexes = {
+        "go.mod" = "github\\.com/pulumi/pulumi",
+        "Pulumi.yaml" = "(?s)runtime:.*?go",
+      },
+    }
+  ],
+  matches_project_priority = 15, # Higher than plain go harness
+}

--- a/packages/go/build.ncl
+++ b/packages/go/build.ncl
@@ -4,19 +4,19 @@ let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
 let variants = {
-  "1.25.5" = {
-    amd64_url = "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz",
-    amd64_sha256 = "9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b",
+  "1.25.8" = {
+    amd64_url = "https://go.dev/dl/go1.25.8.linux-amd64.tar.gz",
+    amd64_sha256 = "ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6",
 
-    arm64_url = "https://go.dev/dl/go1.25.5.linux-arm64.tar.gz",
-    arm64_sha256 = "b00b694903d126c588c378e72d3545549935d3982635ba3f7a964c9fa23fe3b9",
+    arm64_url = "https://go.dev/dl/go1.25.8.linux-arm64.tar.gz",
+    arm64_sha256 = "7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7",
 
-    source_url = "https://go.dev/dl/go1.25.5.src.tar.gz",
-    source_sha256 = "22a5fd0a91efcd28a1b0537106b9959b2804b61f59c3758b51e8e5429c1a954f",
+    source_url = "https://go.dev/dl/go1.25.8.src.tar.gz",
+    source_sha256 = "e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e",
   },
 }
 in
-let version = "1.25.5" in
+let version = "1.25.8" in
 {
   name = "go",
   build_deps = [

--- a/packages/go/build.ncl
+++ b/packages/go/build.ncl
@@ -3,20 +3,18 @@ let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
+let version = "1.25.8" in
 let variants = {
-  "1.25.8" = {
-    amd64_url = "https://go.dev/dl/go1.25.8.linux-amd64.tar.gz",
-    amd64_sha256 = "ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6",
+  amd64_url = "https://go.dev/dl/go%{version}.linux-amd64.tar.gz",
+  amd64_sha256 = "ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6",
 
-    arm64_url = "https://go.dev/dl/go1.25.8.linux-arm64.tar.gz",
-    arm64_sha256 = "7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7",
+  arm64_url = "https://go.dev/dl/go%{version}.linux-arm64.tar.gz",
+  arm64_sha256 = "7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7",
 
-    source_url = "https://go.dev/dl/go1.25.8.src.tar.gz",
-    source_sha256 = "e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e",
-  },
+  source_url = "https://go.dev/dl/go%{version}.src.tar.gz",
+  source_sha256 = "e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e",
 }
 in
-let version = "1.25.8" in
 {
   name = "go",
   build_deps = [
@@ -24,18 +22,18 @@ let version = "1.25.8" in
     match {
       { arch = 'Amd64, .. } =>
         {
-          url = variants."%{version}".amd64_url,
-          sha256 = variants."%{version}".amd64_sha256,
+          url = variants.amd64_url,
+          sha256 = variants.amd64_sha256,
         } | Source,
       { arch = 'Arm64, .. } =>
         {
-          url = variants."%{version}".arm64_url,
-          sha256 = variants."%{version}".arm64_sha256,
+          url = variants.arm64_url,
+          sha256 = variants.arm64_sha256,
         } | Source,
     } target,
     {
-      url = variants."%{version}".source_url,
-      sha256 = variants."%{version}".source_sha256,
+      url = variants.source_url,
+      sha256 = variants.source_sha256,
     } | Source,
     base,
     toolchain,


### PR DESCRIPTION
## Go 1.25.5 → 1.25.8

Patch update with checksums for amd64, arm64, and source.

## New harness: pulumi-go

Combines Go toolchain with Pulumi runtime for Go-based Pulumi projects. Detects projects with:
- `go.mod` importing `github.com/pulumi/pulumi`
- `Pulumi.yaml` with `runtime: go`

Priority 15 (above plain `go` harness, matching `pulumi-nodejs` convention).

Includes reproducibility flags: `-trimpath -ldflags="-buildid="`, `CGO_ENABLED=0`.

## Validation

```
minimal check --harnesses     # 17/17 pass (including pulumi-go)
minimal check --packages go   # all pass
minimal patched-build go      # builds successfully, cached at c4e13e55...
```