### PR TITLE
Add opencode package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,21 @@ At minimum, a build spec needs:
    curl -sL <url> | sha256sum
    ```
 
+**Verify the canonical upstream repo before using it.** GitHub projects get renamed, transferred, or forked — a repo you find via search or an older link may be stale and silently redirect. Before locking in a URL:
+
+- Resolve the repo with `curl -sIL https://github.com/<owner>/<repo> | grep -i '^location:'` (or open it in a browser) and check whether it redirects. If it does, use the new canonical owner/repo in both the `url` and `source_provenance`.
+- Cross-check the project's own README, homepage, or package registry page (npm, crates.io, PyPI) to confirm you have the current canonical source.
+
+Getting this wrong means future version bumps chase a dead repo and `source_provenance` lies about where the code came from.
+
+**Build from source — do not package prebuilt release binaries.** When the upstream project's toolchain is available in pkgs (bun, go, rust, cargo, node, etc.), the package must build from the source tarball rather than downloading a prebuilt binary from the release page. Reasons:
+
+- Prebuilt artifacts can be mutated after the fact; source builds give us a real supply-chain guarantee.
+- Source builds let us tweak flags for reproducibility and patch issues without waiting on upstream.
+- The toolchain is already there — there's no meaningful cost saving from shipping the prebuilt.
+
+Only fall back to a prebuilt binary if the required toolchain genuinely isn't packaged yet, and call that out explicitly in the package.
+
 #### Example: C library (autotools)
 
 ```nickel

--- a/minimal.toml
+++ b/minimal.toml
@@ -10,3 +10,8 @@ exec = "bash --noprofile -l"
 interactive = true
 packages = ["base", "bash", "claude-code", "curl"]
 exec = "claude --dangerously-skip-permissions"
+
+[tasks.opencode]
+interactive = true
+packages = ["base", "bash", "opencode", "curl"]
+exec = "opencode"

--- a/packages/opencode/build.ncl
+++ b/packages/opencode/build.ncl
@@ -1,35 +1,34 @@
-let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
-let { target, .. } = import "config.ncl" in
+let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
+let bun = import "../bun/build.ncl" in
 let git = import "../git/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
+let ripgrep = import "../ripgrep/build.ncl" in
 
 let version = "1.14.20" in
 {
   name = "opencode",
   build_deps = [
     { file = "build.sh" } | Local,
-    match {
-      { arch = 'Amd64, .. } =>
-        {
-          url = "https://github.com/sst/opencode/releases/download/v%{version}/opencode-linux-x64.tar.gz",
-          sha256 = "1707133022382ea8c8cc5bc47ab1db52fa206bd9baf8d3ad4d862b489dbb448f",
-          extract = true,
-        } | Source,
-      { arch = 'Arm64, .. } =>
-        {
-          url = "https://github.com/sst/opencode/releases/download/v%{version}/opencode-linux-arm64.tar.gz",
-          sha256 = "3ca509044e06b8e7dacf08de735addee400788f80729c333fbf4581d0f77b4d3",
-          extract = true,
-        } | Source,
-    } target,
+    {
+      url = "https://github.com/anomalyco/opencode/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "cfa02650be42398be8b8f813ac4736a25d4a8d8a5f92b035bd98b66b4afcd34a",
+    } | Source,
     base,
+    bun,
   ],
 
   runtime_deps = [
     glibc,
     git,
+    ripgrep,
   ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
 
   cmd = "./build.sh",
   build_args = {
@@ -43,9 +42,10 @@ let version = "1.14.20" in
   attrs =
     {
       upstream_version = version,
+      build_cost_multiple = 3,
       source_provenance = {
         category = 'GithubRepo,
-        owner = "sst",
+        owner = "anomalyco",
         repo = "opencode",
       },
       env_dir_mappings = [

--- a/packages/opencode/build.ncl
+++ b/packages/opencode/build.ncl
@@ -1,0 +1,60 @@
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let git = import "../git/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.14.20" in
+{
+  name = "opencode",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://github.com/sst/opencode/releases/download/v%{version}/opencode-linux-x64.tar.gz",
+          sha256 = "1707133022382ea8c8cc5bc47ab1db52fa206bd9baf8d3ad4d862b489dbb448f",
+          extract = true,
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://github.com/sst/opencode/releases/download/v%{version}/opencode-linux-arm64.tar.gz",
+          sha256 = "3ca509044e06b8e7dacf08de735addee400788f80729c333fbf4581d0f77b4d3",
+          extract = true,
+        } | Source,
+    } target,
+    base,
+  ],
+
+  runtime_deps = [
+    glibc,
+    git,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    opencode = { glob = "usr/bin/opencode" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "sst",
+        repo = "opencode",
+      },
+      env_dir_mappings = [
+        { read_only = false, path = "~/.local/share/opencode", class = 'State },
+        { read_only = false, path = "~/.config/opencode", class = 'State },
+      ],
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/opencode --version",
+  },
+} | BuildSpec

--- a/packages/opencode/build.sh
+++ b/packages/opencode/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 opencode "$OUTPUT_DIR/usr/bin/opencode"

--- a/packages/opencode/build.sh
+++ b/packages/opencode/build.sh
@@ -1,5 +1,34 @@
 #!/bin/sh
-set -e
+set -ex
+
+# Upstream's tarball contains filenames with brackets (e.g. `[...callback].ts`)
+# that trip the built-in extractor, so unpack with tar manually.
+tar -xzf "v${MINIMAL_ARG_VERSION}.tar.gz"
+cd "opencode-${MINIMAL_ARG_VERSION}"
+
+# Relax the packageManager pin to whatever bun version pkgs ships.
+# Upstream pins an exact version; the build script's version gate uses a ^range
+# so rewriting the pin to match our shipped bun is sufficient.
+bun_version="$(bun --version)"
+sed -i "s/\"packageManager\": \"bun@[^\"]*\"/\"packageManager\": \"bun@${bun_version}\"/" package.json
+
+# Install monorepo dependencies (requires network access).
+bun install --frozen-lockfile --ignore-scripts
+
+# The build script consults git for a channel name when these are unset;
+# set them explicitly so it doesn't shell out to git in the sandbox.
+export OPENCODE_VERSION="$MINIMAL_ARG_VERSION"
+export OPENCODE_CHANNEL="local"
+
+# Build a single-target native binary, matching the upstream nix recipe.
+cd packages/opencode
+bun --bun ./script/build.ts --single --skip-install
+
+case "$(uname -m)" in
+  x86_64)  DIST_ARCH=x64 ;;
+  aarch64) DIST_ARCH=arm64 ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
 
 mkdir -p "$OUTPUT_DIR/usr/bin"
-install -m 755 opencode "$OUTPUT_DIR/usr/bin/opencode"
+install -m 755 "dist/opencode-linux-${DIST_ARCH}/bin/opencode" "$OUTPUT_DIR/usr/bin/opencode"


### PR DESCRIPTION
## Summary
- Adds `packages/opencode/` packaging the [anomalyco/opencode](https://github.com/anomalyco/opencode) CLI at v1.14.20 (formerly `sst/opencode` — upstream repo was transferred).
- Builds from source via `bun` (rather than repackaging the prebuilt release tarball), matching the policy now documented in `CLAUDE.md`.
- Unpacks the source tarball manually because the built-in extractor trips on bracketed filenames in the monorepo, relaxes the `packageManager` pin to whatever `bun` version pkgs ships, then runs `script/build.ts --single` for a native single-target binary.
- Declares `bun` as a build dep and `glibc` / `git` / `ripgrep` as runtime deps. Wires `~/.local/share/opencode` and `~/.config/opencode` as state dirs and retains the `opencode --version` smoketest.
- Adds an `opencode` task to `minimal.toml` so the CLI can be launched via `minimal run opencode`.
- Updates `CLAUDE.md` with two new authoring rules: verify the canonical upstream repo (catches silent GitHub redirects like `sst → anomalyco`) and prefer building from source when the required toolchain is already packaged.

## Test plan
- [x] `min check --packages opencode` — all checkers pass
- [x] `min patched-pkg opencode` — builds from source successfully
- [x] `opencode --version` smoketest passes post-build