### PR TITLE
jdk: pick per-arch source tarball instead of always-amd64

### DIFF
--- a/packages/jdk/build.ncl
+++ b/packages/jdk/build.ncl
@@ -1,4 +1,5 @@
 let { Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
 let alsa-lib = import "../alsa-lib/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
@@ -6,14 +7,30 @@ let zlib = import "../zlib/build.ncl" in
 
 let version = "21.0.10" in
 let build_num = "7" in
+let dl_base = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-%{version}+%{build_num}" in
+
+let { amd64_sha256, arm64_sha256 } = {
+  amd64_sha256 = "ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4",
+  arm64_sha256 = "357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad703ab27b9a",
+}
+in
+
 {
   name = "jdk",
   build_deps = [
     { file = "build.sh" } | Local,
-    {
-      url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-%{version}+%{build_num}/OpenJDK21U-jdk_x64_linux_hotspot_%{version}_%{build_num}.tar.gz",
-      sha256 = "ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4",
-    } | Source,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "%{dl_base}/OpenJDK21U-jdk_x64_linux_hotspot_%{version}_%{build_num}.tar.gz",
+          sha256 = amd64_sha256,
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "%{dl_base}/OpenJDK21U-jdk_aarch64_linux_hotspot_%{version}_%{build_num}.tar.gz",
+          sha256 = arm64_sha256,
+        } | Source,
+    } target,
     base,
   ],
   runtime_deps = [

--- a/packages/jdk/build.sh
+++ b/packages/jdk/build.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 set -ex
 
-tar -xof "OpenJDK21U-jdk_x64_linux_hotspot_${MINIMAL_ARG_VERSION}_${MINIMAL_ARG_BUILD_NUM}.tar.gz"
+case $(uname -m) in
+  x86_64)  PLATFORM="x64" ;;
+  aarch64) PLATFORM="aarch64" ;;
+  *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+tar -xof "OpenJDK21U-jdk_${PLATFORM}_linux_hotspot_${MINIMAL_ARG_VERSION}_${MINIMAL_ARG_BUILD_NUM}.tar.gz"
 cd "jdk-${MINIMAL_ARG_VERSION}+${MINIMAL_ARG_BUILD_NUM}"
 
 mkdir -p $OUTPUT_DIR/usr/{bin,lib/jvm}


### PR DESCRIPTION
## Summary

Fixes the arm64 jdk build shipping x86-64 binaries (issue #124).

The `build.ncl` `Source` URL was hardcoded to `OpenJDK21U-jdk_x64_linux_hotspot_*.tar.gz` -- so both amd64 and arm64 builds pulled the amd64 Adoptium release. Harmless on amd64, completely broken on arm64. Adopts the per-arch pattern already used by `packages/gcloud/build.ncl`:

- Imports `target` from `config.ncl`
- `match`es on `arch` between `'Amd64` (x64) and `'Arm64` (aarch64) Adoptium URLs
- `build.sh` selects the right tarball name via `uname -m`, mirroring `packages/gcloud/build.sh`

Both sha256 values verified against Adoptium's published sidecar files at https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.10%2B7 -- the existing amd64 sha matches what was already pinned, the arm64 sha is new.

## Why this surfaced now

gominimal/build-servers#56 moved package checks from buildbot to res-server, where the hakoniwa sandbox actually works (build-bot's VM doesn't have the namespace setup). The buildbot run on `main` immediately after that deploy caught it with two complementary signals:

```
[package: jdk] missing runtime_deps  arm64/linux
  executable dependency 'ld-linux-x86-64.so.2' not in runtime deps,
  needed by usr/lib/jvm/lib/libjvm.so [...]
```
`ld-linux-x86-64.so.2` is the x86-64 dynamic linker -- arm64 ELFs use `ld-linux-aarch64.so.1`. The fact that this is being referenced is a static signal that the binaries are x86-64.

```
[package: jdk] standalone tests  arm64/linux
  javac_compile: execve("/bin/javac", ...) => ENOEXEC: Exec format error
```
`ENOEXEC` is what the kernel returns when an ELF's machine type doesn't match the host CPU -- runtime confirmation of the same.

## Cascade

The same buildbot run reported four follow-on failures that should resolve with this fix, since they all spawn the JVM:

- `[package: gradle]` -- `gradle --version` -- exit 1 (JVM can't start)
- `[package: maven]` -- `mvn --version` -- exit 1
- `[package: android-sdk]` -- `sdkmanager --version` -- exit 126 ("cannot execute binary file: Exec format error" on `/usr/bin/java`)
- `[package: jdk]` -- `java_version` and `javac_compile` -- exit 1 / 125

## Test plan

- [ ] After merge, the next buildbot run on `main` should show:
  - `jdk` `missing runtime_deps arm64/linux` cleared (no more reference to `ld-linux-x86-64.so.2`)
  - `jdk` `standalone tests arm64/linux` reports `java_version` and `javac_compile` as Pass
  - `gradle`, `maven`, `android-sdk` standalone tests come back Pass
- [ ] amd64 builds remain unchanged (sha pinned at the same value, URL pattern resolves to the same tarball)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support for JDK builds alongside AMD64
  * Automatic runtime CPU architecture detection for streamlined configuration

* **Improvements**
  * Enhanced error handling for unsupported build architectures
  * Centralized artifact configuration for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->