### PR TITLE
pnpm: use node-lts runtime, frozen-lockfile installs

### DIFF
--- a/harnesses/pnpm/harness.ncl
+++ b/harnesses/pnpm/harness.ncl
@@ -10,7 +10,9 @@ harness {
     "-c",
     m%"
     # Run pnpm install if no packages are installed (first start)
-    [ -z "$(pnpm list 2>/dev/null)" ] && echo "/bin/pnpm install"
+    if [ -z "$(pnpm list 2>/dev/null)" ]; then
+      [ -f pnpm-lock.yaml ] && echo '/bin/pnpm install --frozen-lockfile' || echo '/bin/pnpm install'
+    fi
     echo '/bin/pnpm build'
   "%
   ],

--- a/harnesses/pnpm/harness.ncl
+++ b/harnesses/pnpm/harness.ncl
@@ -2,7 +2,7 @@ let { harness, .. } = import "minimal.ncl" in
 harness {
   name = "pnpm",
 
-  runtime_packages = ["node"],
+  runtime_packages = ["node-lts"],
   build_packages = ["pnpm", "base"],
 
   build_cmds_cmd = [

--- a/packages/pnpm/build.ncl
+++ b/packages/pnpm/build.ncl
@@ -3,7 +3,7 @@ let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let tar = import "../tar/build.ncl" in
 
-let node = import "../node/build.ncl" in
+let node-lts = import "../node-lts/build.ncl" in
 
 let version = "10.33.0" in
 {
@@ -18,7 +18,7 @@ let version = "10.33.0" in
     tar,
   ],
   runtime_deps = [
-    node,
+    node-lts,
     coreutils, # pnpm is a sheband script that invokes node like `#!/usr/bin/env node`
   ],
   needs =


### PR DESCRIPTION
## Summary
- Switch the pnpm harness's `runtime_packages` from `node` to `node-lts`.
- Switch the pnpm package's `runtime_deps` from `node` to `node-lts` to match.
- In the harness install step, use `pnpm install --frozen-lockfile` when `pnpm-lock.yaml` is present, falling back to plain `pnpm install` otherwise.

## Reasoning
**node-lts:** pnpm's own releases are built against Node LTS, and most hosting providers default to LTS for Node runtimes. Aligning both the harness runtime and the pnpm package's declared runtime with LTS matches what pnpm is tested against upstream and what users are most likely to deploy on.

**--frozen-lockfile:** Mirrors the npm harness's `npm ci` behavior — when a lockfile is checked in, installs should be reproducible and fail loudly if the lockfile drifts from `package.json`. Falls back to plain `pnpm install` when no lockfile is present (e.g. a workspace root matched only by `pnpm-workspace.yaml`).

## Test plan
- [ ] `min check --harnesses pnpm`
- [ ] `min check --packages pnpm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)