### PR TITLE
Update redis to 8.6.2

### DIFF
--- a/packages/redis/build.ncl
+++ b/packages/redis/build.ncl
@@ -10,14 +10,14 @@ let linux_headers = import "../linux_headers/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
 
-let version = "8.6.0" in
+let version = "8.6.2" in
 {
   name = "redis",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/redis/redis/%{version}.tar.gz",
-      sha256 = "74261ece988fd2e1526e5aea9f8b9853217d71e2ef2dafaa624ed9579b5f4317",
+      sha256 = "cef021615ec4aef355a824cf933702be5def36e37ca1e9b99ab1cc5599f1748f",
       extract = true,
       strip_prefix = "redis-%{version}",
     } | Source,


### PR DESCRIPTION
## Update redis `8.6.0` → `8.6.2`

**Source:** `github:redis/redis`
**Release:** https://github.com/redis/redis/releases/tag/8.6.2
**Changelog:** https://github.com/redis/redis/compare/8.6.0...8.6.2

> [!WARNING]
> **8 known vulnerabilities still affect `8.6.2` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | GHSA-4q32-c38c-pwgq | **HIGH** | `TBD` |
> | GHSA-m8fj-85cg-7vhp | **HIGH** | `TBD` |
> | GHSA-r67f-p999-2gff | **HIGH** | `TBD` |
> | GHSA-rp2m-q4j6-gr43 | **HIGH** | `TBD` |
> | GHSA-4c68-q8q8-3g4f | MEDIUM | `TBD` |
> | GHSA-5453-q98w-cmvm | MEDIUM | `TBD` |
> | GHSA-prpq-rh5h-46g9 | MEDIUM | `TBD` |
> | GHSA-qrv7-wcrx-q5jp | MEDIUM | `TBD` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `8.6.0` | `8.6.2` |
| **SHA256** | `74261ece988fd2e1...` | `cef021615ec4aef3...` |
| **Size** | | 4.3 MB |
| **Source** | `gs://minimal-staging-archives/redis/redis/8.6.0.tar.gz` | `gs://minimal-staging-archives/redis/redis/8.6.2.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
