### PR TITLE
Update cosign to 3.0.6

### DIFF
--- a/packages/cosign/build.ncl
+++ b/packages/cosign/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.0.4" in
+let version = "3.0.6" in
 {
   name = "cosign",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/sigstore/cosign/v%{version}.tar.gz",
-      sha256 = "8096c07e9a3ae21fa600c19cc8ff8c6f15b027184858d0bc0edde5f74589a01a",
+      sha256 = "ea2f4094d944d79671784ba3d7601d7fdf78c15b0d92cdc4ca31b4d5cff3cd89",
       extract = true,
       strip_prefix = "cosign-%{version}",
     } | Source,
@@ -42,6 +42,7 @@ let version = "3.0.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "cosign",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update cosign `3.0.4` → `3.0.6`

**Source:** `github:sigstore/cosign`
**Release:** https://github.com/sigstore/cosign/releases/tag/v3.0.6
**Changelog:** https://github.com/sigstore/cosign/compare/v3.0.4...v3.0.6

### Vulnerabilities fixed (1)

This update clears 1 vulnerabilities affecting `3.0.4`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-wfqv-66vq-46rm | LOW | `3.0.5` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `3.0.4` | `3.0.6` |
| **SHA256** | `8096c07e9a3ae21f...` | `ea2f4094d944d796...` |
| **Size** | 952 KB | 967 KB |
| **Source** | `gs://minimal-staging-archives/sigstore/cosign/v3.0.4.tar.gz` | `gs://minimal-staging-archives/sigstore/cosign/v3.0.6.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
