### PR TITLE
Add node-lts package (Node.js v24.14.1 LTS "Krypton")

### DIFF
--- a/packages/node-lts/build.ncl
+++ b/packages/node-lts/build.ncl
@@ -35,6 +35,8 @@ let version = "24.14.1" in
     toolchain,
   ],
   runtime_deps = [
+    # Note: lief is absent here (unlike packages/node/) because --shared-lief was not added
+    # to Node.js configure until v25; the v24 LTS branch does not support it.
     coreutils, # npx/npm need /usr/bin/env
     openssl,
     c-ares,

--- a/packages/node-lts/build.ncl
+++ b/packages/node-lts/build.ncl
@@ -1,0 +1,104 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let make = import "../make/build.ncl" in
+let openssl = import "../openssl/build.ncl" in
+let python = import "../python/build.ncl" in
+let base = import "../base/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let c-ares = import "../c-ares/build.ncl" in
+let icu = import "../icu/build.ncl" in
+let libuv = import "../libuv/build.ncl" in
+let nghttp2 = import "../nghttp2/build.ncl" in
+let nghttp3 = import "../nghttp3/build.ncl" in
+let ngtcp2 = import "../ngtcp2/build.ncl" in
+let sqlite = import "../sqlite/build.ncl" in
+let zlib = import "../zlib/build.ncl" in
+let zstd = import "../zstd/build.ncl" in
+let gtest = import "../gtest/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+
+let version = "24.14.1" in
+{
+  name = "node-lts",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://nodejs.org/dist/v%{version}/node-v%{version}.tar.gz",
+      sha256 = "8298cf1f5774093ca819f41b8dd392fd2cff058688b4d5c8805026352e2d31b3",
+    } | Source,
+    base,
+    make,
+    pkgconf,
+    python,
+    toolchain,
+  ],
+  runtime_deps = [
+    coreutils, # npx/npm need /usr/bin/env
+    openssl,
+    c-ares,
+    icu,
+    libuv,
+    zlib,
+    sqlite,
+    nghttp2,
+    nghttp3,
+    ngtcp2,
+    zstd,
+    gtest,
+    glibc,
+    subsetOf gcc ["libgcc", "libstdcpp"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    node = { glob = "usr/bin/node" } | OutputBin,
+    npx = { glob = "usr/bin/npx" } | OutputBin,
+    npm = { glob = "usr/bin/npm" } | OutputBin,
+    node_modules = { glob = "usr/lib/node_modules/**" } | OutputData,
+
+    includes = { glob = "usr/include/**" } | OutputData,
+    mans = { glob = "usr/share/man/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      env_state_wiring = {
+        env_var = "NPM_CONFIG_CACHE",
+        prefix = "npm-cache",
+      },
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "nodejs",
+        repo = "node",
+      },
+      build_cost_multiple = 5,
+    } | Attrs,
+
+  tests = {
+    eval =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "echo 'console.log(\"Hello Node\")' > script.js"],
+          ["/bin/bash", "-c", "node script.js | grep -q '^Hello Node$'"],
+          ["/bin/bash", "-c", "echo 'console.log(2 + 2)' > math.js"],
+          ["/bin/bash", "-c", "node math.js | grep -q '^4$'"],
+        ],
+      } | Test,
+    inline_eval =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "node -e 'console.log(10 * 5)' | grep -q '^50$'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/node-lts/build.sh
+++ b/packages/node-lts/build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+export CC=gcc
+
+tar -xof "node-v${MINIMAL_ARG_VERSION}.tar.gz"
+cd "node-v${MINIMAL_ARG_VERSION}"
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr \
+    --with-intl=system-icu --shared-openssl --shared-zlib --shared-zstd --shared-sqlite --shared-libuv \
+    --shared-nghttp2 --shared-nghttp3 --shared-ngtcp2 --shared-gtest --shared-cares
+make -j$(nproc)
+make DESTDIR=$OUTPUT_DIR install

--- a/packages/node-lts/build.sh
+++ b/packages/node-lts/build.sh
@@ -18,5 +18,6 @@ export CXXFLAGS="${CFLAGS}"
 ./configure --prefix=/usr \
     --with-intl=system-icu --shared-openssl --shared-zlib --shared-zstd --shared-sqlite --shared-libuv \
     --shared-nghttp2 --shared-nghttp3 --shared-ngtcp2 --shared-gtest --shared-cares
+    # Note: --shared-lief is omitted; that configure option was not added until Node.js v25.
 make -j$(nproc)
 make DESTDIR=$OUTPUT_DIR install


### PR DESCRIPTION
## Summary

- Adds a new `node-lts` package for Node.js v24.14.1 LTS ("Krypton")
- Includes `build.ncl` with the build spec and `build.sh` build script
- Node.js binary sourced from the official release tarball

## Test plan

- [ ] `min check --packages node-lts` passes
- [ ] `min patched-pkg node-lts` builds successfully
- [ ] `node --version` outputs `v24.14.1`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)