### PR TITLE
Update zlib to 1.3.2

### DIFF
--- a/packages/zlib/build.ncl
+++ b/packages/zlib/build.ncl
@@ -8,14 +8,14 @@ let coreutils = import "../coreutils/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.3.1" in
+let version = "1.3.2" in
 {
   name = "zlib",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/zlib-%{version}.tar.gz",
-      sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
+      sha256 = "b99a0b86c0ba9360ec7e78c4f1e43b1cbdf1e6936c8fa0f6835c0cd694a495a1"
     } | Source,
     bash-bootstrap,
     make,

--- a/packages/zlib/build.sh
+++ b/packages/zlib/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -ex
 
-tar -xof zlib-1.3.1.tar.gz
-cd zlib-1.3.1
+tar -xof zlib-1.3.2.tar.gz
+cd zlib-1.3.2
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;


### PR DESCRIPTION
## Update zlib `1.3.1` → `1.3.2`

**Source:** `github:madler/zlib`
**Release:** https://github.com/madler/zlib/releases/tag/v1.3.2
**Changelog:** https://github.com/madler/zlib/compare/1.3.1...v1.3.2

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.3.1` | `1.3.2` |
| **SHA256** | `9a93b2b7dfdac77c...` | `b99a0b86c0ba9360...` |
| **Size** | | 1.6 MB |
| **GCS** | | `gs://minimal-staging-archives/gs://minimal-staging-archives/zlib-1.3.2.tar.gz` |

> [!WARNING]
> This package has a **cycle-breaker**. The prebuilt binaries may need to be rebuilt separately.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
