### PR TITLE
Update next to 16.2.4

### DIFF
--- a/packages/next/build.ncl
+++ b/packages/next/build.ncl
@@ -9,14 +9,14 @@ let pnpm = import "../pnpm/build.ncl" in
 let python = import "../python/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "16.2.2" in
+let version = "16.2.4" in
 {
   name = "next",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/vercel/next.js/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "1f346a1c543180b2ad1a22664d02781b85e0f2a001e18a30c2d6381aa9672e48",
+      sha256 = "08a2a3cf0656d2c2d89509b28ad32bf5ef3d6899595e91e2d0aecd350df680e4",
       extract = true,
       strip_prefix = "next.js-%{version}",
     } | Source,


### PR DESCRIPTION
## Update next `16.2.2` → `16.2.4`

**Source:** `github:vercel/next.js`
**Release:** https://github.com/vercel/next.js/releases/tag/v16.2.4
**Changelog:** https://github.com/vercel/next.js/compare/v16.2.2...v16.2.4

### Vulnerabilities fixed (4)

This update clears 4 vulnerabilities affecting `16.2.2`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-77r5-gw3j-2mpf | **HIGH** | `>=13.5.1` |
| GHSA-fq54-2j52-jc42 | **HIGH** | `>=13.5` |
| GHSA-q4gf-8mx6-v5v3 | **HIGH** | `15.5.15, 16.2.3` |
| GHSA-3h52-269p-cp9r | LOW | `14.2.30, >= 15.2.2` |

> [!WARNING]
> **1 known vulnerabilities still affect `16.2.4` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | GHSA-67rr-84xm-4c7r | **HIGH** | `≤15.0.4 and ≥15.2.0` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `16.2.2` | `16.2.4` |
| **SHA256** | `1f346a1c543180b2...` | `08a2a3cf0656d2c2...` |
| **Size** | | 50.2 MB |
| **Source** | `https://github.com/vercel/next.js/archive/refs/tags/v16.2.2.tar.gz` | `https://github.com/vercel/next.js/archive/refs/tags/v16.2.4.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
