### PR TITLE
Update llama.cpp to b8941

### DIFF
--- a/packages/llama.cpp/build.ncl
+++ b/packages/llama.cpp/build.ncl
@@ -10,14 +10,14 @@ let hwdata = import "../hwdata/build.ncl" in
 let pciutils = import "../pciutils/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "b8651" in
+let version = "b8941" in
 {
   name = "llama.cpp",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/ggml-org/llama.cpp/%{version}.tar.gz",
-      sha256 = "b88b0469a1d1cff4344b234b5e18ffc60be3ff3e0516b7d3116c3c605520afb2",
+      sha256 = "fed02e5a3445aa8c6a21cce3ed128d1777dab1bd234135291a21592eafd5e180",
       extract = true,
       strip_prefix = "llama.cpp-%{version}",
     } | Source,
@@ -44,6 +44,7 @@ let version = "b8651" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "ggml-org",


### PR DESCRIPTION
## Update llama.cpp `b8651` → `b8941`

**Source:** `github:ggml-org/llama.cpp`
**Release:** https://github.com/ggml-org/llama.cpp/releases/tag/b8941
**Changelog:** https://github.com/ggml-org/llama.cpp/compare/b8651...b8941

> Detonate scan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

> [!WARNING]
> **1 known vulnerabilities still affect `b8941` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | GHSA-g4cc-763q-h9h6 | MEDIUM | `c33fe8b8` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `b8651` | `b8941` |
| **SHA256** | `b88b0469a1d1cff4...` | `fed02e5a3445aa8c...` |
| **Size** | 29.7 MB | 33.9 MB |
| **Source** | `gs://minimal-staging-archives/ggml-org/llama.cpp/b8651.tar.gz` | `gs://minimal-staging-archives/ggml-org/llama.cpp/b8941.tar.gz` |

- **License:** `MIT` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated llama.cpp to a newer revision with improved stability and features.
  * Added license metadata for better package compliance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->