### PR TITLE
Update icu to 78.3

### DIFF
--- a/packages/icu/build.ncl
+++ b/packages/icu/build.ncl
@@ -5,14 +5,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let make = import "../make/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "78.1" in
+let version = "78.3" in
 {
   name = "icu",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/unicode-org/icu/releases/download/release-%{version}/icu4c-%{version}-sources.tgz",
-      sha256 = "6217f58ca39b23127605cfc6c7e0d3475fe4b0d63157011383d716cb41617886",
+      sha256 = "3a2e7a47604ba702f345878308e6fefeca612ee895cf4a5f222e7955fabfe0c0",
     } | Source,
     base,
     make,


### PR DESCRIPTION
## Update icu `78.1` → `78.3`

**Source:** `github:unicode-org/icu`
**Release:** https://github.com/unicode-org/icu/releases/tag/release-78.3
**Changelog:** https://github.com/unicode-org/icu/compare/78.1...release-78.3

### Changes

| | Old | New |
|---|---|---|
| **Version** | `78.1` | `78.3` |
| **SHA256** | `6217f58ca39b2312...` | `3a2e7a47604ba702...` |
| **Size** | | 28.0 MB |
| **GCS** | | `gs://minimal-staging-archives/https://github.com/unicode-org/icu/releases/download/release-78.3/icu4c-78.3-sources.tgz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
