### PR TITLE
foundationdb: fix test hang

### DIFF
--- a/packages/foundationdb/build.ncl
+++ b/packages/foundationdb/build.ncl
@@ -88,10 +88,10 @@ let version = "7.3.69" in
             set -euo pipefail
 
             # Create a minimal FDB cluster file
-            TMPDIR=$(mktemp -d)
-            CLUSTER_FILE="$TMPDIR/fdb.cluster"
-            DATA_DIR="$TMPDIR/data"
-            LOG_DIR="$TMPDIR/logs"
+            BASE=$(pwd)
+            CLUSTER_FILE="$BASE/fdb.cluster"
+            DATA_DIR="$BASE/data"
+            LOG_DIR="$BASE/logs"
             mkdir -p "$DATA_DIR" "$LOG_DIR"
 
             echo "test:testid@127.0.0.1:4500" > "$CLUSTER_FILE"


### PR DESCRIPTION
For unknown reasons the cluster fails to start on one of my machines when setup on a tmpfs. This adjusts it to run on cwd, which is always on the main fs, which should be backed by ext4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated FoundationDB server smoke testing infrastructure to adjust how configuration and directory paths are managed during testing operations.

**Note:** This is an internal testing infrastructure change with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->