### PR TITLE
Simplify pnpm harness install command

### DIFF
--- a/harnesses/pnpm/harness.ncl
+++ b/harnesses/pnpm/harness.ncl
@@ -9,10 +9,7 @@ harness {
     "/bin/bash",
     "-c",
     m%"
-    # Run pnpm install if no packages are installed (first start)
-    if [ -z "$(pnpm list 2>/dev/null)" ]; then
-      [ -f pnpm-lock.yaml ] && echo '/bin/pnpm install --frozen-lockfile' || echo '/bin/pnpm install'
-    fi
+    [ -f pnpm-lock.yaml ] && echo '/bin/pnpm install --frozen-lockfile' || echo '/bin/pnpm install'
     echo '/bin/pnpm build'
   "%
   ],
@@ -21,7 +18,6 @@ harness {
     {
       file_regexes = {
         "pnpm-lock.yaml" = "*",
-        "pnpm-workspace.yaml" = "*",
       },
     }
   ],


### PR DESCRIPTION
## Summary
- Always emit `pnpm install` (idempotent) instead of gating on an empty `pnpm list` check
- Drop redundant `pnpm-workspace.yaml` matcher since workspaces already match via `pnpm-lock.yaml`

## Test plan
- [ ] `min check --harnesses pnpm` passes
- [ ] Verify a pnpm project still detects this harness via `pnpm-lock.yaml`
- [ ] Verify a workspace project (with both lock + workspace files) still detects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated pnpm build harness to ensure consistent dependency installation based on lock file presence.
  * Refined project detection criteria for pnpm projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->