### PR TITLE
Add starship package

### DIFF
--- a/packages/starship/build.ncl
+++ b/packages/starship/build.ncl
@@ -1,0 +1,55 @@
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "1.25.1" in
+{
+  name = "starship",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/starship/starship/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "521306b14066ee7e332d998ef5b5b6455fdc6085c52e86b6316a7cdc37bae1d8",
+      extract = true,
+      strip_prefix = "starship-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    starship = { glob = "usr/bin/starship" } | OutputBin,
+    bash_completion = { glob = "usr/share/bash-completion/completions/starship" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/starship.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_starship" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "starship",
+        repo = "starship",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/starship/build.sh
+++ b/packages/starship/build.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -ex
 
-cd starship-${MINIMAL_ARG_VERSION}
+# Source unpacks into cwd via `extract = true` + `strip_prefix` in
+# build.ncl — no explicit `cd` needed (mirrors delta/codex pattern).
 
 export CC=gcc
 export LD=gcc

--- a/packages/starship/build.sh
+++ b/packages/starship/build.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -ex
+
+cd starship-${MINIMAL_ARG_VERSION}
+
+export CC=gcc
+export LD=gcc
+# `--remap-path-prefix` strips absolute build-time paths from the
+# binary so reruns are byte-identical regardless of build directory
+# or `$HOME`. Two mappings: source dir (where the tarball extracted)
+# and the cargo registry (where transitive dependency source lives).
+# `CARGO_INCREMENTAL=0` disables incremental compilation, which would
+# otherwise cache build state in non-deterministic ways. Both per
+# gominimal/minimal-repro's reproducibility-fixes guide.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+
+cargo build --release
+
+install -D -m 0755 target/release/starship "$OUTPUT_DIR/usr/bin/starship"
+
+# Emit shell completions via the just-built binary.
+"$OUTPUT_DIR/usr/bin/starship" completions bash > /tmp/starship.bash
+"$OUTPUT_DIR/usr/bin/starship" completions fish > /tmp/starship.fish
+"$OUTPUT_DIR/usr/bin/starship" completions zsh  > /tmp/_starship
+
+install -D -m 0644 /tmp/starship.bash "$OUTPUT_DIR/usr/share/bash-completion/completions/starship"
+install -D -m 0644 /tmp/starship.fish "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/starship.fish"
+install -D -m 0644 /tmp/_starship     "$OUTPUT_DIR/usr/share/zsh/site-functions/_starship"


### PR DESCRIPTION
## Summary

Adds [starship](https://starship.rs) — the cross-shell prompt — as a Minimal package. Builds from source via the `rust` toolchain (no prebuilt-binary fallback needed).

## Build pattern

Mirrors the standard Rust-binary shape (delta, uv, codex) plus the path-remapping reproducibility flags from [gominimal/minimal-repro](https://github.com/gominimal/minimal-repro)'s reproducibility-fixes guide:

```sh
RUSTFLAGS="-C linker=gcc \
           --remap-path-prefix=$(pwd)=/builddir \
           --remap-path-prefix=$HOME/.cargo=/cargo"
CARGO_INCREMENTAL=0
```

Completions emitted from the just-built binary (`starship completions <shell>`) instead of shipping checked-in files that drift across versions.

## Outputs

| Output | Path |
|---|---|
| `starship` (bin) | `usr/bin/starship` |
| `bash_completion` | `usr/share/bash-completion/completions/starship` |
| `fish_completion` | `usr/share/fish/vendor_completions.d/starship.fish` |
| `zsh_completion` | `usr/share/zsh/site-functions/_starship` |

## Validation

- [x] `minimal check --packages starship` — all parse / schema / fmt checks pass
- [x] `minimal package --rebuild -v starship` — clean-room build succeeds; ARM aarch64 ELF, 10MB stripped binary; all three completion files emitted

## Using starship as your shell prompt

Once this lands, you can wire starship into a `tasks.shell` in your project's `minimal.toml`:

```toml
[tasks.shell]
interactive = true
packages = ["base", "bash", "starship"]
bash = """
exec bash --noprofile --rcfile <(starship init bash)
"""
```

(`bash --rcfile <(...)` reads init from a process substitution, so no temp file is needed.)

For zsh:
```toml
exec = "zsh"
vars.STARSHIP_INIT = "true"
```
…with a `~/.zshrc` that does `eval "$(starship init zsh)"` if `$STARSHIP_INIT` is set.

Intentionally not auto-injecting the init into `bash`/`fish`/`zsh` package rcs — keeps prompt opt-in and avoids coupling shell packages to starship.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build specifications and scripts for the starship package (v1.25.1), including shell completion support for bash, fish, and zsh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->