### PR TITLE
Update gh to 2.90.0

### DIFF
--- a/packages/gh/build.ncl
+++ b/packages/gh/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.86.0" in
+let version = "2.90.0" in
 {
   name = "gh",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/cli/cli/v%{version}.tar.gz",
-      sha256 = "cd2998310e81727af5c2056e9936e6541a20f968d6e3a4891f7fedbc0b336008",
+      sha256 = "87a6a3b3df1155e9d253ec6ae273d9e018773498b7ce7570f896a7cb75b64e39",
       extract = true,
       strip_prefix = "cli-%{version}",
     } | Source,


### PR DESCRIPTION
## Update gh `2.86.0` → `2.90.0`

**Source:** `github:cli/cli`
**Release:** https://github.com/cli/cli/releases/tag/v2.90.0
**Changelog:** https://github.com/cli/cli/compare/v2.86.0...v2.90.0

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.86.0` | `2.90.0` |
| **SHA256** | `cd2998310e81727a...` | `87a6a3b3df1155e9...` |
| **Size** | | 14.6 MB |
| **Source** | `gs://minimal-staging-archives/cli/cli/v2.86.0.tar.gz` | `gs://minimal-staging-archives/cli/cli/v2.90.0.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
