### PR TITLE
Update boost to 1.91.0-1

### DIFF
--- a/packages/boost/build.ncl
+++ b/packages/boost/build.ncl
@@ -9,14 +9,14 @@ let xz = import "../xz/build.ncl" in
 let zstd = import "../zstd/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.89.0" in
+let version = "1.91.0-1" in
 {
   name = "boost",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/boost-%{version}-b2-nodocs.tar.xz",
-      sha256 = "875cc413afa6b86922b6df3b2ad23dec4511c8a741753e57c1129e7fa753d700",
+      sha256 = "7334bb672b9c7aa135da88bcc3111a64a198be9a7d44eb5151d9248e7cfd43ef",
     } | Source,
     base,
     python,
@@ -52,6 +52,7 @@ let version = "1.89.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSL-1.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "boostorg",

--- a/packages/boost/build.sh
+++ b/packages/boost/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof boost-1.89.0-b2-nodocs.tar.xz
-cd boost-1.89.0
+tar -xof boost-1.91.0-1-b2-nodocs.tar.xz
+cd boost-1.91.0-1
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;


### PR DESCRIPTION
## Update boost `1.89.0` → `1.91.0-1`

**Source:** `github:boostorg/boost`
**Release:** https://github.com/boostorg/boost/releases/tag/boost-1.91.0-1
**Changelog:** https://github.com/boostorg/boost/compare/boost-1.89.0...boost-1.91.0-1
**Released:** 6 days ago (2026-04-23)

<details><summary>Pkgscan: <strong>8 below-threshold signals</strong> (all Info severity, risk score 0.8). Demoted in benign contexts (test fixtures, CI workflow setup); expand for details.</summary>

| Severity | File | Line | Capability (MBC) | Pattern |
|---|---|---:|---|---|
| INFO | `libs/interprocess/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `~/.profile` |
| INFO | `libs/interprocess/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `/.profile` |
| INFO | `libs/intrusive/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `~/.profile` |
| INFO | `libs/intrusive/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `/.profile` |
| INFO | `libs/container/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `~/.profile` |
| INFO | `libs/container/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `/.profile` |
| INFO | `libs/move/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `~/.profile` |
| INFO | `libs/move/.github/workflows/ci.yml` | 932 | `persistence/filesystem` | `/.profile` |

</details>

> [!WARNING]
> **2 known vulnerabilities still affect `1.91.0-1` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | OSV-2024-112 | MEDIUM | _no fix_ |
> | OSV-2024-914 | MEDIUM | _no fix_ |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.89.0` | `1.91.0-1` |
| **SHA256** | `875cc413afa6b869...` | `7334bb672b9c7aa1...` |
| **Size** | 52.7 MB | 52.3 MB |
| **Source** | `gs://minimal-staging-archives/boost-1.89.0-b2-nodocs.tar.xz` | `gs://minimal-staging-archives/boost-1.91.0-1-b2-nodocs.tar.xz` |

- **License:** `BSL-1.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
