### PR TITLE
Update python to 3.14.4 + make downstream globs version-agnostic

### DIFF
--- a/packages/cython/build.ncl
+++ b/packages/cython/build.ncl
@@ -32,10 +32,10 @@ let version = "3.2.1" in
     cython = { glob = "usr/bin/cython" } | OutputBin,
     cygdb = { glob = "usr/bin/cygdb" } | OutputBin,
 
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/{cython.py,Cython/**}", allow_data = true } | OutputLib,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/cython-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/{cython.py,Cython/**}", allow_data = true } | OutputLib,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/cython-*.dist-info/**" } | OutputData,
 
-    python_site_other = { glob = "usr/lib/python3.13/site-packages/{pyximport,__pycache__}/**" } | OutputData,
+    python_site_other = { glob = "usr/lib/python*/site-packages/{pyximport,__pycache__}/**" } | OutputData,
   },
 
   attrs =

--- a/packages/diffoscope/build.ncl
+++ b/packages/diffoscope/build.ncl
@@ -23,7 +23,7 @@ let version = "306" in
   cmd = "./build.sh",
   outputs = {
     diffoscope = { glob = "usr/bin/diffoscope" } | OutputBin,
-    site_packages = { glob = "usr/lib/python3.13/site-packages/**/*" } | OutputData,
+    site_packages = { glob = "usr/lib/python*/site-packages/**/*" } | OutputData,
   },
   attrs = {
     upstream_version = version,

--- a/packages/flit-core/build.ncl
+++ b/packages/flit-core/build.ncl
@@ -23,8 +23,8 @@ let version = "3.12.0" in
   cmd = "./build.sh",
 
   outputs = {
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/flit_core/**" } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/flit_core-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/flit_core/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/flit_core-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/meson-python/build.ncl
+++ b/packages/meson-python/build.ncl
@@ -30,8 +30,8 @@ let version = "0.18.0" in
   cmd = "./build.sh",
 
   outputs = {
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/mesonpy/**" } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/meson_python-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/mesonpy/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/meson_python-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/meson/build.ncl
+++ b/packages/meson/build.ncl
@@ -24,7 +24,7 @@ let version = "1.10.1" in
   cmd = "./build.sh",
   outputs = {
     meson = { glob = "usr/bin/meson" } | OutputBin,
-    site_packages = { glob = "usr/lib/python3.13/site-packages/**/*" } | OutputData,
+    site_packages = { glob = "usr/lib/python*/site-packages/**/*" } | OutputData,
   },
 
   attrs =

--- a/packages/numpy/build.ncl
+++ b/packages/numpy/build.ncl
@@ -35,8 +35,8 @@ let version = "2.3.5" in
     f2py = { glob = "usr/bin/f2py" } | OutputBin,
     numpy-config = { glob = "usr/bin/numpy-config" } | OutputBin,
 
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/numpy/**", allow_executable = true } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/numpy-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/numpy/**", allow_executable = true } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/numpy-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/py-build/build.ncl
+++ b/packages/py-build/build.ncl
@@ -28,8 +28,8 @@ let version = "1.3.0" in
   cmd = "./build.sh",
 
   outputs = {
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/build/**" } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/build-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/build/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/build-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/py-packaging/build.ncl
+++ b/packages/py-packaging/build.ncl
@@ -28,8 +28,8 @@ let version = "25.0" in
   ],
 
   outputs = {
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/packaging/**" } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/packaging-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/packaging/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/packaging-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/pyproject-hooks/build.ncl
+++ b/packages/pyproject-hooks/build.ncl
@@ -26,8 +26,8 @@ let version = "1.2.0" in
   cmd = "./build.sh",
 
   outputs = {
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/pyproject_hooks/**" } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/pyproject_hooks-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/pyproject_hooks/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/pyproject_hooks-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/pyproject-metadata/build.ncl
+++ b/packages/pyproject-metadata/build.ncl
@@ -28,8 +28,8 @@ let version = "0.9.1" in
   cmd = "./build.sh",
 
   outputs = {
-    python_site_package = { glob = "usr/lib/python3.13/site-packages/pyproject_metadata/**" } | OutputData,
-    python_dist_info = { glob = "usr/lib/python3.13/site-packages/pyproject_metadata-*.dist-info/**" } | OutputData,
+    python_site_package = { glob = "usr/lib/python*/site-packages/pyproject_metadata/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/pyproject_metadata-*.dist-info/**" } | OutputData,
   },
 
   attrs =

--- a/packages/python/build.ncl
+++ b/packages/python/build.ncl
@@ -16,14 +16,14 @@ let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 let xz = import "../xz/build.ncl" in
 
-let version = "3.13.7" in
+let version = "3.14.4" in
 {
   name = "python",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/Python-%{version}.tar.xz",
-      sha256 = "5462f9099dfd30e238def83c71d91897d8caa5ff6ebc7a50f14d4802cdaaa79a"
+      sha256 = "d923c51303e38e249136fc1bdf3568d56ecb03214efdef48516176d3d7faaef8"
     } | Source,
     base,
     make,
@@ -46,15 +46,21 @@ let version = "3.13.7" in
   ],
 
   cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
   outputs = {
+    # Wildcards avoid coupling to a specific python minor version. Future
+    # bumps (3.14 → 3.15 → ...) don't require touching this file — the
+    # `python3.*` patterns match whichever minor is installed.
     python3 = { glob = "usr/bin/python3" } | OutputBin,
-    "python3.13" = { glob = "usr/bin/python3.13" } | OutputBin,
+    python3_minor = { glob = "usr/bin/python3.*" } | OutputBin,
     pip3 = { glob = "usr/bin/pip3" } | OutputBin,
-    "pip3.13" = { glob = "usr/bin/pip3.13" } | OutputBin,
+    pip3_minor = { glob = "usr/bin/pip3.*" } | OutputBin,
     pydoc3 = { glob = "usr/bin/pydoc3" } | OutputBin,
-    "pydoc3.13" = { glob = "usr/bin/pydoc3.13" } | OutputBin,
+    pydoc3_minor = { glob = "usr/bin/pydoc3.*" } | OutputBin,
     python3-config = { glob = "usr/bin/python3-config" } | OutputBin,
-    "python3.13-config" = { glob = "usr/bin/python3.13-config" } | OutputBin,
+    python3_minor-config = { glob = "usr/bin/python3.*-config" } | OutputBin,
 
     libs = { glob = "usr/lib/libpython*.so*" } | OutputLib,
     datas = { glob = "usr/lib/python*/**", allow_executable = true } | OutputData,

--- a/packages/python/build.sh
+++ b/packages/python/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof Python-3.13.7.tar.xz
-cd Python-3.13.7
+tar -xof "Python-${MINIMAL_ARG_VERSION}.tar.xz"
+cd "Python-${MINIMAL_ARG_VERSION}"
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;

--- a/packages/setuptools/build.ncl
+++ b/packages/setuptools/build.ncl
@@ -18,7 +18,7 @@ let version = "80.9.0" in
   ],
   cmd = "./build.sh",
   outputs = {
-    site_packages = { glob = "usr/lib/python3.13/site-packages/**/*" } | OutputData,
+    site_packages = { glob = "usr/lib/python*/site-packages/**/*" } | OutputData,
   },
   attrs =
     {


### PR DESCRIPTION
python: bump to 3.14.4 + make downstream globs version-agnostic

## Summary

Updates python from 3.13.7 to 3.14.4 (requested upgrade, no CVE driver).

**Also fixes a structural issue:** 11 downstream packages hardcoded
`python3.13` in their site-packages output globs. A naive python bump
would have silently broken every one of them — numpy, cython, meson,
meson-python, setuptools, py-build, py-packaging, pyproject-hooks,
pyproject-metadata, flit-core, and diffoscope — because Python would
install to `usr/lib/python3.14/...` and every `usr/lib/python3.13/...`
glob would match nothing.

This PR switches those globs to `python*/` (directory-segment wildcard,
verified via existing precedent in `usr/include/at-spi*/**`). **Future
python bumps become zero-touch for these packages** — the glob matches
whatever python minor is installed.

## Detailed changes

### `packages/python/`

- `build.ncl`:
  - `version`: `3.13.7` → `3.14.4` + new sha256
  - Adds `build_args = { include version }` so build.sh can use `$MINIMAL_ARG_VERSION`
  - Output names: renamed the minor-specific keys (`"python3.13"`,
    `"pip3.13"`, etc.) to `python3_minor` / `pip3_minor` / etc. with
    `usr/bin/python3.*` wildcard globs. No external `subsetOf` caller
    referenced the old names (grep-verified).
- `build.sh`: now uses `${MINIMAL_ARG_VERSION}` (util-linux/vim-#68 pattern)
  instead of hardcoding `Python-3.13.7`.

### `packages/{cython,diffoscope,flit-core,meson,meson-python,numpy,py-build,py-packaging,pyproject-hooks,pyproject-metadata,setuptools}/`

Replaces every `usr/lib/python3.13/...` glob with `usr/lib/python*/...`.
Pure search-and-replace, no logic changes. Directory-segment wildcards
in Minimal globs are supported (precedent: `at-spi*/`).

### Tarball

Python-3.14.4.tar.xz fetched from python.org canonical
(https://www.python.org/ftp/python/3.14.4/Python-3.14.4.tar.xz),
sha256 `d923c51303e38e249136fc1bdf3568d56ecb03214efdef48516176d3d7faaef8`,
uploaded to `gs://minimal-staging-archives/Python-3.14.4.tar.xz`
(22.8 MiB, verified).

## Blast radius

40 packages rebuild downstream of python. Of those, the 11 that carry
hardcoded python3.13 globs needed this PR's companion edits; the rest
(autotools packages that invoke python during build, meson consumers,
etc.) rebuild transparently when python's hash changes.

## pkgmgr follow-up (separate, not part of this PR)

While investigating, I sketched `upstream_download_url_template` as an
attr to let pkgmgr auto-handle python-style packages (tag on GitHub,
distribute on python.org) — but it's blocked on extending the `Attrs`
type in `minimal.ncl`. Dormant code sits on `main` in pkgmgr-rs for when
the stdlib catches up. Until then, python bumps need to follow this
manual-download-then-mirror pattern. With the glob fix landed here,
future bumps only touch python's own build.ncl + build.sh + GCS mirror.

## Test plan

- [x] `minimal check --packages python` — Pass
- [x] `minimal check --packages {cython,numpy,meson,…}` — all 11 Pass
- [x] Tarball sha256 matches python.org canonical
- [x] GCS upload verified (`gsutil ls` shows object with matching size)
- [ ] `minimal patched-pkg python` — build the tree (needs CI/buildbot)
- [ ] One dependent rebuild to confirm site-packages globs resolve
      (`minimal patched-pkg numpy` or similar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
