### PR TITLE
Update base-soup: xz 5.8.1 -> 5.8.3

### DIFF
--- a/packages/xz/build.ncl
+++ b/packages/xz/build.ncl
@@ -5,14 +5,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let make = import "../make/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "5.8.1" in
+let version = "5.8.3" in
 {
   name = "xz",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/xz-%{version}.tar.xz",
-      sha256 = "0b54f79df85912504de0b14aec7971e3f964491af1812d83447005807513cd9e"
+      sha256 = "fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
     } | Source,
     base-bootstrap,
     make,
@@ -84,6 +84,7 @@ let version = "5.8.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(0BSD AND GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)",
       source_provenance = {
         category = 'GithubRepo,
         owner = "tukaani-project",

--- a/packages/xz/build.sh
+++ b/packages/xz/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof xz-5.8.1.tar.xz
-cd xz-5.8.1
+tar -xof xz-5.8.3.tar.xz
+cd xz-5.8.3
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;
@@ -15,7 +15,7 @@ export CXXFLAGS="${CFLAGS}"
 
 ./configure --prefix=/usr   \
            --disable-static \
-           --docdir=/usr/share/doc/xz-5.8.1
+           --docdir=/usr/share/doc/xz-5.8.3
 
 make -j$(nproc)
 # make check


### PR DESCRIPTION
## Update base-soup (1 package)

> [!NOTE]
> These packages declare `replace_on_cycle` in their build.ncl, so
> they participate in the toolchain rebuild graph and one hash change
> cascades through the set. Bundling ensures the cascading rebuild
> lands as a single unit, even when only one package is bumping —
> avoids back-to-back full rebuilds from singleton PRs.


> Pkgscan: **clean** across all bundle members — diffs against prior versions surfaced no newly-introduced suspicious patterns.
### Summary

| Package | Old | New | Source |
|---|---|---|---|
| xz | `5.8.1` | `5.8.3` | `github:tukaani-project/xz` |

### Vulnerabilities fixed (1)

| Package | CVE / GHSA | Severity | Fixed in |
|---|---|---|---|
| xz | GHSA-x872-m794-cxhv | LOW | `5.8.3` |

### Per-package details

<details><summary><code>xz 5.8.1 → 5.8.3</code></summary>

- **SHA256:** `0b54f79df8591250...` → `fff1ffcf2b0da84d...`
- **Size:** 1.5 MB → 1.5 MB
- **Source:** `gs://minimal-staging-archives/xz-5.8.1.tar.xz` → `gs://minimal-staging-archives/xz-5.8.3.tar.xz`
- **License:** `(0BSD AND GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)` _(source: tarball)_

</details>


---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated xz package to version 5.8.3
  * Added SPDX license expression metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->