### PR TITLE
Update caddy to 2.11.2

### DIFF
--- a/packages/caddy/build.ncl
+++ b/packages/caddy/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.10.2" in
+let version = "2.11.2" in
 {
   name = "caddy",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/caddyserver/caddy/v%{version}.tar.gz",
-      sha256 = "f63f46b7ae68ced0a5c2e31df1b6dfc7656117d162a1bc7fed4bd4afd14ddc8f",
+      sha256 = "ee12f7b5f97308708de5067deebb3d3322fc24f6d54f906a47a0a4e8db799122",
       extract = true,
       strip_prefix = "caddy-%{version}",
     } | Source,


### PR DESCRIPTION
## Update caddy `2.10.2` → `2.11.2`

**Source:** `github:caddyserver/caddy`
**Release:** https://github.com/caddyserver/caddy/releases/tag/v2.11.2
**Changelog:** https://github.com/caddyserver/caddy/compare/v2.10.2...v2.11.2

### Vulnerabilities fixed (8)

This update clears 8 vulnerabilities affecting `2.10.2`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-5r3v-vc8m-m96g | **HIGH** | `v2.11.0` |
| GHSA-7r4p-vjf4-gxv4 | **HIGH** | `v2.11.2` |
| GHSA-hffm-g8v7-wrv7 | **HIGH** | `v2.11.0` |
| GHSA-4xrr-hq4w-6vf4 | MEDIUM | `v2.11.0` |
| GHSA-879p-475x-rqh2 | MEDIUM | `v2.11.0` |
| GHSA-g7pc-pc7g-h8jh | MEDIUM | `v2.11.0` |
| GHSA-m2w3-8f23-hxxf | MEDIUM | `v2.11.2` |
| GHSA-x76f-jf84-rqj8 | MEDIUM | `v2.11.0` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.10.2` | `2.11.2` |
| **SHA256** | `f63f46b7ae68ced0...` | `ee12f7b5f9730870...` |
| **Size** | | 804 KB |
| **Source** | `gs://minimal-staging-archives/caddyserver/caddy/v2.10.2.tar.gz` | `gs://minimal-staging-archives/caddyserver/caddy/v2.11.2.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
