### PR TITLE
Update htop to 3.5.1

### DIFF
--- a/packages/htop/build.ncl
+++ b/packages/htop/build.ncl
@@ -11,14 +11,14 @@ let m4 = import "../m4/build.ncl" in
 let ncurses = import "../ncurses/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.4.1" in
+let version = "3.5.1" in
 {
   name = "htop",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/htop-dev/htop/%{version}.tar.gz",
-      sha256 = "af9ec878f831b7c27d33e775c668ec79d569aa781861c995a0fbadc1bdb666cf",
+      sha256 = "dfc4a09845e9bc86f466a722e62b8f87d59028ff39689077ff2257a6a605061d",
       extract = true,
       strip_prefix = "htop-%{version}",
     } | Source,
@@ -50,6 +50,7 @@ let version = "3.4.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "htop-dev",


### PR DESCRIPTION
## Update htop `3.4.1` → `3.5.1`

**Source:** `github:htop-dev/htop`
**Release:** https://github.com/htop-dev/htop/releases/tag/3.5.1
**Changelog:** https://github.com/htop-dev/htop/compare/3.4.1...3.5.1
**Released:** 1 days ago (2026-04-28)

> [!WARNING]
> **Pkgscan: 1 new signal introduced by this update** (risk score 2.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | MEDIUM | `htop (upstream release)` | 0 | `metadata/recent-bump` | `upstream release <48h ago` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `3.4.1` | `3.5.1` |
| **SHA256** | `af9ec878f831b7c2...` | `dfc4a09845e9bc86...` |
| **Size** | 428 KB | 470 KB |
| **Source** | `gs://minimal-staging-archives/htop-dev/htop/3.4.1.tar.gz` | `gs://minimal-staging-archives/htop-dev/htop/3.5.1.tar.gz` |

- **License:** `GPL-2.0-only` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated htop package to version 3.5.1
  * Added license attribution metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->