### PR TITLE
Update opencv to 4.13.0

### DIFF
--- a/packages/opencv/build.ncl
+++ b/packages/opencv/build.ncl
@@ -12,7 +12,7 @@ let zlib = import "../zlib/build.ncl" in
 # See:
 #  - https://docs.opencv.org/4.x/db/d05/tutorial_config_reference.html
 #  - https://docs.opencv.org/4.x/d7/d9f/tutorial_linux_install.html
-let version = "4.12.0" in
+let version = "4.13.0" in
 {
   name = "opencv",
   build_deps = [
@@ -20,7 +20,7 @@ let version = "4.12.0" in
     {
       # https://github.com/opencv/opencv/archive/refs/tags/4.12.0.tar.gz
       url = "gs://minimal-staging-archives/opencv-%{version}.tar.gz",
-      sha256 = "44c106d5bb47efec04e531fd93008b3fcd1d27138985c5baf4eafac0e1ec9e9d",
+      sha256 = "1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d",
       extract = true,
     } | Source,
     base,


### PR DESCRIPTION
## Update opencv `4.12.0` → `4.13.0`

**Source:** `github:opencv/opencv`
**Release:** https://github.com/opencv/opencv/releases/tag/4.13.0
**Changelog:** https://github.com/opencv/opencv/compare/4.12.0...4.13.0
**Released:** 119 days ago (2025-12-31)

> [!WARNING]
> **Pkgscan: 1 new signal introduced by this update** (risk score 2.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | MEDIUM | `modules/python/package/setup.py` | 22 | `exfiltration/env-vars` | `os.environ` |

> [!WARNING]
> **4 known vulnerabilities still affect `4.13.0` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | OSV-2022-394 | MEDIUM | `9eb887d02d43ca3e95cd60ed259404b14d13064e` |
> | OSV-2023-444 | MEDIUM | _no fix_ |
> | OSV-2025-486 | MEDIUM | `dac243bd265e79af2315ce04fac2a0a5bdf47efe` |
> | OSV-2025-525 | MEDIUM | `468de9b36740b3355f0d5cd8be2ce28b340df120` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `4.12.0` | `4.13.0` |
| **SHA256** | `44c106d5bb47efec...` | `1d40ca017ea51c53...` |
| **Size** | 95.3 MB | 95.4 MB |
| **Source** | `gs://minimal-staging-archives/opencv-4.12.0.tar.gz` | `gs://minimal-staging-archives/opencv-4.13.0.tar.gz` |

- **License:** `Apache-2.0` ⚠️ GitHub says `Apache-2.0`, tarball says `(Apache-2.0 AND BSD-3-Clause)`

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenCV to version 4.13.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->