### PR TITLE
Add k9s package

### DIFF
--- a/packages/k9s/build.ncl
+++ b/packages/k9s/build.ncl
@@ -1,0 +1,67 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "0.50.18" in
+{
+  name = "k9s",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/derailed/k9s/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "4a438b4bc480c05ba6f78a1573ee7e1dad7956ef3e30912ae22c744cea031f96",
+      extract = true,
+      strip_prefix = "k9s-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    k9s = { glob = "usr/bin/k9s" } | OutputBin,
+  },
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [],
+        cmds = [["k9s", "version", "--short"]],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "derailed",
+        repo = "k9s",
+      },
+      env_dir_mappings = [
+        { read_only = false, path = "~/.kube", class = 'Credential },
+        { read_only = false, path = "~/.config/k9s", class = 'Credential },
+      ],
+      env_file_mappings = [
+        { read_only = false, path = "~/.kubeconfig", class = 'Credential },
+      ],
+    } | Attrs,
+} | BuildSpec

--- a/packages/k9s/build.sh
+++ b/packages/k9s/build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -ex
+
+# Source unpacks into cwd via `extract = true` + `strip_prefix` in
+# build.ncl — no explicit `cd` needed.
+
+export GOROOT=/usr/go
+# Static binary so the result has no glibc-version coupling beyond
+# what the runtime_dep declares; matches kubectl's choice.
+export CGO_ENABLED=0
+# Reproducibility: strip absolute build paths and skip embedding
+# git VCS metadata — per gominimal/minimal-repro's
+# reproducibility-fixes guide.
+export GOFLAGS="-trimpath -buildvcs=false"
+# Skip the public sum DB check; sandbox doesn't have outbound to
+# sum.golang.org. Module checksums in go.sum are still verified.
+export GONOSUMCHECK=*
+export GONOSUMDB=*
+# Universal env hygiene from the same guide — deterministic locale
+# + UTC for any date strings the build emits.
+export LC_ALL=C
+export TZ=UTC
+
+# `-buildid=` clears Go's content-derived build ID stamp; combined
+# with `-trimpath` above this is the canonical "deterministic Go
+# binary" recipe. `-w -s` strips DWARF + symbol tables (smaller
+# binary, no source-path leaks). The `-X` flag injects the
+# upstream version string into k9s's `cmd.version` package
+# variable (declared at cmd/root.go:36) so `k9s version` reports
+# the right number instead of the "dev" default.
+go build \
+  -ldflags "-buildid= -w -s -X github.com/derailed/k9s/cmd.version=v${MINIMAL_ARG_VERSION}" \
+  -o k9s
+
+install -D -m 0755 k9s "$OUTPUT_DIR/usr/bin/k9s"


### PR DESCRIPTION
## Summary

Adds [k9s](https://k9scli.io) — terminal UI for managing Kubernetes clusters — as a Minimal package. Builds from source via the `go` toolchain following the existing kubectl/gh pattern.

## Build pattern

Mirrors the standard Go-binary shape (kubectl, gh) plus the full reproducibility flag set from [gominimal/minimal-repro](https://github.com/gominimal/minimal-repro)'s reproducibility-fixes guide:

```sh
CGO_ENABLED=0           # static binary (matches kubectl)
GOFLAGS="-trimpath -buildvcs=false"
LC_ALL=C TZ=UTC         # universal env hygiene
GONOSUMCHECK=* GONOSUMDB=*  # sandbox has no outbound to sum.golang.org

go build -ldflags "-buildid= -w -s \
  -X github.com/derailed/k9s/cmd.version=v${VERSION}"
```

The `-X` flag injects into k9s's `cmd.version` package variable (declared at [`cmd/root.go:36`](https://github.com/derailed/k9s/blob/v0.50.18/cmd/root.go#L36)) so `k9s version` reports the upstream tag rather than the "dev" default.

## Outputs

| Output | Path |
|---|---|
| `k9s` (bin) | `usr/bin/k9s` |

## Credential mappings

Same `~/.kube` / `~/.kubeconfig` as kubectl, plus k9s's own `~/.config/k9s`:

```nickel
env_dir_mappings = [
  { read_only = false, path = "~/.kube",       class = 'Credential },
  { read_only = false, path = "~/.config/k9s", class = 'Credential },
],
env_file_mappings = [
  { read_only = false, path = "~/.kubeconfig", class = 'Credential },
],
```

## Validation

- [x] `minimal check --packages k9s` — all parse / schema / fmt / standalone-test checks pass
- [x] `minimal package --rebuild -v k9s` — clean-room build, 121MB stripped static ARM64 ELF
- [x] Standalone test (`k9s version --short`) declared

## Using k9s

Once this lands:

```bash
minimal add k9s   # adds it to the registry
k9s              # if your kubeconfig is in the standard location
```

Or in a `minimal.toml` task:

```toml
[tasks.k9s]
interactive = true
packages = ["k9s"]
exec = "k9s"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build configuration and script for k9s (version 0.50.18), enabling static binary builds with automated version verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->