### PR TITLE
Update protobuf to 34.1

### DIFF
--- a/packages/protobuf/build.ncl
+++ b/packages/protobuf/build.ncl
@@ -10,14 +10,14 @@ let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "32.0" in
+let version = "34.1" in
 {
   name = "protobuf",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/protocolbuffers/protobuf/releases/download/v%{version}/protobuf-%{version}.tar.gz",
-      sha256 = "9dfdf08129f025a6c5802613b8ee1395044fecb71d38210ca59ecad283ef68bb",
+      sha256 = "e4e6ff10760cf747a2decd1867741f561b216bd60cc4038c87564713a6da1848",
       extract = true,
       strip_prefix = "protobuf-%{version}",
     } | Source,
@@ -50,6 +50,7 @@ let version = "32.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "protocolbuffers",


### PR DESCRIPTION
## Update protobuf `32.0` → `34.1`

**Source:** `github:protocolbuffers/protobuf`
**Release:** https://github.com/protocolbuffers/protobuf/releases/tag/v34.1
**Changelog:** https://github.com/protocolbuffers/protobuf/compare/v32.0...v34.1
**Released:** 48 days ago (2026-03-19)

> [!WARNING]
> **Pkgscan: 1 new signal introduced by this update** (risk score 2.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | MEDIUM | `rust/release_crates/protobuf_tests/build.rs` | 122 | `execution/eval` | `compile(` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `32.0` | `34.1` |
| **SHA256** | `9dfdf08129f025a6...` | `e4e6ff10760cf747...` |
| **Size** |  | 7.0 MB |
| **Source** | `https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protobuf-32.0.tar.gz` | `https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.tar.gz` |

- **License:** `BSD-3-Clause` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded protobuf to version 34.1, including updated checksums for package verification and integrity assurance.
  * Added license metadata (BSD-3-Clause) to improve license tracking and compliance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->