### PR TITLE
Update vim to 9.2.0470

### DIFF
--- a/packages/vim/build.ncl
+++ b/packages/vim/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let acl = import "../acl/build.ncl" in
 let ncurses = import "../ncurses/build.ncl" in
 
-let version = "9.2.0388" in
+let version = "9.2.0470" in
 {
   name = "vim",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/vim-%{version}.tar.gz",
-      sha256 = "1ac056c943f5129722dcab58b304d72c3434c239cc2d658e05fdb21253792ad0"
+      sha256 = "9dbaaab1c79f67628e72c52ab7180c509a4ed433b4df31cb9fce485ccf5c599d"
     } | Source,
     base,
     make,


### PR DESCRIPTION
## Update vim `9.2.0388` → `9.2.0470`

**Source:** `github:vim/vim:tag`
**Release:** https://github.com/vim/vim/releases/tag/v9.2.0470
**Changelog:** https://github.com/vim/vim/compare/v9.2.0388...v9.2.0470
**Released:** 17 minutes ago (2026-05-10)

> [!NOTE]
> **Pkgscan: skipped** (`--skip-pkgscan`). The scan was bypassed by the caller; this PR carries no diff-finding evidence either way. The flag is intended for already-audited urgent patches — confirm the source diff was reviewed out-of-band before approving.

### Vulnerabilities fixed (2)

This update clears 2 vulnerabilities affecting `9.2.0388`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-hwg5-3cxw-wvvg | MEDIUM | _via range:_ `<= 9.2.0435; <= 9.2.0435` |
| GHSA-q4jv-r9gj-6cwv | MEDIUM | `9.2.0450` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `9.2.0388` | `9.2.0470` |
| **SHA256** | `1ac056c943f51297...` | `9dbaaab1c79f6762...` |
| **Size** | 19.9 MB | 20.0 MB |
| **Source** | `gs://minimal-staging-archives/vim-9.2.0388.tar.gz` | `gs://minimal-staging-archives/vim-9.2.0470.tar.gz` |

- **License:** `Vim` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vim to version 9.2.0470, bringing in the latest patches and improvements from the Vim development cycle.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->