### PR TITLE
Update vim to 9.2.0388

### DIFF
--- a/packages/vim/build.ncl
+++ b/packages/vim/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let acl = import "../acl/build.ncl" in
 let ncurses = import "../ncurses/build.ncl" in
 
-let version = "9.2.0350" in
+let version = "9.2.0388" in
 {
   name = "vim",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/vim-%{version}.tar.gz",
-      sha256 = "fd07df5cfd0a5e479c9320bef72d72e627923017ef20373979a4d04670db130d"
+      sha256 = "1ac056c943f5129722dcab58b304d72c3434c239cc2d658e05fdb21253792ad0"
     } | Source,
     base,
     make,
@@ -37,6 +37,7 @@ let version = "9.2.0350" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Vim",
       source_provenance = {
         category = 'GithubRepo,
         owner = "vim",


### PR DESCRIPTION
## Update vim `9.2.0350` → `9.2.0388`

**Source:** `github:vim/vim:tag`
**Release:** https://github.com/vim/vim/releases/tag/v9.2.0388
**Changelog:** https://github.com/vim/vim/compare/v9.2.0350...v9.2.0388

### Changes

| | Old | New |
|---|---|---|
| **Version** | `9.2.0350` | `9.2.0388` |
| **SHA256** | `fd07df5cfd0a5e47...` | `1ac056c943f51297...` |
| **Size** | 19.9 MB | 19.9 MB |
| **Source** | `gs://minimal-staging-archives/vim-9.2.0350.tar.gz` | `gs://minimal-staging-archives/vim-9.2.0388.tar.gz` |

- **License:** `Vim` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
