### PR TITLE
Update pulumi to 3.230.0

### DIFF
--- a/packages/pulumi/build.ncl
+++ b/packages/pulumi/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.220.0" in
+let version = "3.230.0" in
 {
   name = "pulumi",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/pulumi/pulumi/v%{version}.tar.gz",
-      sha256 = "6a48a7cd6747f503b009a0bfdfd257a96288db5c264042c1465a32eb0f0feab9",
+      sha256 = "bc9e749c3833e46ca7cb3879ed99b8ce58afbb050151a866fc8ddc26a908a57a",
       extract = true,
       strip_prefix = "pulumi-%{version}",
     } | Source,


### PR DESCRIPTION
## Summary
- Bumps pulumi from 3.220.0 to 3.230.0 (latest, released 2026-04-08)
- Motivated by the deprecation warning surfaced during `minimal run preview` against `minimal-prod-builds`
- Mirrored source tarball uploaded to `gs://minimal-staging-archives/pulumi/pulumi/v3.230.0.tar.gz`, sha256 `bc9e749c3833e46ca7cb3879ed99b8ce58afbb050151a866fc8ddc26a908a57a` (byte-identical to `gh release download v3.230.0 --repo pulumi/pulumi --archive=tar.gz`, cross-verified v3.220.0 download against the existing mirror hash)

## Test plan
- [x] `minimal check --packages pulumi` — all validations pass
- [x] `minimal patched-build pulumi` — compiles from new source, cache hash `077c594f57abe42c30f3256ac6052d07a21842264f1a9dd7dbe873b98a77f1fc`
- [ ] `minimal package pulumi` — full clean-room build skipped locally (full `--no-cache --no-fetch` would rebuild glibc/toolchain from source, hours); CI `minimal check` will cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)