### PR TITLE
Update nginx to 1.30.0

### DIFF
--- a/packages/nginx/build.ncl
+++ b/packages/nginx/build.ncl
@@ -13,14 +13,14 @@ let zlib = import "../zlib/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 let pcre2 = import "../pcre2/build.ncl" in
 
-let version = "1.28.1" in
+let version = "1.30.0" in
 {
   name = "nginx",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://nginx.org/download/nginx-%{version}.tar.gz",
-      sha256 = "40e7a0916d121e8905ef50f2a738b675599e42b2224a582dd938603fed15788e",
+      sha256 = "058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b",
       extract = true,
       strip_prefix = "nginx-%{version}",
     } | Source,


### PR DESCRIPTION
## Update nginx `1.28.1` → `1.30.0`

**Source:** `github:nginx/nginx`
**Release:** https://github.com/nginx/nginx/releases/tag/release-1.30.0
**Changelog:** https://github.com/nginx/nginx/compare/release-1.28.1...release-1.30.0

### Vulnerabilities fixed (1)

This update clears 1 vulnerabilities affecting `1.28.1`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| CVE-2026-1642 | **HIGH** | `1.28.2` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.28.1` | `1.30.0` |
| **SHA256** | `40e7a0916d121e89...` | `058188c64bf22bae...` |
| **Size** | | 1.3 MB |
| **Source** | `https://nginx.org/download/nginx-1.28.1.tar.gz` | `https://nginx.org/download/nginx-1.30.0.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
