### PR TITLE
Update syft to 1.42.4

### DIFF
--- a/packages/syft/build.ncl
+++ b/packages/syft/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.42.0" in
+let version = "1.42.4" in
 {
   name = "syft",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/anchore/syft/v%{version}.tar.gz",
-      sha256 = "ed946fd7a485573e5e7784bb5691d60a9cffffebd330e3e2b487afbf11d30102",
+      sha256 = "8e84d456e253149d0e0c5a381a1cc4121a0e169c0608c73f99eed9ea56ed036d",
       extract = true,
       strip_prefix = "syft-%{version}",
     } | Source,


### PR DESCRIPTION
## Update syft `1.42.0` → `1.42.4`

**Source:** `github:anchore/syft`
**Release:** https://github.com/anchore/syft/releases/tag/v1.42.4
**Changelog:** https://github.com/anchore/syft/compare/v1.42.0...v1.42.4

### Vulnerabilities fixed (1)

This update clears 1 vulnerabilities affecting `1.42.0`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-rjcw-vg7j-m9rc | MEDIUM | `v1.42.3` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.42.0` | `1.42.4` |
| **SHA256** | `ed946fd7a485573e...` | `8e84d456e253149d...` |
| **Size** | | 6.9 MB |
| **Source** | `gs://minimal-staging-archives/anchore/syft/v1.42.0.tar.gz` | `gs://minimal-staging-archives/anchore/syft/v1.42.4.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
