### PR TITLE
Update rust to 1.95.0

### DIFF
--- a/packages/rust/build.ncl
+++ b/packages/rust/build.ncl
@@ -11,7 +11,7 @@ let libffi = import "../libffi/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "1.93.1" in
+let version = "1.95.0" in
 {
   name = "rust",
   build_deps = [
@@ -19,7 +19,7 @@ let version = "1.93.1" in
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/rustc-%{version}-src.tar.xz",
-      sha256 = "848c9171212c998c069e6979a205a1a44fa3235a463696d62e24701c83596ce0",
+      sha256 = "62b67230754da642a264ca0cb9fc08820c54e2ed7b3baba0289876d4cdb48c08",
       extract = true,
       strip_prefix = "rustc-%{version}-src",
     } | Source,
@@ -50,11 +50,7 @@ let version = "1.93.1" in
     bins = { glob = "usr/bin/*", allow_missing_interpreter = true } | OutputBin,
 
     librustc_driver = { glob = "usr/lib/librustc_driver*.so" } | OutputLib,
-    rustlib_src = { glob = "usr/lib/rustlib/src/**" } | OutputData,
-    rustlib_etc = { glob = "usr/lib/rustlib/etc/**" } | OutputData,
-    rustlib_bins = { glob = "usr/lib/rustlib/*/bin/**" } | OutputBin,
-    rustlib_libs = { glob = "usr/lib/rustlib/*/lib/*.{so*,rlib}" } | OutputLib,
-
+    rustlib = { glob = "usr/lib/rustlib/**", allow_executable = true } | OutputData,
     rust-analyzer-proc-macro-srv = { glob = "usr/libexec/rust-analyzer-proc-macro-srv" } | OutputBin,
 
     mans = { glob = "usr/share/man/**" } | OutputData,
@@ -63,6 +59,7 @@ let version = "1.93.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT OR Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "rust-lang",


### PR DESCRIPTION
## Update rust `1.93.1` → `1.95.0`

**Source:** `github:rust-lang/rust`
**Release:** https://github.com/rust-lang/rust/releases/tag/1.95.0
**Changelog:** https://github.com/rust-lang/rust/compare/1.93.1...1.95.0
**Released:** 17 days ago (2026-04-16)

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.93.1` | `1.95.0` |
| **SHA256** | `848c9171212c998c...` | `62b67230754da642...` |
| **Size** | 270.9 MB | 239.0 MB |
| **Source** | `gs://minimal-staging-archives/rustc-1.93.1-src.tar.xz` | `gs://minimal-staging-archives/rustc-1.95.0-src.tar.xz` |

- **License:** `MIT OR Apache-2.0` (declared explicitly in `attrs.license_spdx`). pkgmgr's tarball detector reported `(MIT AND Pixar)` — askalono mis-matched rust's `LICENSE-APACHE` to the SPDX `Pixar` license (Pixar = Apache-2.0 with attribution modifications). Detector fix in flight: gominimal/pkgmgr-rs#82.

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust version to 1.95.0 and corresponding source archive checksum.
  * Added explicit SPDX license metadata (MIT OR Apache-2.0).
  * Removed legacy environment configuration with added clarifying comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
