### PR TITLE
Bump Go from 1.25.8 to 1.26.2

### DIFF
--- a/packages/go/build.ncl
+++ b/packages/go/build.ncl
@@ -3,16 +3,16 @@ let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "1.25.8" in
+let version = "1.26.2" in
 let variants = {
   amd64_url = "https://go.dev/dl/go%{version}.linux-amd64.tar.gz",
-  amd64_sha256 = "ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6",
+  amd64_sha256 = "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282",
 
   arm64_url = "https://go.dev/dl/go%{version}.linux-arm64.tar.gz",
-  arm64_sha256 = "7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7",
+  arm64_sha256 = "c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23",
 
   source_url = "https://go.dev/dl/go%{version}.src.tar.gz",
-  source_sha256 = "e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e",
+  source_sha256 = "2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b",
 }
 in
 {


### PR DESCRIPTION
## Summary

Bumps Go from 1.25.8 to 1.26.2 (latest stable, released 2026-04-07).

This is a major version bump (1.25 -> 1.26) plus the latest security patch.

## Security fixes (1.26.2)

- `crypto/x509`: unexpected work during chain building (CVE)
- `crypto/x509`: inefficient policy validation (CVE)
- `crypto/x509`: case-sensitive excludedSubtrees auth bypass (CVE)
- `crypto/tls`: unauthenticated TLS 1.3 KeyUpdate DoS (CVE)
- `html/template`: JsBraceDepth XSS (CVE)
- `archive/tar`: unbounded allocation for old GNU sparse (CVE)
- `os`: various fixes

These CVEs are currently flagged by Dependabot on gominimal/infra and by govulncheck.

## Go 1.26 highlights

- Green Tea GC enabled by default
- 30% cgo overhead reduction
- Generic self-referential type params
- Stack allocation for slice backing stores in more cases

## Verified

- [x] `minimal check go` passes
- [x] `minimal package -v go` builds successfully

## After merge

Run `minimal update` in repos that use Go to pick up the new version.

Generated with [Claude Code](https://claude.com/claude-code)
