### PR TITLE
Update libtasn1 to 4.21.0

### DIFF
--- a/packages/libtasn1/build.ncl
+++ b/packages/libtasn1/build.ncl
@@ -4,14 +4,14 @@ let glibc = import "../glibc/build.ncl" in
 let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "4.19.0" in
+let version = "4.21.0" in
 {
   name = "libtasn1",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://ftpmirror.gnu.org/libtasn1/libtasn1-%{version}.tar.gz",
-      sha256 = "1613f0ac1cf484d6ec0ce3b8c06d56263cc7242f1c23b30d82d23de345a63f7a",
+      sha256 = "1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87",
       extract = true,
       strip_prefix = "libtasn1-%{version}",
     } | Source,
@@ -35,6 +35,7 @@ let version = "4.19.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-3.0-only AND LGPL-2.1-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "libtasn1",

--- a/packages/libtasn1/build.ncl
+++ b/packages/libtasn1/build.ncl
@@ -10,7 +10,7 @@ let version = "4.21.0" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "https://ftpmirror.gnu.org/libtasn1/libtasn1-%{version}.tar.gz",
+      url = "gs://minimal-staging-archives/libtasn1-%{version}.tar.gz",
       sha256 = "1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87",
       extract = true,
       strip_prefix = "libtasn1-%{version}",


### PR DESCRIPTION
## Update libtasn1 `4.19.0` → `4.21.0` + GCS migration

Two changes bundled:

1. **Version bump.** Pkgmgr-driven update to the latest GNU release (4.21.0, released 2026-01-08). Tarball downloaded, SHA256 verified.
2. **Source URL migration: `ftpmirror.gnu.org` → `gs://minimal-staging-archives/`.** The FTP mirror has been failing intermittently in other builds. Pinning to the GCS bucket matches the shape used by other GnuProject packages (`acl`, `attr`, etc.) and gives builds a deterministic source.

The 4.21.0 tarball was uploaded to `gs://minimal-staging-archives/libtasn1-4.21.0.tar.gz` (1.7 MiB) with the verified sha256.

**Source:** `gnu:libtasn1`
**Released:** 2026-01-08

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `4.19.0` | `4.21.0` |
| **SHA256** | `1613f0ac1cf484d6…` | `1d8a444a223cc546…` |
| **Size** | | 1.7 MiB |
| **Source URL** | `https://ftpmirror.gnu.org/libtasn1/libtasn1-4.19.0.tar.gz` | `gs://minimal-staging-archives/libtasn1-4.21.0.tar.gz` |

- **License:** `(GPL-3.0-only AND LGPL-2.1-only)` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of a follow-up so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Original PR created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs); GCS URL switch added manually.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated libtasn1 to version 4.21.0 and refreshed the package tarball checksum.
  * Switched the package source reference and adjusted checksum accordingly.
  * Added license metadata (SPDX) to the build specification to clarify licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->