### PR TITLE
Update prek to 0.3.10

### DIFF
--- a/packages/prek/build.ncl
+++ b/packages/prek/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "0.3.2" in
+let version = "0.3.10" in
 {
   name = "prek",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/j178/prek/v%{version}.tar.gz",
-      sha256 = "1e17e690d65b8d84b9d23adff8189a6b0667e3484d65f5add0acf7e8a787beec",
+      sha256 = "1fe32ea1b83f8566faefdd978e74cf78ead65841f60effa20b9da480e7d73551",
       extract = true,
       strip_prefix = "prek-%{version}",
     } | Source,


### PR DESCRIPTION
## Update prek `0.3.2` → `0.3.10`

**Source:** `github:j178/prek`
**Release:** https://github.com/j178/prek/releases/tag/v0.3.10
**Changelog:** https://github.com/j178/prek/compare/v0.3.2...v0.3.10

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.3.2` | `0.3.10` |
| **SHA256** | `1e17e690d65b8d84...` | `1fe32ea1b83f8566...` |
| **Size** | | 668 KB |
| **Source** | `gs://minimal-staging-archives/j178/prek/v0.3.2.tar.gz` | `gs://minimal-staging-archives/j178/prek/v0.3.10.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
