### PR TITLE
claude-code: add base as a runtime_dep instead of bash

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -1,7 +1,6 @@
 let { Attrs, BuildSpec, Local, OutputBin, OutputLib, Source, .. } = import "minimal.ncl" in
 let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
-let bash = import "../bash/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let findutils = import "../findutils/build.ncl" in
 let curl = import "../curl/build.ncl" in
@@ -39,10 +38,9 @@ in
           sha256 = arm64_sha256,
         } | Source,
     } target,
-    base,
   ],
   runtime_deps = [
-    bash,
+    base,
     coreutils,
     findutils,
     curl,


### PR DESCRIPTION
I noticed that the `/login` failed to start the local listener unless we had `base`. Not 100% sure why, but for now I'm wiring `base` as a runtime_dep. Given `base` includes `bash`, im ripping that out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Adjusted dependency configuration to streamline build and runtime package requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->