### PR TITLE
Update python to 3.14.5

### DIFF
--- a/packages/python/build.ncl
+++ b/packages/python/build.ncl
@@ -16,14 +16,14 @@ let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 let xz = import "../xz/build.ncl" in
 
-let version = "3.14.4" in
+let version = "3.14.5" in
 {
   name = "python",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/Python-%{version}.tar.xz",
-      sha256 = "d923c51303e38e249136fc1bdf3568d56ecb03214efdef48516176d3d7faaef8"
+      sha256 = "7e32597b99e5d9a39abed35de4693fa169df3e5850d4c334337ffd6a19a36db6"
     } | Source,
     base,
     make,
@@ -72,6 +72,7 @@ let version = "3.14.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Python-2.0.1",
       source_provenance = {
         category = 'GithubRepo,
         owner = "python",


### PR DESCRIPTION
## Update python `3.14.4` → `3.14.5`

**Source:** `github:python/cpython:tag`
**Release:** https://github.com/python/cpython/releases/tag/v3.14.5
**Changelog:** https://github.com/python/cpython/compare/v3.14.4...v3.14.5
**Released:** 1 days ago (2026-05-10)

> [!WARNING]
> **Pkgscan: 1 new signal introduced by this update** (risk score 2.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | MEDIUM | `python (upstream release)` | 0 | `metadata/recent-bump` | `upstream release <48h ago` |

### Vulnerabilities fixed (5)

This update clears 5 vulnerabilities affecting `3.14.4`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| PSF-0000-CVE-2026-3298 | MEDIUM | _commits:_ `1274766d`, `27522b7d`, `95633d2a` |
| PSF-0000-CVE-2026-6100 | MEDIUM | _commits:_ `6a5f79c8`, `8fc66aef`, `c3cf71c3` |
| PSF-2026-15 | MEDIUM | _commits:_ `05ed7ce7`, `b1cf9016` |
| PSF-2026-22 | MEDIUM | _commits:_ `ab5ef98a`, `b01e594f`, `fc829e88` |
| PSF-2026-21 | LOW | _commits:_ `76b3923d`, `3c59b8b5`, `f795e042` |

> [!WARNING]
> **6 known vulnerabilities still affect `3.14.5` after this update.**
>
> ⚠️ **Data-quality note:** 6/6 entries below have no clearance metadata (no fixed-version, vulnerable-range, or affected-ranges). The scanner may have stale or incomplete data for this package — verify the list before relying on it.
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | PSF-0000-CVE-2026-4786 | **HIGH** | _no fix info_ |
> | PSF-2026-19 | MEDIUM | _no fix info_ |
> | PSF-2026-3 | MEDIUM | _no fix info_ |
> | PSF-2026-4 | MEDIUM | _no fix info_ |
> | CVE-2026-3479 | LOW | _no fix info_ |
> | PSF-2025-2 | LOW | _no fix info_ |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `3.14.4` | `3.14.5` |
| **SHA256** | `d923c51303e38e24...` | `7e32597b99e5d9a3...` |
| **Size** | 23.9 MB | 23.9 MB |
| **Source** | `gs://minimal-staging-archives/Python-3.14.4.tar.xz` | `gs://minimal-staging-archives/Python-3.14.5.tar.xz` |

- **License:** `Python-2.0.1` _(source: tarball)_

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Python package version from 3.14.4 to 3.14.5
  * Added Python-2.0.1 license metadata to package attributes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
