### PR TITLE
git: add upstream_download_url_template for kernel.org source

### DIFF
--- a/packages/git/build.ncl
+++ b/packages/git/build.ncl
@@ -61,6 +61,11 @@ let version = "2.52.0" in
         owner = "git",
         repo = "git",
       },
+      # git distributes source tarballs at kernel.org; no GitHub release
+      # assets. pkgmgr uses this template to fetch the new tarball when
+      # updating, since provenance (GithubRepo) only identifies where
+      # advisories are tracked, not where the source lives.
+      upstream_download_url_template = "https://www.kernel.org/pub/software/scm/git/git-%{version}.tar.xz",
     } | Attrs,
 
   tests = {


### PR DESCRIPTION
## Summary

- git distributes source tarballs at [kernel.org](https://www.kernel.org/pub/software/scm/git/), not as GitHub release assets — provenance (GithubRepo) only identifies where advisories are tracked.
- This adds the `upstream_download_url_template` attr so pkgmgr knows the canonical download URL when bumping versions.

## Why

`pkgmgr update --package git` currently fails with:

> extension mismatch: source URL expects .tar.xz but upstream provides .tar.gz.

Root cause: pkgmgr was treating `source_provenance = GithubRepo` as the download source and hitting GitHub's auto-archive (which only produces `.tar.gz`). The `upstream_download_url_template` attr is the existing escape hatch in pkgmgr's updater for this case — git is the first package to use it.

Pattern is general: ~40 other `.tar.xz` packages in this repo (python, gcc, llvm, harfbuzz, curl, xz, etc.) will need similar attrs over time. This PR establishes the template.

## Test plan

- [ ] After merge: run `pkgmgr update --package git --dry-run` against a checkout of main — should succeed.
- [ ] Then run `pkgmgr update --package git --create-pr` to generate the actual 2.52.0 → 2.54.0 bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)