### PR TITLE
rust-arm-embedded: dedupe upstream_version string literal, read from upstream nickel

### DIFF
--- a/packages/rust-arm-embedded/build.ncl
+++ b/packages/rust-arm-embedded/build.ncl
@@ -4,7 +4,6 @@ let base = import "../base/build.ncl" in
 let rust = import "../rust/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "1.93.1" in
 {
   name = "rust-arm-embedded",
   build_deps = [
@@ -31,7 +30,7 @@ let version = "1.93.1" in
 
   attrs =
     {
-      upstream_version = version,
+      upstream_version = rust.attrs.upstream_version,
       source_provenance = {
         category = 'GithubRepo,
         owner = "rust-lang",


### PR DESCRIPTION
Nickel change, but doesnt change any value that comes out of nickel eval, hence no impact on spec hashes or packages or anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust ARM embedded build configuration to dynamically reference upstream version from imported build specification, replacing locally hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->