### PR TITLE
Update iana-etc to 20260424

### DIFF
--- a/packages/iana-etc/build.ncl
+++ b/packages/iana-etc/build.ncl
@@ -1,14 +1,14 @@
 let { Attrs, BuildSpec, Local, OutputData, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 
-let version = "20250618" in
+let version = "20260424" in
 {
   name = "iana-etc",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/iana-etc-%{version}.tar.gz",
-      sha256 = "432d475ea36aa3f18fe709878e6f1e4e894efc5e92a8ee0bee0756b792ac2160"
+      sha256 = "93b3ed0e38c9d63fa65309d7fd811bec2aa5cbdeda983812e50b16bbc5eb01bb"
     } | Source,
     base,
   ],

--- a/packages/iana-etc/build.sh
+++ b/packages/iana-etc/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof iana-etc-20250618.tar.gz
-cd iana-etc-20250618
+tar -xof iana-etc-20260424.tar.gz
+cd iana-etc-20260424
 
 mkdir -p "$OUTPUT_DIR/etc"
 cp services protocols "$OUTPUT_DIR/etc/"


### PR DESCRIPTION
## Update iana-etc `20250618` → `20260424`

**Source:** `github:Mic92/iana-etc`
**Release:** https://github.com/Mic92/iana-etc/releases/tag/20260424
**Changelog:** https://github.com/Mic92/iana-etc/compare/20250618...20260424
**Released:** 5 days ago (2026-04-26)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `20250618` | `20260424` |
| **SHA256** | `432d475ea36aa3f1...` | `93b3ed0e38c9d63f...` |
| **Size** | 606 KB | 609 KB |
| **Source** | `gs://minimal-staging-archives/iana-etc-20250618.tar.gz` | `gs://minimal-staging-archives/iana-etc-20260424.tar.gz` |

- **License:** `MIT` _(source: GitHub)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IANA-etc package to the latest version with current Internet standards data for network services and protocols, ensuring compatibility with the most recent Internet Assigned Numbers Authority definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->