### PR TITLE
Update next to 16.2.6

### DIFF
--- a/packages/next/build.ncl
+++ b/packages/next/build.ncl
@@ -9,14 +9,14 @@ let pnpm = import "../pnpm/build.ncl" in
 let python = import "../python/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "16.2.4" in
+let version = "16.2.6" in
 {
   name = "next",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/vercel/next.js/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "08a2a3cf0656d2c2d89509b28ad32bf5ef3d6899595e91e2d0aecd350df680e4",
+      sha256 = "119c7afb3f19bf3de81283d4fab6b318f3b9ba3113acda83aee0de181be68a85",
       extract = true,
       strip_prefix = "next.js-%{version}",
     } | Source,
@@ -74,6 +74,7 @@ let version = "16.2.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "vercel",


### PR DESCRIPTION
## Update next `16.2.4` → `16.2.6`

**Source:** `github:vercel/next.js`
**Release:** https://github.com/vercel/next.js/releases/tag/v16.2.6
**Changelog:** https://github.com/vercel/next.js/compare/v16.2.4...v16.2.6
**Released:** 2026-05-07 (urgent security release)

> [!IMPORTANT]
> **PR opened as DRAFT due to pkgscan recency gate** — the upstream
> release is <12h old (CRITICAL pkgscan signal `metadata/recent-bump`).
> No code-level critical signals were detected; the gate fired purely
> on release age. This is a security release from Vercel; un-draft
> after manual audit of the diff.
>
> Diff signals beyond recency: 1 MEDIUM signal (`compile(` in build
> tooling — endemic to the codebase, not new in 16.2.6).

### Patches in this release (13 advisories)

Per [v16.2.6 release notes](https://github.com/vercel/next.js/releases/tag/v16.2.6):

**High:**
- GHSA-8h8q-6873-q5fj — Denial of Service with Server Components
- GHSA-267c-6grr-h53f — Middleware/Proxy bypass via segment-prefetch routes
- GHSA-26hh-7cqf-hhc6 — Middleware/Proxy bypass (incomplete-fix follow-up)
- GHSA-mg66-mrh9-m8jx — DoS via connection exhaustion in Cache Components
- GHSA-492v-c6pp-mqqv — Middleware/Proxy bypass via dynamic route parameter injection
- GHSA-c4j6-fc7j-m34r — SSRF in WebSocket upgrades
- GHSA-36qx-fr4f-26g5 — Middleware/Proxy bypass in Pages Router (i18n)

**Moderate:**
- GHSA-ffhc-5mcf-pf4q — XSS in App Router (CSP nonces)
- GHSA-gx5p-jg67-6x7h — XSS in beforeInteractive scripts
- GHSA-h64f-5h5j-jqjh — DoS in Image Optimization API
- GHSA-wfc6-r584-vfw7 — Cache poisoning in RSC responses

**Low:**
- GHSA-vfv6-92ff-j949 — Cache poisoning via collisions in RSC cache-busting
- GHSA-3g8h-86w9-wvmq — Middleware/Proxy redirects can be cache-poisoned

### Changes

| | Old | New |
|---|---|---|
| **Version** | `16.2.4` | `16.2.6` |
| **Source** | `https://github.com/vercel/next.js/archive/refs/tags/v16.2.4.tar.gz` | `https://github.com/vercel/next.js/archive/refs/tags/v16.2.6.tar.gz` |

### Vulnerabilities still affecting `16.2.6`

After this bump, 3 advisories remain (no known fix in any released next.js version per OSV data — pending upstream patch in a future release):

| ID | Severity |
|---|---|
| GHSA-67rr-84xm-4c7r | HIGH |
| GHSA-4342-x723-ch2f | MEDIUM |
| GHSA-xv57-4mr9-wg8v | MEDIUM |

These three predate today's release; they're independent of the patch being applied here.

### Detection-flow notes

The original PR body (auto-generated by pkgmgr) wrongly listed all 28 historical advisories as "still affecting" due to a partition-flow bug where dual-ecosystem packages (next has both NativeC and Npm ecosystems) had their per-package query metadata wiped during deduplication. Diagnosed and fixed in supply-chain#96; this body is the corrected version.

---
*Originally created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs); body manually corrected pending sc#96 merge.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js dependency to version 16.2.6
  * Added MIT license metadata to build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->