### PR TITLE
Update claude-code to 2.1.119

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -11,9 +11,9 @@ let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
-  version = "2.1.112",
-  amd64_sha256 = "57be9406d3e5cae259552790bf7288dd6496675430ec93dbed76a33a57580d3d",
-  arm64_sha256 = "1015ef5747767cdac58376de4ec990253dcac49314d54e19750d5512fa7422f6",
+  version = "2.1.119",
+  amd64_sha256 = "cca43053f062949495596b11b6fd1b59cf79102adb13bacbe66997e6fae41e4a",
+  arm64_sha256 = "382aa73ea4b07fd8d698e3159b5ef9e1b8739fae7505ba8ddd28b8a6a62819ce",
 }
 in
 


### PR DESCRIPTION
## Update claude-code `2.1.112` → `2.1.119`

**Stable manifest:** https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/stable
**Per-version manifest:** https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.119/manifest.json
**Build date:** 2026-04-23 (per manifest)
**Upstream commit:** `6f68554839756189e277b8285a18fe47acd9a5a1`

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.1.112` | `2.1.119` |
| **amd64 SHA** | `57be9406...` | `cca43053...` |
| **arm64 SHA** | `1015ef57...` | `382aa73e...` |

SHAs taken from the per-version manifest, **independently verified** by downloading both linux binaries and re-hashing locally:

```
cca43053f062949495596b11b6fd1b59cf79102adb13bacbe66997e6fae41e4a  linux-x64/claude
382aa73ea4b07fd8d698e3159b5ef9e1b8739fae7505ba8ddd28b8a6a62819ce  linux-arm64/claude
```

Both match the manifest.

### Why manual

`claude-code`'s upstream-check pattern isn't covered by pkgmgr's chain (custom-regex → GitHub releases → repology → GNU FTP). The package's stable version sits at a known GCS bucket as a plain text file, and per-version checksums are in a manifest JSON keyed by platform. This is the "custom-URL whose body IS the version" shape — natural follow-up for pkgmgr to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated claude-code package to version 2.1.119 with updated platform-specific binaries for amd64 and arm64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->