### PR TITLE
Update expat to 2.7.5 (fixes 6 CVEs)

### DIFF
--- a/packages/expat/build.ncl
+++ b/packages/expat/build.ncl
@@ -4,14 +4,14 @@ let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.7.3" in
+let version = "2.7.5" in
 {
   name = "expat",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/expat-%{version}.tar.xz",
-      sha256 = "71df8f40706a7bb0a80a5367079ea75d91da4f8c65c58ec59bcdfbf7decdab9f",
+      sha256 = "1032dfef4ff17f70464827daa28369b20f6584d108bc36f17ab1676e1edd2f91",
       extract = true,
       strip_prefix = "expat-%{version}",
     } | Source,
@@ -24,6 +24,9 @@ let version = "2.7.3" in
   ],
 
   cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
   outputs = {
     xmlwf = { glob = "usr/bin/xmlwf" } | OutputBin,
 

--- a/packages/expat/build.sh
+++ b/packages/expat/build.sh
@@ -12,7 +12,7 @@ export CXXFLAGS="${CFLAGS}"
 
 ./configure --prefix="/usr" \
             --disable-static \
-            --docdir="/usr/share/doc/expat-2.7.1"
+            --docdir="/usr/share/doc/expat-${MINIMAL_ARG_VERSION}"
 
 make -j$(nproc)
 make check


### PR DESCRIPTION
## Summary

Bumps expat from 2.7.3 → 2.7.5 to fix **6 CVEs**, including one HIGH severity:

| CVE | Severity |
|---|---|
| CVE-2026-25210 | **HIGH** |
| CVE-2025-66382 | MEDIUM |
| CVE-2026-32776 | MEDIUM |
| CVE-2026-32777 | MEDIUM |
| CVE-2026-32778 | MEDIUM |
| CVE-2026-24515 | LOW |

## Source

Official release asset `expat-2.7.5.tar.xz` from tag `R_2_7_5` in libexpat/libexpat.

- URL: https://github.com/libexpat/libexpat/releases/download/R_2_7_5/expat-2.7.5.tar.xz
- SHA256: `1032dfef4ff17f70464827daa28369b20f6584d108bc36f17ab1676e1edd2f91`
- Mirror: `gs://minimal-staging-archives/expat-2.7.5.tar.xz`

This one was done manually because pkgmgr-rs doesn't yet support fetching named release assets (it only downloads the GitHub auto-archive, which is .tar.gz, not the .tar.xz this package expects). Filed as a follow-up in pkgmgr-rs/todo.md.

## Bonus fix

Switches `build.sh` from hardcoded `--docdir="/usr/share/doc/expat-2.7.1"` (stale since 2.7.1) to `$MINIMAL_ARG_VERSION`. Adds `build_args = { include version }` to build.ncl. Future version bumps only need to touch the `let version` line.

## Validation
- [x] `minimal check --packages expat`
- [ ] Local build (will run after review)
