### PR TITLE
Update harfbuzz to 14.2.0

### DIFF
--- a/packages/harfbuzz/build.ncl
+++ b/packages/harfbuzz/build.ncl
@@ -9,14 +9,14 @@ let freetype = import "../freetype/build.ncl" in
 let glib = import "../glib/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "14.1.0" in
+let version = "14.2.0" in
 {
   name = "harfbuzz",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/harfbuzz-%{version}.tar.xz",
-      sha256 = "ee0eb3a1da2c5a28147f12dff55f6c7d60aeeeb29ac7ef334eabe84c8476c105",
+      sha256 = "94017020f96d025bb66ae91574e4cf334bcad23e8175a8a40565b3721bc2eaff",
       extract = true,
       strip_prefix = "harfbuzz-%{version}",
     } | Source,
@@ -42,6 +42,7 @@ let version = "14.1.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT-Modern-Variant",
       source_provenance = {
         category = 'GithubRepo,
         owner = "harfbuzz",


### PR DESCRIPTION
## Update harfbuzz `14.1.0` → `14.2.0`

**Source:** `github:harfbuzz/harfbuzz`
**Release:** https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0
**Changelog:** https://github.com/harfbuzz/harfbuzz/compare/14.1.0...14.2.0
**Released:** 7 days ago (2026-04-20)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

> [!WARNING]
> **1 known vulnerabilities still affect `14.2.0` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | GHSA-f6q6-4vjq-m6j7 | LOW | _affected:_ `None` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `14.1.0` | `14.2.0` |
| **SHA256** | `ee0eb3a1da2c5a28...` | `94017020f96d025b...` |
| **Size** | 19.5 MB | 19.6 MB |
| **Source** | `gs://minimal-staging-archives/harfbuzz-14.1.0.tar.xz` | `gs://minimal-staging-archives/harfbuzz-14.2.0.tar.xz` |

- **License:** `MIT-Modern-Variant` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HarfBuzz to version 14.2.0
  * Added license metadata clarification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->