### PR TITLE
Add sd package

### DIFF
--- a/packages/sd/build.ncl
+++ b/packages/sd/build.ncl
@@ -1,0 +1,65 @@
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "1.1.0" in
+{
+  name = "sd",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/chmln/sd/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "defdce484f8c92f265e1282490572575028967c2c55d356111d1e49a3ea9a88e",
+      extract = true,
+      strip_prefix = "sd-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    sd = { glob = "usr/bin/sd" } | OutputBin,
+    bash_completion = { glob = "usr/share/bash-completion/completions/sd" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/sd.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_sd" } | OutputData,
+  },
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [],
+        cmds = [["sd", "--version"]],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "chmln",
+        repo = "sd",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/sd/build.sh
+++ b/packages/sd/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -ex
+
+# Source unpacks into cwd via `extract = true` + `strip_prefix` in
+# build.ncl — no explicit `cd` needed.
+
+export CC=gcc
+export LD=gcc
+# Reproducibility: strip absolute build-time paths from the binary
+# (source dir AND cargo registry where dep source lives) plus
+# disable incremental compilation. Per gominimal/minimal-repro's
+# reproducibility-fixes guide.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+
+# sd is a cargo workspace; the binary lives in the sd-cli member.
+cargo build --release -p sd-cli
+
+install -D -m 0755 target/release/sd "$OUTPUT_DIR/usr/bin/sd"
+
+# Upstream ships pre-generated completions in gen/completions/ — use
+# those rather than a `sd completions <shell>` subcommand (sd doesn't
+# have one) or a runtime-generation step.
+install -D -m 0644 gen/completions/sd.bash  "$OUTPUT_DIR/usr/share/bash-completion/completions/sd"
+install -D -m 0644 gen/completions/sd.fish  "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/sd.fish"
+install -D -m 0644 gen/completions/_sd      "$OUTPUT_DIR/usr/share/zsh/site-functions/_sd"


### PR DESCRIPTION
## Summary

Adds [sd](https://github.com/chmln/sd) — intuitive find-and-replace CLI, sed alternative — as a Minimal package. Builds from source via the `rust` toolchain.

## Build pattern

Mirrors the standard Rust-binary shape (delta, starship) plus the path-remapping reproducibility flags from [gominimal/minimal-repro](https://github.com/gominimal/minimal-repro)'s reproducibility-fixes guide:

```sh
RUSTFLAGS="-C linker=gcc \
           --remap-path-prefix=$(pwd)=/builddir \
           --remap-path-prefix=$HOME/.cargo=/cargo"
CARGO_INCREMENTAL=0
```

sd is a cargo workspace with the binary in the `sd-cli` member (declared as `[[bin]] name = "sd"`), so the build is `cargo build --release -p sd-cli`.

Upstream ships pre-generated completions in `gen/completions/` (sd has no `sd completions <shell>` subcommand) — installed directly rather than runtime-regenerated.

## Outputs

| Output | Path |
|---|---|
| `sd` (bin) | `usr/bin/sd` |
| `bash_completion` | `usr/share/bash-completion/completions/sd` |
| `fish_completion` | `usr/share/fish/vendor_completions.d/sd.fish` |
| `zsh_completion` | `usr/share/zsh/site-functions/_sd` |

## Validation

- [x] `minimal check --packages sd` — all parse / schema / fmt checks pass
- [x] `minimal package --rebuild -v sd` — clean-room build, 2.1MB stripped ARM64 ELF, all 3 completions installed
- [x] Standalone `sd --version` test declared


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `sd` command-line tool with integrated shell completions for bash, fish, and zsh. Includes automated build infrastructure and validation testing to ensure reliable operation across different shell environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/165)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->