### PR TITLE
Update hwdata to 0.406

### DIFF
--- a/packages/hwdata/build.ncl
+++ b/packages/hwdata/build.ncl
@@ -3,14 +3,14 @@ let base = import "../base/build.ncl" in
 let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "0.404" in
+let version = "0.406" in
 {
   name = "hwdata",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/vcrhonek/hwdata/v%{version}.tar.gz",
-      sha256 = "5c14fc99bf193faad1ccc267ccfff14ee4e4550a582b17a76aec72178539f837",
+      sha256 = "1ccfd1ca723595b1fe8794f4157ec5635be1ebedb5d13769b4be75d0b75bc199",
       extract = true,
       strip_prefix = "hwdata-%{version}",
     } | Source,
@@ -28,6 +28,7 @@ let version = "0.404" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       repology_project = "hwdata",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update hwdata `0.404` → `0.406`

**Source:** `github:vcrhonek/hwdata`
**Release:** https://github.com/vcrhonek/hwdata/releases/tag/v0.406
**Changelog:** https://github.com/vcrhonek/hwdata/compare/v0.404...v0.406
**Released:** 29 days ago (2026-04-02)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.404` | `0.406` |
| **SHA256** | `5c14fc99bf193faa...` | `1ccfd1ca723595b1...` |
| **Size** | 2.6 MB | 2.6 MB |
| **Source** | `gs://minimal-staging-archives/vcrhonek/hwdata/v0.404.tar.gz` | `gs://minimal-staging-archives/vcrhonek/hwdata/v0.406.tar.gz` |

- **License:** `GPL-2.0-only` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated hwdata dependency to version 0.406
* Added GPL-2.0-only license specification to build metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->