### PR TITLE
Added lsd

### DIFF
--- a/packages/lsd/build.ncl
+++ b/packages/lsd/build.ncl
@@ -1,0 +1,53 @@
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.2.0" in
+{
+  name = "lsd",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/lsd-rs/lsd/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "dae8d43087686a4a1de0584922608e9cbab00727d0f72e4aa487860a9cbfeefa",
+      extract = true,
+      strip_prefix = "lsd-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    lsd = { glob = "usr/bin/lsd" } | OutputBin,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "lsd-rs",
+        repo = "lsd",
+      },
+      build_cost_multiple = 2,
+    } | Attrs,
+} | BuildSpec

--- a/packages/lsd/build.sh
+++ b/packages/lsd/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+cargo build --release
+
+install -D -m 0755 target/release/lsd "$OUTPUT_DIR/usr/bin/lsd"


### PR DESCRIPTION
Added a package for `lsd`. It's an `ls` replacement that is very similar to `eza` but has a license that some organizations will find more favourable.

<img width="623" height="293" alt="Screenshot 2026-05-05 at 4 38 59 PM" src="https://github.com/user-attachments/assets/aa9f1426-35c0-44ac-bb38-9cbe134ec239" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added build configuration for the lsd package to enable automated compilation and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->