### PR TITLE
Update redis to 8.6.3

### DIFF
--- a/packages/redis/build.ncl
+++ b/packages/redis/build.ncl
@@ -10,14 +10,14 @@ let linux_headers = import "../linux_headers/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
 
-let version = "8.6.0" in
+let version = "8.6.3" in
 {
   name = "redis",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/redis/redis/%{version}.tar.gz",
-      sha256 = "74261ece988fd2e1526e5aea9f8b9853217d71e2ef2dafaa624ed9579b5f4317",
+      sha256 = "58d0d1eb49a1ea6c2179659707fec171b1e2e2b8d5157ed2ec59d1d66ad5a654",
       extract = true,
       strip_prefix = "redis-%{version}",
     } | Source,


### PR DESCRIPTION
## Update redis `8.6.0` → `8.6.3`

**Source:** `github:redis/redis`
**Release:** https://github.com/redis/redis/releases/tag/8.6.3
**Changelog:** https://github.com/redis/redis/compare/8.6.0...8.6.3
**Released:** 2 days ago (2026-05-05)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Vulnerabilities fixed (3)

This update clears 3 vulnerabilities affecting `8.6.0`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| CVE-2026-23479 (alias `GHSA-93m2-935m-8rj3`) | **HIGH** | `8.6.3` |
| CVE-2026-23631 (alias `GHSA-8ghh-qpmp-7826`) | **HIGH** | `8.6.3` |
| CVE-2026-25243 (alias `GHSA-c8h9-259x-jff4`) | **HIGH** | `8.6.3` |

> [!NOTE]
> **PR-body amended after creation.** The original body listed the GHSA aliases of the three CVEs as "still affecting" — same advisories as the cleared CVEs, just keyed under their GHSA-side IDs whose own ranges encode `[..., < TBD)` (the unfixed-yet sentinel). The renderer didn't de-alias before partitioning.
>
> NVD CPE data confirms all three CVEs (and therefore their GHSA aliases) are not affected at 8.6.3 (`version_end_excluding=8.6.3`). The scan-time NVD verification path agrees — `pkgmgr vulns --package redis` against build.ncl@8.6.3 reports zero findings.
>
> Renderer fix in flight: gominimal/pkgmgr-rs#89.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `8.6.0` | `8.6.3` |
| **SHA256** | `74261ece988fd2e1...` | `58d0d1eb49a1ea6c...` |
| **Size** | 4.3 MB | 4.3 MB |
| **Source** | `gs://minimal-staging-archives/redis/redis/8.6.0.tar.gz` | `gs://minimal-staging-archives/redis/redis/8.6.3.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis dependency to version 8.6.3, incorporating the latest stability improvements and fixes from the Redis project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
