### PR TITLE
Update bash-completions to 2.17.0

### DIFF
--- a/packages/bash-completions/build.ncl
+++ b/packages/bash-completions/build.ncl
@@ -3,14 +3,14 @@ let base = import "../base/build.ncl" in
 let tar = import "../tar/build.ncl" in
 let make = import "../make/build.ncl" in
 
-let version = "2.16.0" in
+let version = "2.17.0" in
 {
   name = "bash-completions",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/scop/bash-completion/releases/download/%{version}/bash-completion-%{version}.tar.xz",
-      sha256 = "3369bd5e418a75fb990863925aed5b420398acebb320ec4c0306b3eae23f107a",
+      sha256 = "dd9d825e496435fb3beba3ae7bea9f77e821e894667d07431d1d4c8c570b9e58",
     } | Source,
     base,
     make,
@@ -30,6 +30,7 @@ let version = "2.16.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "scop",


### PR DESCRIPTION
## Update bash-completions `2.16.0` → `2.17.0`

**Source:** `github:scop/bash-completion`
**Release:** https://github.com/scop/bash-completion/releases/tag/2.17.0
**Changelog:** https://github.com/scop/bash-completion/compare/2.16.0...2.17.0
**Released:** 182 days ago (2025-10-31)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.16.0` | `2.17.0` |
| **SHA256** | `3369bd5e418a75fb...` | `dd9d825e496435fb...` |
| **Size** |  | 483 KB |
| **Source** | `https://github.com/scop/bash-completion/releases/download/2.16.0/bash-completion-2.16.0.tar.xz` | `https://github.com/scop/bash-completion/releases/download/2.17.0/bash-completion-2.17.0.tar.xz` |

- **License:** `GPL-2.0-only` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded bash-completions package to version 2.17.0
  * Added explicit license information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->