### PR TITLE
Update libfuse to 3.18.2

### DIFF
--- a/packages/libfuse/build.ncl
+++ b/packages/libfuse/build.ncl
@@ -7,14 +7,14 @@ let meson = import "../meson/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.18.1" in
+let version = "3.18.2" in
 {
   name = "libfuse",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/libfuse/libfuse/fuse-%{version}.tar.gz",
-      sha256 = "dd395c88f29c7540bbdd0b830260ab8092ccb241bb6e66f603643f715fb9322c",
+      sha256 = "f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298",
       extract = true,
       strip_prefix = "fuse-%{version}",
     } | Source,


### PR DESCRIPTION
## Update libfuse `3.18.1` → `3.18.2`

**Source:** `github:libfuse/libfuse`
**Release:** https://github.com/libfuse/libfuse/releases/tag/fuse-3.18.2
**Changelog:** https://github.com/libfuse/libfuse/compare/fuse-3.18.1...fuse-3.18.2

### Vulnerabilities fixed (2)

This update clears 2 vulnerabilities affecting `3.18.1`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| CVE-2026-33150 | **HIGH** | `3.18.2` |
| CVE-2026-33179 | MEDIUM | `3.18.2` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `3.18.1` | `3.18.2` |
| **SHA256** | `dd395c88f29c7540...` | `f01de85717e20adf...` |
| **Size** | | 4.9 MB |
| **Source** | `gs://minimal-staging-archives/libfuse/libfuse/fuse-3.18.1.tar.gz` | `gs://minimal-staging-archives/libfuse/libfuse/fuse-3.18.2.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
