### PR TITLE
add zizmor package

### DIFF
--- a/packages/zizmor/build.ncl
+++ b/packages/zizmor/build.ncl
@@ -1,0 +1,48 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.24.1" in
+{
+  name = "zizmor",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/zizmorcore/zizmor/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "4a037cd9ccdebdcf02e508f248c5ee8656ebf024d8f29d2c458498f16fe9893b",
+      extract = true,
+      strip_prefix = "zizmor-%{version}",
+    } | Source,
+    base,
+    make,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    zizmor = { glob = "usr/bin/zizmor" } | OutputBin,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "zizmorcore",
+        repo = "zizmor",
+      },
+      build_cost_multiple = 3,
+    } | Attrs,
+} | BuildSpec

--- a/packages/zizmor/build.sh
+++ b/packages/zizmor/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+cargo build --release --package zizmor
+
+install -D -m 0755 target/release/zizmor "$OUTPUT_DIR/usr/bin/zizmor"


### PR DESCRIPTION
zizmor v1.24.1 — static analysis for GitHub Actions workflows.
Standard rust build; jemalloc's bundled C build needs `make` in build_deps.

Files to add: packages/zizmor/build.ncl and packages/zizmor/build.sh.

https://docs.zizmor.sh/