### PR TITLE
Update cups to 2.4.18

### DIFF
--- a/packages/cups/build.ncl
+++ b/packages/cups/build.ncl
@@ -8,14 +8,14 @@ let openssl = import "../openssl/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.4.13" in
+let version = "2.4.18" in
 {
   name = "cups",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/cups-%{version}-source.tar.gz",
-      sha256 = "8255ecf037be72660de24a73bcada042fc5bf509fc87bc8ad16cd0675735c1a8",
+      sha256 = "8fe23bf4905f8889f4bd5ebf375e81916e84754bfc59eccc88cfd7b1e97a741b",
       extract = true,
       strip_prefix = "cups-%{version}",
     } | Source,
@@ -40,6 +40,7 @@ let version = "2.4.13" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "OpenPrinting",


### PR DESCRIPTION
## Update cups `2.4.13` → `2.4.18`

**Source:** `github:OpenPrinting/cups`
**Release:** https://github.com/OpenPrinting/cups/releases/tag/v2.4.18
**Changelog:** https://github.com/OpenPrinting/cups/compare/v2.4.13...v2.4.18

### Vulnerabilities fixed (8)

This update clears 8 vulnerabilities affecting `2.4.13`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-6qxf-7jx6-86fh | MEDIUM | `2.4.17` |
| GHSA-6wpw-g8g6-wvrv | MEDIUM | `2.4.17` |
| GHSA-8wpw-vfgm-qrrr | MEDIUM | `2.4.15` |
| GHSA-hxm8-vfpq-jrfc | MEDIUM | `2.4.15` |
| GHSA-pjv5-prqp-46rg | MEDIUM | `2.4.17` |
| GHSA-pp8w-2g52-7vj7 | MEDIUM | `2.4.17` |
| GHSA-qfp8-9frx-5j48 | MEDIUM | `2.4.17` |
| GHSA-v987-m8hp-phj9 | MEDIUM | `2.4.17` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.4.13` | `2.4.18` |
| **SHA256** | `8255ecf037be7266...` | `8fe23bf4905f8889...` |
| **Size** | 8.2 MB | 8.2 MB |
| **Source** | `gs://minimal-staging-archives/cups-2.4.13-source.tar.gz` | `gs://minimal-staging-archives/cups-2.4.18-source.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
