### PR TITLE
shellcheck: per-arch tarball URL (fix arm64 builds)

### DIFF
--- a/packages/shellcheck/build.ncl
+++ b/packages/shellcheck/build.ncl
@@ -1,4 +1,5 @@
 let { Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
@@ -7,10 +8,18 @@ let version = "0.10.0" in
   name = "shellcheck",
   build_deps = [
     { file = "build.sh" } | Local,
-    {
-      url = "https://github.com/koalaman/shellcheck/releases/download/v%{version}/shellcheck-v%{version}.linux.x86_64.tar.xz",
-      sha256 = "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87",
-    } | Source,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://github.com/koalaman/shellcheck/releases/download/v%{version}/shellcheck-v%{version}.linux.x86_64.tar.xz",
+          sha256 = "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://github.com/koalaman/shellcheck/releases/download/v%{version}/shellcheck-v%{version}.linux.aarch64.tar.xz",
+          sha256 = "324a7e89de8fa2aed0d0c28f3dab59cf84c6d74264022c00c22af665ed1a09bb",
+        } | Source,
+    } target,
     base,
   ],
   runtime_deps = [

--- a/packages/shellcheck/build.sh
+++ b/packages/shellcheck/build.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 set -ex
 
-tar -xof shellcheck-v${MINIMAL_ARG_VERSION}.linux.x86_64.tar.xz
+case $(uname -m) in
+  x86_64)  PLATFORM="x86_64" ;;
+  aarch64) PLATFORM="aarch64" ;;
+  *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+tar -xof shellcheck-v${MINIMAL_ARG_VERSION}.linux.${PLATFORM}.tar.xz
 
 mkdir -p $OUTPUT_DIR/usr/bin
 install -m 755 shellcheck-v${MINIMAL_ARG_VERSION}/shellcheck $OUTPUT_DIR/usr/bin/shellcheck

--- a/packages/shellcheck/build.sh
+++ b/packages/shellcheck/build.sh
@@ -7,7 +7,7 @@ case $(uname -m) in
   *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
 esac
 
-tar -xof shellcheck-v${MINIMAL_ARG_VERSION}.linux.${PLATFORM}.tar.xz
+tar -xof "shellcheck-v${MINIMAL_ARG_VERSION}.linux.${PLATFORM}.tar.xz"
 
 mkdir -p $OUTPUT_DIR/usr/bin
 install -m 755 shellcheck-v${MINIMAL_ARG_VERSION}/shellcheck $OUTPUT_DIR/usr/bin/shellcheck


### PR DESCRIPTION
## Summary

- shellcheck's `build.ncl` hardcoded the `linux.x86_64` tarball URL, so arm64 builds were untarring the x86_64 prebuilt and installing an x86_64 binary. Post-upload arch validation only catches this on a fresh build (cache hits skip it), which is why the bug surfaced now after `/var/lib/res-server/built/` was wiped on res-server-arm64.
- Adds a per-arch `match { arch = 'Amd64 | 'Arm64 }` source selection (gcloud / chromium-bin pattern). aarch64 tarball + sha256 added.
- Parametrizes `build.sh`'s tarball filename via `case $(uname -m)`. Inner directory layout is identical across both arches (both extract to `shellcheck-v0.10.0/shellcheck`), so the install step is unchanged.

## Test plan

- [ ] CI build on arm64 res-server: shellcheck rebuilds with aarch64 tarball, output arch validation passes
- [ ] CI build on amd64 res-server: shellcheck still builds correctly (regression check)
- [ ] After merge, re-trigger python PR (#168) — its shellcheck dep will now resolve to a correct-arch artifact on arm64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ShellCheck installer now supports both AMD64 and ARM64, selecting and validating the correct architecture-specific release for proper installation and execution.
  * Installer reports a clear error for unsupported CPU architectures to prevent misinstallation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/169)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->