### PR TITLE
Update btop to 1.4.7

### DIFF
--- a/packages/btop/build.ncl
+++ b/packages/btop/build.ncl
@@ -4,14 +4,14 @@ let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let ncurses = import "../ncurses/build.ncl" in
 
-let version = "1.4.6" in
+let version = "1.4.7" in
 {
   name = "btop",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/aristocratos/btop/v%{version}.tar.gz",
-      sha256 = "4beb90172c6acaac08c1b4a5112fb616772e214a7ef992bcbd461453295a58be",
+      sha256 = "933de2e4d1b2211a638be463eb6e8616891bfba73aef5d38060bd8319baeefc6",
       extract = true,
     } | Source,
     base,
@@ -27,6 +27,7 @@ let version = "1.4.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "aristocratos",

--- a/packages/btop/build.sh
+++ b/packages/btop/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cd btop-1.4.6
+cd btop-1.4.7
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;


### PR DESCRIPTION
## Update btop `1.4.6` → `1.4.7`

**Source:** `github:aristocratos/btop`
**Release:** https://github.com/aristocratos/btop/releases/tag/v1.4.7
**Changelog:** https://github.com/aristocratos/btop/compare/v1.4.6...v1.4.7
**Released:** 12 hours ago (2026-05-01)

> [!CAUTION]
> **Pkgscan: 1 new signal introduced by this update** (risk score 5.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | **HIGH** | `btop (upstream release)` | 0 | `metadata/recent-bump` | `upstream release <24h ago` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.4.6` | `1.4.7` |
| **SHA256** | `4beb90172c6acaac...` | `933de2e4d1b2211a...` |
| **Size** | 1.3 MB | 1.3 MB |
| **Source** | `gs://minimal-staging-archives/aristocratos/btop/v1.4.6.tar.gz` | `gs://minimal-staging-archives/aristocratos/btop/v1.4.7.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
