### PR TITLE
agent-browser: make runtime usable out of the box

### DIFF
--- a/packages/agent-browser/build.ncl
+++ b/packages/agent-browser/build.ncl
@@ -38,6 +38,8 @@ let nspr = import "../nspr/build.ncl" in
 let pango = import "../pango/build.ncl" in
 let atk = import "../atk/build.ncl" in
 let at-spi2-core = import "../at-spi2-core/build.ncl" in
+let eudev = import "../eudev/build.ncl" in
+let liberation-fonts = import "../liberation-fonts/build.ncl" in
 
 let version = "0.15.1" in
 {
@@ -90,6 +92,8 @@ let version = "0.15.1" in
     pango,
     atk,
     at-spi2-core,
+    eudev, # provides libudev.so.1, required by Chromium at runtime
+    liberation-fonts, # Chromium renders boxes without a fallback font available
   ],
 
   cmd = "./build.sh",

--- a/packages/agent-browser/build.sh
+++ b/packages/agent-browser/build.sh
@@ -5,8 +5,12 @@ export CC=gcc
 export LD=gcc
 export RUSTFLAGS="-C linker=gcc"
 
-# Install JS deps (skip postinstall which downloads pre-built binary)
-pnpm install --ignore-scripts
+# Install JS deps (skip postinstall which downloads pre-built binary).
+# Use the hoisted node-linker so node_modules is a flat, self-contained
+# tree — pnpm's default symlinked layout into .pnpm/ doesn't survive
+# being copied into $OUTPUT_DIR and causes runtime ERR_MODULE_NOT_FOUND
+# on transitive deps (e.g. jszip).
+pnpm install --ignore-scripts --config.node-linker=hoisted
 
 # Build TypeScript daemon
 pnpm build


### PR DESCRIPTION
## Summary
Three fixes so `min add agent-browser` followed by `agent-browser open <url>` works in a bare sandbox, without consumers needing to carry their own Chromium install / dep-hoisting workarounds.

### 1. Use pnpm's hoisted node-linker at build time (`build.sh`)
pnpm's default layout symlinks packages into `.pnpm/`. When `build.sh` did `cp -R node_modules` into `$OUTPUT_DIR`, the relative links didn't resolve from the install location and Node's resolver threw `ERR_MODULE_NOT_FOUND` on transitive deps (`jszip` was the reported symptom). Passing `--config.node-linker=hoisted` produces a flat, self-contained `node_modules` that copies cleanly.

### 2. Add `eudev` to `runtime_deps` (`build.ncl`)
Chromium dlopens `libudev.so.1` at startup; without it the daemon fails to start (surfaced as an opaque `Daemon failed to start` in the CLI). Playwright's host-validation also flags this during build.

### 3. Add `liberation-fonts` to `runtime_deps` (`build.ncl`)
Without a fallback font available, Chromium renders text as boxes. Safe and cheap to depend on.

## Test plan
- [x] `min patched-pkg agent-browser` builds clean
- [x] In a fresh sandbox: `min add --session agent-browser && XDG_RUNTIME_DIR=/tmp agent-browser open <url>` succeeds (verified locally)
- [x] `min check --packages agent-browser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)