### PR TITLE
Update glow to 2.1.2

### DIFF
--- a/packages/glow/build.ncl
+++ b/packages/glow/build.ncl
@@ -5,14 +5,14 @@ let toolchain = import "../toolchain/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.1.1" in
+let version = "2.1.2" in
 {
   name = "glow",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/charmbracelet/glow/v%{version}.tar.gz",
-      sha256 = "f13e1d6be1ab4baf725a7fedc4cd240fc7e5c7276af2d92f199e590e1ef33967",
+      sha256 = "1b933139da1d08647bf5b3f112cab9548fdc2b40c056c7fa3d84d8706de5265a",
       extract = true,
       strip_prefix = "glow-%{version}",
     } | Source,
@@ -24,6 +24,9 @@ let version = "2.1.1" in
     glibc,
   ],
 
+  build_args = { include version },
+
+
   cmd = "./build.sh",
 
   outputs = {
@@ -32,6 +35,7 @@ let version = "2.1.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "charmbracelet",


### PR DESCRIPTION
## Update glow `2.1.1` → `2.1.2`

**Source:** `github:charmbracelet/glow`
**Release:** https://github.com/charmbracelet/glow/releases/tag/v2.1.2
**Changelog:** https://github.com/charmbracelet/glow/compare/v2.1.1...v2.1.2
**Released:** 19 days ago (2026-04-09)

> [!NOTE]
> **Auto-applied structural fixes:**
> - Added `build_args = { include version }` so `version` reaches `build.sh` as `MINIMAL_ARG_VERSION` (was missing — caught by CR on curl#129).

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.1.1` | `2.1.2` |
| **SHA256** | `f13e1d6be1ab4baf...` | `1b933139da1d0864...` |
| **Size** | 510 KB | 510 KB |
| **Source** | `gs://minimal-staging-archives/charmbracelet/glow/v2.1.1.tar.gz` | `gs://minimal-staging-archives/charmbracelet/glow/v2.1.2.tar.gz` |

- **License:** `MIT` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated glow package to version 2.1.2 with refreshed source checksum and added MIT license declaration to package attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->