### PR TITLE
feat(nats-server): add nats-server 2.12.7 package

### DIFF
--- a/packages/nats-server/build.ncl
+++ b/packages/nats-server/build.ncl
@@ -1,0 +1,40 @@
+let { Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+
+let version = "2.12.7" in
+{
+  name = "nats-server",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/nats-io/nats-server/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "4a28aff2f4f98180a2bd17b5f175b96ca987204295268338e3468f6bc108e703",
+      extract = true,
+      strip_prefix = "nats-server-%{version}",
+    } | Source,
+    base,
+    go,
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  needs = {
+    dns = {},
+    internet = {},
+  },
+
+  outputs = {
+    nats-server = { glob = "usr/bin/nats-server" } | OutputBin,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "nats-io",
+        repo = "nats-server",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/nats-server/build.sh
+++ b/packages/nats-server/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+export GOROOT=/usr/go
+export GONOSUMCHECK=*
+export GONOSUMDB=*
+export CGO_ENABLED=0
+
+go build -trimpath \
+  -ldflags="-w -buildid= -X github.com/nats-io/nats-server/v2/server.serverVersion=${MINIMAL_ARG_VERSION}" \
+  -o nats-server .
+install -D -m 0755 nats-server "$OUTPUT_DIR/usr/bin/nats-server"


### PR DESCRIPTION
Static Go binary built with CGO_ENABLED=0, matching upstream's Dockerfile.nightly. Embeds version info via ldflags.