### PR TITLE
Update libcap-ng to 0.9.3

### DIFF
--- a/packages/libcap-ng/build.ncl
+++ b/packages/libcap-ng/build.ncl
@@ -11,14 +11,14 @@ let pkgconf = import "../pkgconf/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "0.9.2" in
+let version = "0.9.3" in
 {
   name = "libcap-ng",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "df6910d996818848de92db9c05f96492e008c4e35f96a8673f9b7cc44f5cf813",
+      sha256 = "fe11ebbb55904763b3532f19069f13ec319042634620180a03bd4653d301563e",
       extract = true,
       strip_prefix = "libcap-ng-%{version}",
     } | Source,


### PR DESCRIPTION
## Update libcap-ng `0.9.2` → `0.9.3`

**Source:** `github:stevegrubb/libcap-ng`
**Release:** https://github.com/stevegrubb/libcap-ng/releases/tag/v0.9.3
**Changelog:** https://github.com/stevegrubb/libcap-ng/compare/v0.9.2...v0.9.3
**Released:** 22 days ago (2026-04-09)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.9.2` | `0.9.3` |
| **SHA256** | `df6910d996818848...` | `fe11ebbb55904763...` |
| **Size** |  | 126 KB |
| **Source** | `https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v0.9.2.tar.gz` | `https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v0.9.3.tar.gz` |

- **License:** `GPL-2.0` ⚠️ GitHub says `GPL-2.0`, tarball says `(GPL-2.0-only AND LGPL-2.1-only)`

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated libcap-ng dependency to version 0.9.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->