### PR TITLE
Update kubectl to 1.36.0

### DIFF
--- a/packages/kubectl/build.ncl
+++ b/packages/kubectl/build.ncl
@@ -2,7 +2,7 @@ let { Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.n
 let bash = import "../bash/build.ncl" in
 let go = import "../go/build.ncl" in
 
-let version = "1.35.4" in
+let version = "1.36.0" in
 
 {
   name = "kubectl",
@@ -11,7 +11,7 @@ let version = "1.35.4" in
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "46a0dead69674fb2bdf33f5ef1deadab123a96becfafef6043f399ae53761f4f",
+      sha256 = "b98652d8ebf5d60d0715cd952e5d489aa10e14ad75d7b6e2425b8de8c65aa4c5",
       extract = true,
       strip_prefix = "kubernetes-%{version}",
     } | Source,
@@ -38,6 +38,7 @@ let version = "1.35.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "kubernetes",


### PR DESCRIPTION
## Update kubectl `1.35.4` → `1.36.0`

**Source:** `github:kubernetes/kubernetes`
**Release:** https://github.com/kubernetes/kubernetes/releases/tag/v1.36.0
**Changelog:** https://github.com/kubernetes/kubernetes/compare/v1.35.4...v1.36.0
**Released:** 15 days ago (2026-04-22)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.35.4` | `1.36.0` |
| **SHA256** | `46a0dead69674fb2...` | `b98652d8ebf5d60d...` |
| **Size** |  | 43.8 MB |
| **Source** | `https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.35.4.tar.gz` | `https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.36.0.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kubectl to version 1.36.0, including updated package integrity checksums
  * Added Apache 2.0 license attribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->