### PR TITLE
Update curl to 8.20.0

### DIFF
--- a/packages/curl/build.ncl
+++ b/packages/curl/build.ncl
@@ -8,14 +8,14 @@ let perl = import "../perl/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "8.19.0" in
+let version = "8.20.0" in
 {
   name = "curl",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/curl-%{version}.tar.xz",
-      sha256 = "4eb41489790d19e190d7ac7e18e82857cdd68af8f4e66b292ced562d333f11df",
+      sha256 = "63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896",
       extract = true,
       strip_prefix = "curl-%{version}",
     } | Source,


### PR DESCRIPTION
## Update curl `8.19.0` → `8.20.0`

**Source:** `github:curl/curl`
**Release:** https://github.com/curl/curl/releases/tag/curl-8_20_0
**Changelog:** https://github.com/curl/curl/compare/8.19.0...curl-8_20_0
**Released:** 2 days ago (2026-04-29)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Vulnerabilities fixed (8)

This update clears 8 vulnerabilities affecting `8.19.0`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| CURL-CVE-2026-4873 | UNKNOWN | _via range:_ `>= 7.20.0, < 8.20.0` |
| CURL-CVE-2026-5545 | UNKNOWN | _via range:_ `>= 7.10.6, < 8.20.0` |
| CURL-CVE-2026-5773 | UNKNOWN | _via range:_ `>= 7.40.0, < 8.20.0` |
| CURL-CVE-2026-6253 | UNKNOWN | _via range:_ `>= 7.14.1, < 8.20.0` |
| CURL-CVE-2026-6276 | UNKNOWN | _via range:_ `>= 7.71.0, < 8.20.0` |
| CURL-CVE-2026-6429 | UNKNOWN | _via range:_ `>= 7.14.0, < 8.20.0` |
| CURL-CVE-2026-7009 | UNKNOWN | _via range:_ `>= 8.17.0, < 8.20.0` |
| CURL-CVE-2026-7168 | UNKNOWN | _via range:_ `>= 7.12.0, < 8.20.0` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `8.19.0` | `8.20.0` |
| **SHA256** | `4eb41489790d19e1...` | `63fe2dc148ba0cea...` |
| **Size** | 2.8 MB | 2.8 MB |
| **Source** | `gs://minimal-staging-archives/curl-8.19.0.tar.xz` | `gs://minimal-staging-archives/curl-8.20.0.tar.xz` |

- **License:** `curl` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated curl package from version 8.19.0 to 8.20.0 with updated checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->