### PR TITLE
Update openssl to 3.6.2 (patches CVE-2026-2673 HIGH)

### DIFF
--- a/packages/openssl/build.ncl
+++ b/packages/openssl/build.ncl
@@ -5,14 +5,14 @@ let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.6.1" in
+let version = "3.6.2" in
 {
   name = "openssl",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/openssl/openssl/openssl-%{version}.tar.gz",
-      sha256 = "f68e6e3a19902c0487d684a4122d4127bc649b4f8f51c15324bb36e0e4dc0bfa",
+      sha256 = "bc7dc809d1842e4a9c190765d83fb6a88084c75c8b04b4c3c304a929d33a5108",
       extract = true,
       strip_prefix = "openssl-openssl-%{version}",
     } | Source,


### PR DESCRIPTION
## Summary

Patches **CVE-2026-2673 (HIGH)** by bumping openssl 3.6.1 → 3.6.2.

## Vulnerability

> An OpenSSL TLS 1.3 server may fail to negotiate the expected preferred key exchange group when its key exchange group configuration includes the default by using the 'DEFAULT' keyword.
>
> A less preferred key exchange may be used even when a more preferred group is supported by both client and server, if the group was not included among the client's initial predicted keyshares. This will sometimes be the case with the new hybrid post-quantum groups.
>
> No OpenSSL FIPS modules are affected by this issue, the code in question lies outside the FIPS boundary.
>
> — [OpenSSL advisory 20260313](https://openssl-library.org/news/secadv/20260313.txt)

Affected: OpenSSL 3.5 and 3.6.
Not affected: 3.4, 3.3, 3.0, 1.0.2, 1.1.1.

## Why not 4.0.0?

pkgmgr surfaces 4.0.0 as "latest" (it is — was released alongside 3.6.2), but 4.0.0 is a major version bump with potentially breaking API surface. The security advisory explicitly directs 3.6 users to 3.6.2 — a patch release on the existing series with minimal breakage surface.

Followup in pkgmgr-rs#TBD adds `latest_in_series` detection so this case auto-surfaces in `check` output instead of requiring manual research.

## Mechanics

- Tarball fetched from `https://codeload.github.com/openssl/openssl/tar.gz/refs/tags/openssl-3.6.2`
- SHA256: `bc7dc809d1842e4a9c190765d83fb6a88084c75c8b04b4c3c304a929d33a5108`
- Mirrored to `gs://minimal-staging-archives/openssl/openssl/openssl-3.6.2.tar.gz`
- `strip_prefix = "openssl-openssl-%{version}"` unchanged — matches the auto-archive's top-level dir

## Test plan

- [x] sha256 verified against freshly-downloaded tarball
- [x] GCS upload verified present at expected path
- [x] strip_prefix matches tarball's root (`openssl-openssl-3.6.2/`)
- [ ] CI green
