### PR TITLE
Update vim to 9.2.0350

### DIFF
--- a/packages/vim/build.ncl
+++ b/packages/vim/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let acl = import "../acl/build.ncl" in
 let ncurses = import "../ncurses/build.ncl" in
 
-let version = "9.1.1629" in
+let version = "9.2.0350" in
 {
   name = "vim",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/vim-%{version}.tar.gz",
-      sha256 = "d92c6550e8eca741085fce94e5b0d3d13d2c62fcb5b69bf5a6010d3114de4828"
+      sha256 = "fd07df5cfd0a5e479c9320bef72d72e627923017ef20373979a4d04670db130d"
     } | Source,
     base,
     make,

--- a/packages/vim/build.ncl
+++ b/packages/vim/build.ncl
@@ -25,6 +25,9 @@ let version = "9.2.0350" in
     ncurses,
   ],
   cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
   outputs = {
     vim = { glob = "usr/bin/vim" } | OutputBin,
     vimdiff = { glob = "usr/bin/vimdiff" } | OutputBin,

--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof vim-9.1.1629.tar.gz
-cd vim-9.1.1629
+tar -xof vim-9.2.0350.tar.gz
+cd vim-9.2.0350
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;

--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof vim-9.2.0350.tar.gz
-cd vim-9.2.0350
+tar -xof "vim-${MINIMAL_ARG_VERSION}.tar.gz"
+cd "vim-${MINIMAL_ARG_VERSION}"
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;


### PR DESCRIPTION
## Update vim `9.1.1629` → `9.2.0350`

**Source:** `github:vim/vim:tag`
**Release:** https://github.com/vim/vim/releases/tag/v9.2.0350
**Changelog:** https://github.com/vim/vim/compare/v9.1.1629...v9.2.0350

### Vulnerabilities fixed (15)

This update clears 15 GitHub Security Advisories affecting 9.1.1629:

| CVE / GHSA | Severity |
|---|---|
| GHSA-2gmj-rpqf-pxvh | **HIGH** |
| GHSA-8h6p-m6gr-mpw9 | **HIGH** |
| GHSA-g77q-xrww-p834 | **HIGH** |
| GHSA-5w93-4g67-mm43 | MEDIUM |
| GHSA-9phh-423r-778r | MEDIUM |
| GHSA-9w5c-hwr9-hc68 | MEDIUM |
| GHSA-h4mf-vg97-hj8j | MEDIUM |
| GHSA-jc86-w7vm-8p24 | MEDIUM |
| GHSA-m3xh-9434-g336 | MEDIUM |
| GHSA-mr87-rhgv-7pw6 | MEDIUM |
| GHSA-r2gw-2x48-jj5p | MEDIUM |
| GHSA-rvj2-jrf9-2phg | MEDIUM |
| GHSA-w5jw-f54h-x46c | MEDIUM |
| GHSA-xcc8-r6c5-hvwv | MEDIUM |
| GHSA-gmqx-prf2-8mwf | LOW |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `9.1.1629` | `9.2.0350` |
| **SHA256** | `d92c6550e8eca741...` | `fd07df5cfd0a5e47...` |
| **Size** | | 19.9 MB |
| **Source** | `gs://minimal-staging-archives/vim-9.1.1629.tar.gz` | `gs://minimal-staging-archives/vim-9.2.0350.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
