### PR TITLE
minimal.toml: require stlib 0.0.11 now we use license_spdx attr

### DIFF
--- a/minimal.toml
+++ b/minimal.toml
@@ -1,5 +1,5 @@
 [stdlib]
-minimum_version = "0.0.9"
+minimum_version = "0.0.11"
 
 [tasks.shell]
 interactive = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum standard library version requirement to 0.0.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->