### PR TITLE
Update nghttp2 to 1.68.1 (patches GHSA-6933-cjhr-5qg6 HIGH)

### DIFF
--- a/packages/nghttp2/build.ncl
+++ b/packages/nghttp2/build.ncl
@@ -8,14 +8,14 @@ let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "1.68.0" in
+let version = "1.68.1" in
 {
   name = "nghttp2",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "https://github.com/nghttp2/nghttp2/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "07dfdadf670193baa7d6c23a007afa6ff2d3e4301b2a701c41dfd053e3468f09",
+      url = "https://github.com/nghttp2/nghttp2/releases/download/v%{version}/nghttp2-%{version}.tar.gz",
+      sha256 = "ceb434c1f9dfe2a9d305b6b797786fb9227484dfa88508d14ca1c50263db55d3",
       extract = true,
       strip_prefix = "nghttp2-%{version}",
     } | Source,


### PR DESCRIPTION
## Summary

Patches **`GHSA-6933-cjhr-5qg6`** (HIGH): denial-of-service via assertion failure from missing state validation. Fixed upstream in **nghttp2 1.68.1**.

## Why not 1.69.0?

pkgmgr currently reports 1.69.0 as "latest" — that also contains the fix, but it's a full minor version bump with new features on top. 1.68.1 is a targeted patch release for exactly this advisory, following the same pattern as openssl 3.6.1 → 3.6.2 (gominimal/pkgs#99): smaller blast radius, stays within the current series.

Future: pkgmgr-rs#32 surfaces `latest_in_series` in `check` output, and a follow-up will add `--target-version` to `pkgmgr update` so in-series security bumps can be one command.

## URL change

Also switches the source URL from GitHub's auto-archive to the maintainer's release asset:

```
before: https://github.com/nghttp2/nghttp2/archive/refs/tags/v%{version}.tar.gz
after:  https://github.com/nghttp2/nghttp2/releases/download/v%{version}/nghttp2-%{version}.tar.gz
```

Release assets are the maintainer's canonical, versioned distribution (the ones nghttp2 ships with detached `.asc` signatures). More stable than auto-archives (which GitHub regenerates on demand and can technically differ run-to-run), and aligns with upstream's own signing flow if we ever want to verify signatures. `strip_prefix` stays the same (`nghttp2-%{version}/` in both tarballs), and the cmake-only build script doesn't care about the difference.

## Test plan

- [x] SHA256 verified against the downloaded release asset (`ceb434c1f9dfe2a9d305b6b797786fb9227484dfa88508d14ca1c50263db55d3`)
- [x] strip_prefix matches tarball's root (`nghttp2-1.68.1/`)
- [x] cmake build script has no autoconf dependency → release asset works identically to auto-archive
- [ ] CI green
