### PR TITLE
Update kubectl to 1.35.4

### DIFF
--- a/packages/kubectl/build.ncl
+++ b/packages/kubectl/build.ncl
@@ -2,7 +2,7 @@ let { Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.n
 let bash = import "../bash/build.ncl" in
 let go = import "../go/build.ncl" in
 
-let version = "1.35.3" in
+let version = "1.35.4" in
 
 {
   name = "kubectl",
@@ -11,7 +11,7 @@ let version = "1.35.3" in
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "4374809bf135137568135384209f160acdab7372f2608fa60ca3513782db4f03",
+      sha256 = "46a0dead69674fb2bdf33f5ef1deadab123a96becfafef6043f399ae53761f4f",
       extract = true,
       strip_prefix = "kubernetes-%{version}",
     } | Source,


### PR DESCRIPTION
## Update kubectl `1.35.3` → `1.35.4`

**Source:** `github:kubernetes/kubernetes`
**Release:** https://github.com/kubernetes/kubernetes/releases/tag/v1.35.4
**Changelog:** https://github.com/kubernetes/kubernetes/compare/v1.35.3...v1.35.4

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.35.3` | `1.35.4` |
| **SHA256** | `4374809bf1351375...` | `46a0dead69674fb2...` |
| **Size** | | 39.2 MB |
| **Source** | `https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.35.3.tar.gz` | `https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.35.4.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
