### PR TITLE
Update trivy to 0.70.0

### DIFF
--- a/packages/trivy/build.ncl
+++ b/packages/trivy/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "0.69.1" in
+let version = "0.70.0" in
 {
   name = "trivy",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/aquasecurity/trivy/v%{version}.tar.gz",
-      sha256 = "997f7b744e93bd2faa9f0c2f86345ab142d50d42a6ed2b3a35dc8b65676355ee",
+      sha256 = "ff9ac06468aab89802388f16d1d179f4680db714afbf6a8132a417d288aa008e",
       extract = true,
       strip_prefix = "trivy-%{version}",
     } | Source,
@@ -42,6 +42,7 @@ let version = "0.69.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "trivy",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update trivy `0.69.1` → `0.70.0`

**Source:** `github:aquasecurity/trivy`
**Release:** https://github.com/aquasecurity/trivy/releases/tag/v0.70.0
**Changelog:** https://github.com/aquasecurity/trivy/compare/v0.69.1...v0.70.0
**Released:** 2026-04-17

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.69.1` | `0.70.0` |
| **SHA256** | `997f7b744e93bd2f...` | `ff9ac06468aab898...` |
| **Size** | 56.8 MB | 56.9 MB |
| **Source** | `gs://minimal-staging-archives/aquasecurity/trivy/v0.69.1.tar.gz` | `gs://minimal-staging-archives/aquasecurity/trivy/v0.70.0.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

### About the auto-generated "still affecting" list

The original PR body showed:

> 2 known vulnerabilities still affect 0.70.0 after this update.
> | GHSA-69fq-xp46-6x23 | **CRITICAL** | _no fix info_ |
> | GHSA-xcq4-m2r3-cmrj | MEDIUM | _no fix info_ |

**Both are FALSE POSITIVES.** Verified manually against OSV.dev:

- [GHSA-69fq-xp46-6x23](https://github.com/advisories/GHSA-69fq-xp46-6x23): "Trivy ecosystem supply chain was briefly compromised." Affects `aquasecurity/trivy-action` and `aquasecurity/setup-trivy` — the GitHub Actions, NOT the trivy binary. Different artifacts in the same repo.
- GHSA-xcq4-m2r3-cmrj: same pattern (sibling-artifact in the trivy repo, not the trivy binary).

Our scanner attributed these to the trivy binary because both share the `aquasecurity/trivy` GitHub repo URL. Tracked in [supply-chain#97](https://github.com/gominimal/minimal-supply-chain/issues/97).

This update is independently good (latest trivy release) and the false-positive list does not represent real risk to the trivy binary.

---
*Originally created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs); body manually corrected for the false-positive vuln list.*
