### PR TITLE
mono, or-tools: cap build parallelism to nproc/4

### DIFF
--- a/packages/mono/build.sh
+++ b/packages/mono/build.sh
@@ -45,7 +45,13 @@ sed -i 's/cmake_minimum_required (VERSION 2\.8\.10)/cmake_minimum_required (VERS
   --with-monotouch=no \
   --with-xammac=no
 
-make -j$(nproc)
+# Cap parallelism to nproc/4 (matches packages/foundationdb). Mono's
+# bootstrap (byacc + jay + corlib + the runtime) is memory-greedy at
+# -j32 and OOMs the whole build.
+JOBS=$(( $(nproc) / 4 ))
+[ "$JOBS" -lt 1 ] && JOBS=1
+
+make -j"$JOBS"
 make DESTDIR=$OUTPUT_DIR install
 
 # Remove .la files for reproducibility

--- a/packages/or-tools/build.sh
+++ b/packages/or-tools/build.sh
@@ -40,6 +40,12 @@ cmake -G Ninja \
 # protoc and other build-time tools need to find their shared libs
 export LD_LIBRARY_PATH="$(pwd)/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-ninja -j$(nproc)
+# Cap parallelism to nproc/4 (matches packages/foundationdb). or-tools'
+# inline-built deps (protobuf, abseil, HiGHS, eigen) link together at peak
+# and explode memory at -j32, OOMing the whole build.
+JOBS=$(( $(nproc) / 4 ))
+[ "$JOBS" -lt 1 ] && JOBS=1
+
+ninja -j"$JOBS"
 
 DESTDIR="$OUTPUT_DIR" ninja install


### PR DESCRIPTION
## Summary

Caps build parallelism on `or-tools` and `mono` at `nproc/4`, matching the existing pattern in `packages/foundationdb/build.sh`.

Both packages were running their build at `-j$(nproc)` — `-j32` on the buildbot res-servers. Each has a known memory blow-up at full parallelism:

- **`or-tools`** links its inline-built deps (protobuf, abseil, HiGHS, eigen) together at peak; `-j32` OOMs the host.
- **`mono`** bootstraps byacc + jay + corlib + the runtime; the corlib compile + .NET assembly phase OOMs at `-j32`.

Both observed OOMing on buildbot in the last day with `exit code 125: container received signal SIGKILL`. Standard practice across Debian/Fedora/Arch is to cap these specific packages similarly — it's not a workaround, it's how memory-greedy C++ builds are handled at scale.

## Implementation

Identical pattern to `packages/foundationdb/build.sh:41-44`:

```bash
JOBS=$(( $(nproc) / 4 ))
[ "$JOBS" -lt 1 ] && JOBS=1

ninja -j"$JOBS"     # or-tools
make -j"$JOBS"      # mono
```

`nproc / 4` is 8 jobs on the current 32-core res-servers, with a floor of 1 so single-core CI environments don't end up at `-j0`. Relative rather than absolute — scales if VM size changes later.

## Test plan

- [ ] Open the buildbot PR (this one) and verify the next build of mono/or-tools completes without SIGKILL on either arch
- [ ] Confirm the build doesn't slow down disproportionately — `-j8` should still be plenty for the actual compile work; the speedup from -j32 to -j8 on a memory-bound C++ build is often <2x because the bottleneck moves from CPU to memory bandwidth anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process resource usage by reducing parallel job execution to one-quarter of available CPU cores during compilation and linking stages. This change affects build performance and system resource consumption during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->