### PR TITLE
Update curl to 8.19.0

### DIFF
--- a/packages/curl/build.ncl
+++ b/packages/curl/build.ncl
@@ -8,14 +8,14 @@ let perl = import "../perl/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "8.17.0" in
+let version = "8.19.0" in
 {
   name = "curl",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/curl-%{version}.tar.xz",
-      sha256 = "955f6e729ad6b3566260e8fef68620e76ba3c31acf0a18524416a185acf77992",
+      sha256 = "4eb41489790d19e190d7ac7e18e82857cdd68af8f4e66b292ced562d333f11df",
       extract = true,
       strip_prefix = "curl-%{version}",
     } | Source,
@@ -53,6 +53,7 @@ let version = "8.17.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "curl",
       repology_project = "curl",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update curl `8.17.0` → `8.19.0`

**Source:** `github:curl/curl`
**Release:** https://github.com/curl/curl/releases/tag/curl-8_19_0
**Changelog:** https://github.com/curl/curl/compare/8.17.0...curl-8_19_0
**Released:** 47 days ago (2026-03-11)

> [!WARNING]
> **Pkgscan: 3 new signals introduced by this update** (risk score 0.3).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | INFO | `tests/http/scorecard.py` | 364 | `persistence/filesystem` | `.profile` |
> | INFO | `tests/http/scorecard.py` | 393 | `persistence/filesystem` | `.profile` |
> | INFO | `tests/http/scorecard.py` | 427 | `persistence/filesystem` | `.profile` |

### Vulnerabilities fixed (10)

This update clears 10 vulnerabilities affecting `8.17.0`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| CVE-2026-3805 | **HIGH** | _no fix_ |
| CVE-2025-13034 | MEDIUM | _no fix_ |
| CVE-2025-14017 | MEDIUM | _no fix_ |
| CVE-2025-14524 | MEDIUM | _no fix_ |
| CVE-2025-14819 | MEDIUM | _no fix_ |
| CVE-2025-15079 | MEDIUM | _no fix_ |
| CVE-2026-1965 | MEDIUM | _no fix_ |
| CVE-2026-3783 | MEDIUM | _no fix_ |
| CVE-2026-3784 | MEDIUM | _no fix_ |
| CVE-2025-15224 | LOW | _no fix_ |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `8.17.0` | `8.19.0` |
| **SHA256** | `955f6e729ad6b356...` | `4eb41489790d19e1...` |
| **Size** | 2.8 MB | 2.8 MB |
| **Source** | `gs://minimal-staging-archives/curl-8.17.0.tar.xz` | `gs://minimal-staging-archives/curl-8.19.0.tar.xz` |

- **License:** `curl` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated curl dependency from version 8.17.0 to 8.19.0 with corresponding integrity checks
  * Updated package metadata to include SPDX license information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->