### PR TITLE
Add broot package

### DIFF
--- a/packages/broot/build.ncl
+++ b/packages/broot/build.ncl
@@ -12,7 +12,7 @@ let version = "1.56.2" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "https://github.com/Canop/broot/archive/refs/tags/v%{version}.tar.gz",
+      url = "gs://minimal-staging-archives/Canop/broot/v%{version}.tar.gz",
       sha256 = "3e7be4252c76565f6d71b34bd07d26e1444b9ac2e1c8271c724f6e866fe75565",
       extract = true,
       strip_prefix = "broot-%{version}",

--- a/packages/broot/build.ncl
+++ b/packages/broot/build.ncl
@@ -1,0 +1,54 @@
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.56.2" in
+{
+  name = "broot",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/Canop/broot/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "3e7be4252c76565f6d71b34bd07d26e1444b9ac2e1c8271c724f6e866fe75565",
+      extract = true,
+      strip_prefix = "broot-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    broot = { glob = "usr/bin/broot" } | OutputBin,
+    completions = { glob = "usr/share/**/broot*" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "Canop",
+        repo = "broot",
+      },
+      build_cost_multiple = 3,
+    } | Attrs,
+} | BuildSpec

--- a/packages/broot/build.sh
+++ b/packages/broot/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+cargo build --release
+
+install -D -m 0755 target/release/broot "$OUTPUT_DIR/usr/bin/broot"
+
+# build.rs emits shell completions into OUT_DIR; copy them out
+completion_dir=$(find target/release/build -path '*/out/broot.bash' -printf '%h\n' | head -n1)
+if [[ -n "$completion_dir" ]]; then
+  install -D -m 0644 "$completion_dir/broot.bash" "$OUTPUT_DIR/usr/share/bash-completion/completions/broot"
+  install -D -m 0644 "$completion_dir/broot.fish" "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/broot.fish"
+  install -D -m 0644 "$completion_dir/_broot"     "$OUTPUT_DIR/usr/share/zsh/site-functions/_broot"
+fi


### PR DESCRIPTION
broot v1.56.2 — interactive tree-style file browser/launcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added build configuration for the broot package, pinned to version 1.56.2, including package metadata (version, license, source).
  * Installs the broot executable into the system path as part of the package output.
  * Integrated shell completion support for Bash, Fish, and Zsh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->