### PR TITLE
claude-code: 2.1.119 -> 2.1.128

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -11,9 +11,9 @@ let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
-  version = "2.1.119",
-  amd64_sha256 = "cca43053f062949495596b11b6fd1b59cf79102adb13bacbe66997e6fae41e4a",
-  arm64_sha256 = "382aa73ea4b07fd8d698e3159b5ef9e1b8739fae7505ba8ddd28b8a6a62819ce",
+  version = "2.1.128",
+  amd64_sha256 = "770c81373ad42970ef576676da78d6be60413f4ade23abadbf1343ca0809bb3e",
+  arm64_sha256 = "e2a31879b7433f658d915e6716249f10b913b467873950e8e7e066ba7c4d96e9",
 }
 in
 

--- a/packages/python/build.ncl
+++ b/packages/python/build.ncl
@@ -16,14 +16,14 @@ let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 let xz = import "../xz/build.ncl" in
 
-let version = "3.14.4" in
+let version = "3.14.5" in
 {
   name = "python",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/Python-%{version}.tar.xz",
-      sha256 = "d923c51303e38e249136fc1bdf3568d56ecb03214efdef48516176d3d7faaef8"
+      sha256 = "7e32597b99e5d9a39abed35de4693fa169df3e5850d4c334337ffd6a19a36db6"
     } | Source,
     base,
     make,
@@ -72,6 +72,7 @@ let version = "3.14.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Python-2.0.1",
       source_provenance = {
         category = 'GithubRepo,
         owner = "python",


### PR DESCRIPTION
Current stable per Anthropic's GCS release channel:

```
$ curl -sf https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/stable
2.1.128
```

We're on 2.1.119; this bumps to 2.1.128.

## Shas

Computed by fetching the binaries directly and `shasum -a 256`:

- linux-x64: `770c81373ad42970ef576676da78d6be60413f4ade23abadbf1343ca0809bb3e`
- linux-arm64: `e2a31879b7433f658d915e6716249f10b913b467873950e8e7e066ba7c4d96e9`

## Why manual

pkgmgr's auto-updater only swaps the first `sha256` field in a build.ncl (single-source assumption). claude-code is multi-arch with separate shas per architecture, so both need refreshing. Tracked in [gominimal/pkgmgr-rs#121](https://github.com/gominimal/pkgmgr-rs/issues/121) — fixing that will let future bumps go through `pkgmgr update`.

## Also new

`pkgmgr check --package claude-code` correctly reports this update now via [supply-chain#129](https://github.com/gominimal/minimal-supply-chain/pull/129) / [pkgmgr-rs#119](https://github.com/gominimal/pkgmgr-rs/pull/119) — a hand-coded handler that consults Anthropic's stable channel. Before these PRs, claude-code was silently skipped ("no upstream source found") since it has no GitHub repo to detect from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code binary to version 2.1.128
  * Updated Python runtime to version 3.14.5
  * Added license metadata for Python package

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/170)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->