### PR TITLE
claude-code: add git/openssh as runtime_deps, needed by plugins

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -5,7 +5,9 @@ let bash = import "../bash/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let findutils = import "../findutils/build.ncl" in
 let curl = import "../curl/build.ncl" in
+let git = import "../git/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
+let openssh = import "../openssh/build.ncl" in
 let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
@@ -44,8 +46,10 @@ in
     coreutils,
     findutils,
     curl,
+    git,
     glibc,
     ripgrep,
+    openssh,
   ],
 
   cmd = "./build.sh",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added git and openssh to runtime dependencies in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->