### PR TITLE
Update libpng to 1.6.58

### DIFF
--- a/packages/libpng/build.ncl
+++ b/packages/libpng/build.ncl
@@ -6,15 +6,15 @@ let make = import "../make/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "1.6.53" in
+let version = "1.6.58" in
 {
   name = "libpng",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://downloads.sourceforge.net/libpng/libpng-1.6.53.tar.xz
+      # https://downloads.sourceforge.net/libpng/libpng-1.6.58.tar.xz
       url = "gs://minimal-staging-archives/libpng-%{version}.tar.xz",
-      sha256 = "1d3fb8ccc2932d04aa3663e22ef5ef490244370f4e568d7850165068778d98d4",
+      sha256 = "28eb403f51f0f7405249132cecfe82ea5c0ef97f1b32c5a65828814ae0d34775",
       extract = true,
       strip_prefix = "libpng-%{version}",
     } | Source,


### PR DESCRIPTION
## Update libpng `1.6.53` → `1.6.58`

**Source:** `github:pnggroup/libpng:tag (+sf-mirror)`
**Release:** https://github.com/pnggroup/libpng/releases/tag/v1.6.58
**Changelog:** https://github.com/pnggroup/libpng/compare/v1.6.53...v1.6.58

### Vulnerabilities fixed (2)

This update clears 2 vulnerabilities affecting `1.6.53`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-mmq5-27w3-rxpp | MEDIUM | `1.6.54` |
| GHSA-vgjq-8cw5-ggw8 | MEDIUM | `1.6.54` |

> [!WARNING]
> **4 known vulnerabilities still affect `1.6.58` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | GHSA-g8hp-mq4h-rqm3 | **HIGH** | `` |
> | GHSA-m4pc-p4q3-4c7j | **HIGH** | `1.6.56, 1.8.0 (trunk)` |
> | GHSA-wjr5-c57x-95m2 | **HIGH** | `1.6.56, 1.8.0 (trunk)` |
> | GHSA-6fr7-g8h7-v645 | MEDIUM | `1.6.57, 1.8.0 (trunk)` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.6.53` | `1.6.58` |
| **SHA256** | `1d3fb8ccc2932d04...` | `28eb403f51f0f740...` |
| **Size** | | 1.1 MB |
| **Source** | `gs://minimal-staging-archives/libpng-1.6.53.tar.xz` | `gs://minimal-staging-archives/libpng-1.6.58.tar.xz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
