### PR TITLE
Update fzf to 0.72.0

### DIFF
--- a/packages/fzf/build.ncl
+++ b/packages/fzf/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
 
-let version = "0.67.0" in
+let version = "0.72.0" in
 {
   name = "fzf",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/junegunn/fzf/v%{version}.tar.gz",
-      sha256 = "da72936dd23045346769dbf233a7a1fa6b4cfe4f0e856b279821598ce8f692af",
+      sha256 = "ca5ce083cec5187503ceb96d837c20d8efde85f03e62bba3a8890f8da526f2fc",
       extract = true,
       strip_prefix = "fzf-%{version}",
     } | Source,
@@ -40,6 +40,7 @@ let version = "0.67.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "junegunn",


### PR DESCRIPTION
## Update fzf `0.67.0` → `0.72.0`

**Source:** `github:junegunn/fzf`
**Release:** https://github.com/junegunn/fzf/releases/tag/v0.72.0
**Changelog:** https://github.com/junegunn/fzf/compare/v0.67.0...v0.72.0
**Released:** 3 days ago (2026-04-26)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.67.0` | `0.72.0` |
| **SHA256** | `da72936dd2304534...` | `ca5ce083cec51875...` |
| **Size** | 363 KB | 412 KB |
| **Source** | `gs://minimal-staging-archives/junegunn/fzf/v0.67.0.tar.gz` | `gs://minimal-staging-archives/junegunn/fzf/v0.72.0.tar.gz` |

- **License:** `MIT` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded fzf to version 0.72.0 with updated source verification
  * Added MIT license metadata to package information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->