### PR TITLE
Update deno to 2.7.13

### DIFF
--- a/packages/deno/build.ncl
+++ b/packages/deno/build.ncl
@@ -5,7 +5,7 @@ let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let python = import "../python/build.ncl" in
 
-let version = "2.7.2" in
+let version = "2.7.13" in
 {
   name = "deno",
   build_deps = [
@@ -14,12 +14,12 @@ let version = "2.7.2" in
       { arch = 'Amd64, .. } =>
         {
           url = "https://github.com/denoland/deno/releases/download/v%{version}/deno-x86_64-unknown-linux-gnu.zip",
-          sha256 = "bc3af4d1bedd7893664b925c0f39fb08f7b12242e57ed4acdc0cf64540b4449c",
+          sha256 = "d7b452de2578742889b70a7e3cf90eb14b8e6b1bca4758380da3630d694f04ff",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "https://github.com/denoland/deno/releases/download/v%{version}/deno-aarch64-unknown-linux-gnu.zip",
-          sha256 = "c36c0b284d084dfe7045a106e60bd98d919183fd69d7902a42f3c7a244bf4386",
+          sha256 = "c017fa8389bd96b6b07b3416bdb8d37074ab2ff1c83a9c94f7b2a6a7da026dac",
         } | Source,
     } target,
     base,
@@ -39,6 +39,7 @@ let version = "2.7.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       env_state_wiring = {
         env_var = "DENO_DIR",
         prefix = "deno-cache",


### PR DESCRIPTION
## Update deno `2.7.2` → `2.7.13`

**Source:** `github:denoland/deno`
**Release:** https://github.com/denoland/deno/releases/tag/v2.7.13
**Changelog:** https://github.com/denoland/deno/compare/v2.7.2...v2.7.13

### Vulnerabilities fixed (2)

This update clears 2 vulnerabilities affecting `2.7.2`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-8vxj-4cph-c596 | **HIGH** | `>= 2.2.5` |
| GHSA-mc52-jpm2-cqh6 | **HIGH** | `>= 1.29.3` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.7.2` | `2.7.13` |
| **SHA256** | `c36c0b284d084dfe...` | `d7b452de25787428...` |
| **Size** |  | 50.2 MB |
| **Source** | `https://github.com/denoland/deno/releases/download/v2.7.2/deno-aarch64-unknown-linux-gnu.zip` | `https://github.com/denoland/deno/releases/download/v2.7.13/deno-x86_64-unknown-linux-gnu.zip` |

- **License:** `MIT` _(source: GitHub + tarball)_

### Per-arch sources

| Arch | New SHA256 | Size | URL |
|---|---|---|---|
| `Amd64` | `d7b452de25787428...` (was `bc3af4d1bedd7893...`) | 50.2 MB | `https://github.com/denoland/deno/releases/download/v2.7.13/deno-x86_64-unknown-linux-gnu.zip` |
| `Arm64` | `c017fa8389bd96b6...` (was `c36c0b284d084dfe...`) | 48.1 MB | `https://github.com/denoland/deno/releases/download/v2.7.13/deno-aarch64-unknown-linux-gnu.zip` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
