### PR TITLE
Update git to 2.54.0

### DIFF
--- a/packages/git/build.ncl
+++ b/packages/git/build.ncl
@@ -10,15 +10,15 @@ let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "2.52.0" in
+let version = "2.54.0" in
 {
   name = "git",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://www.kernel.org/pub/software/scm/git/git-2.52.0.tar.xz
+      # https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.xz
       url = "gs://minimal-staging-archives/git-%{version}.tar.xz",
-      sha256 = "3cd8fee86f69a949cb610fee8cd9264e6873d07fa58411f6060b3d62729ed7c5",
+      sha256 = "f689162364c10de79ef89aa8dbf48731eb057e34edbbd20aca510ce0154681a3",
       extract = true,
       strip_prefix = "git-%{version}",
     } | Source,

--- a/packages/git/build.ncl
+++ b/packages/git/build.ncl
@@ -55,6 +55,7 @@ let version = "2.54.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       repology_project = "git",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update git `2.52.0` → `2.54.0`

**Source:** `github:git/git:tag`
**Release:** https://github.com/git/git/releases/tag/v2.54.0
**Changelog:** https://github.com/git/git/compare/v2.52.0...v2.54.0

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.52.0` | `2.54.0` |
| **SHA256** | `3cd8fee86f69a949...` | `f689162364c10de7...` |
| **Size** | 8.0 MB | 8.1 MB |
| **Source** | `gs://minimal-staging-archives/git-2.52.0.tar.xz` | `gs://minimal-staging-archives/git-2.54.0.tar.xz` |

- **License:** `GPL-2.0-only` _(source: tarball)_

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
