### PR TITLE
(re-)Add package Helix

### DIFF
--- a/packages/helix/build.ncl
+++ b/packages/helix/build.ncl
@@ -1,0 +1,55 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let git = import "../git/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "25.07.1" in
+{
+  name = "helix",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/helix-editor/helix/%{version}.tar.gz",
+      sha256 = "27c8bc3eba46bc7bab1e3629c6b28ff94882eeff17366b3ea69cd8ceffba7541",
+      extract = true,
+      strip_prefix = "helix-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    git,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  runtime_deps = [
+    glibc,
+    gcc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    hx = { glob = "usr/bin/hx" } | OutputBin,
+    runtime = { glob = "usr/lib/helix/runtime/**", allow_executable = true } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MPL-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "helix-editor",
+        repo = "helix",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/helix/build.sh
+++ b/packages/helix/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc"
+export HELIX_DEFAULT_RUNTIME=/usr/lib/helix/runtime
+export HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
+
+cargo build --release --locked
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 target/release/hx "$OUTPUT_DIR/usr/bin/hx"
+
+mkdir -p "$OUTPUT_DIR/usr/lib/helix"
+rm -rf runtime/grammars/sources
+cp -r runtime "$OUTPUT_DIR/usr/lib/helix/runtime"


### PR DESCRIPTION
Helix was removed in https://github.com/gominimal/pkgs/commit/5cbd640501093bb5f316d1dd7e79079562ef75af because the build was broken.

The `helix-term` crate has a `build.rs` file which tries to check out __245__ tree-sitter grammars from git repositories so that it can pre-build them. ~~This was failing due to the minimal Helix package not allowing internet access during builds.~~ This left a few ways forward:

1. Allow the helix package to have limited internet access during its build to fetch the grammars
2. Don't pre-build the grammars and let users fetch them at runtime
3. Create minimal packages for all or a subset of the grammars and provide them locally when building helix

I choose to go with option 2 for now because it's relatively quick without needing to escape the sandbox. 3 is most likely the "proper" way to do this in the long run, but likely not worth it for now.

I tested the package by adding it to the sandbox after build and running it then using it to clean up the outputs line about grammars that I had commented out while working on this.

Besides adding `export HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1` to `build.sh` (to disable trying to build the grammars) and removing the grammars from the outputs the package recipe is identical to what it was prior to being removed.

Update: Also added the SPDX license identifier and cleaned up a few things coderabbit suggested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added build configuration and scripts for the Helix editor package, enabling automated compilation and installation of the Helix executable and its runtime assets, and preparing versioned upstream sources for reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->