### PR TITLE
npm harness: use node-lts for runtime

### DIFF
--- a/harnesses/npm/harness.ncl
+++ b/harnesses/npm/harness.ncl
@@ -2,7 +2,7 @@ let { harness, .. } = import "minimal.ncl" in
 harness {
   name = "npm",
 
-  runtime_packages = ["node"],
+  runtime_packages = ["node-lts"],
   build_packages = ["base", "curl"],
 
   build_cmds_cmd = [


### PR DESCRIPTION
## Summary
- Switch the npm harness's `runtime_packages` from `node` to `node-lts`.

## Reasoning
npm is bundled with Node, so the npm version most users and hosting providers run is whichever ships with the current Node LTS. Aligning the harness with LTS matches what the ecosystem is tested against and what users are most likely to deploy on. Mirrors #97 for pnpm.

## Test plan
- [ ] `min check --harnesses npm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)