### PR TITLE
Update ngtcp2 to 1.22.1

### DIFF
--- a/packages/ngtcp2/build.ncl
+++ b/packages/ngtcp2/build.ncl
@@ -7,14 +7,14 @@ let pkgconf = import "../pkgconf/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 
-let version = "1.22.0" in
+let version = "1.22.1" in
 {
   name = "ngtcp2",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/ngtcp2/ngtcp2/releases/download/v%{version}/ngtcp2-%{version}.tar.gz",
-      sha256 = "9622e2f6606afb6c0a6b2d96584963d47f97b85b7c79f3f9d6adbe1215140e5b",
+      sha256 = "063d80531acac0ddbbc1b9d12829a824edc2abe8dba2e632fd1ce15cfd5632f9",
       extract = true,
       strip_prefix = "ngtcp2-%{version}",
     } | Source,
@@ -42,6 +42,7 @@ let version = "1.22.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "ngtcp2",


### PR DESCRIPTION
## Update ngtcp2 `1.22.0` → `1.22.1`

**Source:** `github:ngtcp2/ngtcp2`
**Release:** https://github.com/ngtcp2/ngtcp2/releases/tag/v1.22.1
**Changelog:** https://github.com/ngtcp2/ngtcp2/compare/v1.22.0...v1.22.1

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.22.0` | `1.22.1` |
| **SHA256** | `9622e2f6606afb6c...` | `063d80531acac0dd...` |
| **Size** |  | 1.2 MB |
| **Source** | `https://github.com/ngtcp2/ngtcp2/releases/download/v1.22.0/ngtcp2-1.22.0.tar.gz` | `https://github.com/ngtcp2/ngtcp2/releases/download/v1.22.1/ngtcp2-1.22.1.tar.gz` |

- **License:** `MIT` _(source: GitHub + tarball)_

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
