### PR TITLE
Update pnpm to 10.33.0

### DIFF
--- a/packages/pnpm/build.ncl
+++ b/packages/pnpm/build.ncl
@@ -5,14 +5,14 @@ let tar = import "../tar/build.ncl" in
 
 let node = import "../node/build.ncl" in
 
-let version = "10.15.1" in
+let version = "10.33.0" in
 {
   name = "pnpm",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://registry.npmjs.org/pnpm/-/pnpm-%{version}.tgz",
-      sha256 = "8c53af02ae3ec1fb0ae75377f8d4d6217c2d7cbe6f03c16350cabf7493de6eff"
+      sha256 = "bfcc1bcbad279b13a516c446a75b3c58b6904b45d57a1951411015e50b751a80"
     } | Source,
     base,
     tar,


### PR DESCRIPTION
## Update pnpm `10.15.1` → `10.33.0`

**Source:** `github:pnpm/pnpm`
**Release:** https://github.com/pnpm/pnpm/releases/tag/v10.33.0
**Changelog:** https://github.com/pnpm/pnpm/compare/v10.15.1...v10.33.0

### Vulnerabilities fixed (8)

This update clears 8 vulnerabilities affecting `10.15.1`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-2phv-j68v-wwqx | **HIGH** | `>=10.27.0` |
| GHSA-379q-355j-w6rj | **HIGH** | `>=10.26.0` |
| GHSA-7vhp-vf5g-r2fw | **HIGH** | `>=10.26.0` |
| GHSA-6pfh-p556-v868 | MEDIUM | `>=10.28.1` |
| GHSA-6x96-7vc8-cm3p | MEDIUM | `>=10.28.1` |
| GHSA-m733-5w8f-5ggw | MEDIUM | `>=10.28.2` |
| GHSA-v253-rj99-jwpq | MEDIUM | `>=10.28.2` |
| GHSA-xpqm-wm3m-f34h | MEDIUM | `>=10.28.1` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `10.15.1` | `10.33.0` |
| **SHA256** | `8c53af02ae3ec1fb...` | `bfcc1bcbad279b13...` |
| **Size** | | 4.5 MB |
| **Source** | `https://registry.npmjs.org/pnpm/-/pnpm-10.15.1.tgz` | `https://registry.npmjs.org/pnpm/-/pnpm-10.33.0.tgz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
