### PR TITLE
Add zoxide package

### DIFF
--- a/packages/zoxide/build.ncl
+++ b/packages/zoxide/build.ncl
@@ -1,0 +1,65 @@
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "0.9.9" in
+{
+  name = "zoxide",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "eddc76e94db58567503a3893ecac77c572f427f3a4eabdfc762f6773abf12c63",
+      extract = true,
+      strip_prefix = "zoxide-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    zoxide = { glob = "usr/bin/zoxide" } | OutputBin,
+    bash_completion = { glob = "usr/share/bash-completion/completions/zoxide" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/zoxide.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_zoxide" } | OutputData,
+  },
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [],
+        cmds = [["zoxide", "--version"]],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ajeetdsouza",
+        repo = "zoxide",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/zoxide/build.sh
+++ b/packages/zoxide/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -ex
+
+# Source unpacks into cwd via `extract = true` + `strip_prefix` in
+# build.ncl — no explicit `cd` needed.
+
+export CC=gcc
+export LD=gcc
+# Reproducibility: strip absolute build-time paths from the binary
+# (source dir AND cargo registry where dep source lives) plus
+# disable incremental compilation. Per gominimal/minimal-repro's
+# reproducibility-fixes guide.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+
+cargo build --release
+
+install -D -m 0755 target/release/zoxide "$OUTPUT_DIR/usr/bin/zoxide"
+
+# Upstream ships pre-generated completions in contrib/completions/ —
+# install directly rather than generating at build time (zoxide's
+# `init` subcommand is for shell-prompt integration, not completion
+# emission).
+install -D -m 0644 contrib/completions/zoxide.bash "$OUTPUT_DIR/usr/share/bash-completion/completions/zoxide"
+install -D -m 0644 contrib/completions/zoxide.fish "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/zoxide.fish"
+install -D -m 0644 contrib/completions/_zoxide     "$OUTPUT_DIR/usr/share/zsh/site-functions/_zoxide"


### PR DESCRIPTION
## Summary

Adds [zoxide](https://github.com/ajeetdsouza/zoxide) — smarter `cd` that learns the directories you spend time in — as a Minimal package. Builds from source via the `rust` toolchain.

Pairs naturally with the existing `starship` + `fzf` + `atuin` "modern shell" stack.

## Build pattern

Same Rust-binary shape as `sd` / `starship` / `delta`, with the path-remapping reproducibility flags from [gominimal/minimal-repro](https://github.com/gominimal/minimal-repro)'s reproducibility-fixes guide:

```sh
RUSTFLAGS="-C linker=gcc \
           --remap-path-prefix=$(pwd)=/builddir \
           --remap-path-prefix=$HOME/.cargo=/cargo"
CARGO_INCREMENTAL=0
```

Upstream ships pre-generated completions in `contrib/completions/` — installed directly rather than at runtime (zoxide's `init` subcommand emits shell-prompt-integration code, not completion files).

## Outputs

| Output | Path |
|---|---|
| `zoxide` (bin) | `usr/bin/zoxide` |
| `bash_completion` | `usr/share/bash-completion/completions/zoxide` |
| `fish_completion` | `usr/share/fish/vendor_completions.d/zoxide.fish` |
| `zsh_completion` | `usr/share/zsh/site-functions/_zoxide` |

## Validation

- [x] `minimal check --packages zoxide` — all parse / schema / fmt checks pass
- [x] `minimal package --rebuild -v zoxide` — clean-room build, 988KB stripped ARM64 ELF, all 3 completions installed

## Using zoxide in a minimal shell task

```toml
[tasks.shell]
interactive = true
packages = ["base", "bash", "starship", "zoxide"]
bash = """
INIT=$(starship init bash; zoxide init bash)
exec bash --noprofile --rcfile <(echo "$INIT")
"""
```

After this, `z foo` jumps to whatever directory you most recently used containing "foo," and `zi` opens an interactive picker (uses fzf if installed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Zoxide application is now available as a package (v0.9.9)
  * Includes shell completions for bash, fish, and zsh
  * Built-in version verification and testing included

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->