### PR TITLE
Update bun to 1.3.13

### DIFF
--- a/packages/bun/build.ncl
+++ b/packages/bun/build.ncl
@@ -18,11 +18,11 @@ let automake = import "../automake/build.ncl" in
 let libtool = import "../libtool/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.3.11" in
+let version = "1.3.13" in
 let dl_base = "https://github.com/oven-sh/bun/releases/download/bun-v%{version}" in
 let { amd64_sha256, arm64_sha256 } = {
-  amd64_sha256 = "8611ba935af886f05a6f38740a15160326c15e5d5d07adef966130b4493607ed",
-  arm64_sha256 = "d13944da12a53ecc74bf6a720bd1d04c4555c038dfe422365356a7be47691fdf",
+  amd64_sha256 = "79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a",
+  arm64_sha256 = "70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22",
 }
 in
 {
@@ -31,7 +31,7 @@ in
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/oven-sh/bun/archive/refs/tags/bun-v%{version}.tar.gz",
-      sha256 = "5dbe65a63f1225b18717159d7c4bedb6983fbc684a7b5848d3af801279f8ec6a",
+      sha256 = "8cd7b2fd45df28546155f921541c35d2df265a591483853c7c54961ddfbcef7c",
       extract = true,
       strip_prefix = "bun-bun-v%{version}",
     } | Source,

--- a/packages/bun/build.ncl
+++ b/packages/bun/build.ncl
@@ -16,6 +16,7 @@ let git = import "../git/build.ncl" in
 let curl = import "../curl/build.ncl" in
 let automake = import "../automake/build.ncl" in
 let libtool = import "../libtool/build.ncl" in
+let unzip = import "../unzip/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
 let version = "1.3.13" in
@@ -63,6 +64,7 @@ in
     curl,
     automake,
     libtool,
+    unzip,
   ],
   runtime_deps = [
     glibc,

--- a/packages/bun/build.sh
+++ b/packages/bun/build.sh
@@ -1,44 +1,12 @@
 #!/bin/sh
 set -ex
 
-# Provide an `unzip` shim backed by python's zipfile module (no unzip package
-# in the minimal environment). The nested build calls `unzip -o -DD -d <dest>
-# <zip>` to extract the downloaded zig toolchain.
-mkdir -p shims
-cat > shims/unzip <<'SHIM'
-#!/usr/bin/env python3
-import sys, os, zipfile
-args = sys.argv[1:]
-dest, src = ".", None
-i = 0
-while i < len(args):
-    a = args[i]
-    if a in ("-o", "-DD", "-q", "-qq"):
-        i += 1
-    elif a == "-d":
-        dest = args[i + 1]; i += 2
-    else:
-        src = a; i += 1
-if src is None:
-    sys.exit("unzip shim: missing zip path")
-os.makedirs(dest, exist_ok=True)
-with zipfile.ZipFile(src) as z:
-    z.extractall(dest)
-    for info in z.infolist():
-        if info.external_attr:
-            mode = (info.external_attr >> 16) & 0o777
-            if mode:
-                os.chmod(os.path.join(dest, info.filename), mode)
-SHIM
-chmod +x shims/unzip
-export PATH="$(pwd)/shims:$PATH"
-
 # Extract and set up bootstrap bun binary
 case $(uname -m) in
   x86_64)  BUN_ARCH=x64;   CARGO_TARGET=x86_64-unknown-linux-gnu ;;
   aarch64) BUN_ARCH=aarch64; CARGO_TARGET=aarch64-unknown-linux-gnu ;;
 esac
-python3 -m zipfile -e "bun-linux-${BUN_ARCH}.zip" .
+unzip -o "bun-linux-${BUN_ARCH}.zip"
 chmod +x "bun-linux-${BUN_ARCH}/bun"
 export PATH="$(pwd)/bun-linux-${BUN_ARCH}:$PATH"
 bun --version

--- a/packages/bun/build.sh
+++ b/packages/bun/build.sh
@@ -1,6 +1,38 @@
 #!/bin/sh
 set -ex
 
+# Provide an `unzip` shim backed by python's zipfile module (no unzip package
+# in the minimal environment). The nested build calls `unzip -o -DD -d <dest>
+# <zip>` to extract the downloaded zig toolchain.
+mkdir -p shims
+cat > shims/unzip <<'SHIM'
+#!/usr/bin/env python3
+import sys, os, zipfile
+args = sys.argv[1:]
+dest, src = ".", None
+i = 0
+while i < len(args):
+    a = args[i]
+    if a in ("-o", "-DD", "-q", "-qq"):
+        i += 1
+    elif a == "-d":
+        dest = args[i + 1]; i += 2
+    else:
+        src = a; i += 1
+if src is None:
+    sys.exit("unzip shim: missing zip path")
+os.makedirs(dest, exist_ok=True)
+with zipfile.ZipFile(src) as z:
+    z.extractall(dest)
+    for info in z.infolist():
+        if info.external_attr:
+            mode = (info.external_attr >> 16) & 0o777
+            if mode:
+                os.chmod(os.path.join(dest, info.filename), mode)
+SHIM
+chmod +x shims/unzip
+export PATH="$(pwd)/shims:$PATH"
+
 # Extract and set up bootstrap bun binary
 case $(uname -m) in
   x86_64)  BUN_ARCH=x64;   CARGO_TARGET=x86_64-unknown-linux-gnu ;;
@@ -33,29 +65,16 @@ export CXXFLAGS="${CFLAGS}"
 # our stable rust is sufficient for lol-html
 rm -f rust-toolchain.toml
 
-# Initialize a git repo so CMake's dependency version generation works
+# Initialize a git repo so nested dep version generation works
 # (it runs "git rev-parse HEAD" to get version strings for bundled packages)
 git init -q
 git -c user.email=build@local -c user.name=build commit -q -m "v${MINIMAL_ARG_VERSION}" --allow-empty
 
-# Install npm dependencies and generate source file lists
-bun install --frozen-lockfile
-bun run glob-sources
-
-# Configure with CMake
-cmake -GNinja -B build \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DENABLE_BASELINE=OFF \
-  -DENABLE_LTO=OFF \
-  -DENABLE_ASAN=OFF \
-  -DUSE_STATIC_LIBATOMIC=OFF \
-  -Wno-dev
-
-# Build
-ninja -C build bun
+# Build via bun's own build orchestration (handles bun install, codegen, cmake
+# deps, zig, linking, and strip). Outputs the stripped binary at build/release/bun.
+bun run build:release
 
 # Install
 mkdir -p "$OUTPUT_DIR/usr/bin"
-install -m 755 build/bun "$OUTPUT_DIR/usr/bin/bun"
+install -m 755 build/release/bun "$OUTPUT_DIR/usr/bin/bun"
 ln -s bun "$OUTPUT_DIR/usr/bin/bunx"


### PR DESCRIPTION
Switch the build to bun's own build:release orchestration (handles codegen, cmake deps, zig, link, and strip) and add a python-backed unzip shim so the nested zig toolchain extraction works in the minimal sandbox.