### PR TITLE
Update codex to 0.130.0

### DIFF
--- a/packages/codex/build.ncl
+++ b/packages/codex/build.ncl
@@ -12,14 +12,14 @@ let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 let git = import "../git/build.ncl" in
 
-let version = "0.116.0" in
+let version = "0.130.0" in
 {
   name = "codex",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/openai/codex/archive/refs/tags/rust-v%{version}.tar.gz",
-      sha256 = "37affa694148a0fdda1bd8f335de86075a517cb9bd45b21d798bc47550115b38",
+      sha256 = "13fac7f7aa8ef2e2747696ae2681bd2129f31f0f592a9d276af9780234f4fdf0",
       extract = true,
       strip_prefix = "codex-rust-v%{version}",
     } | Source,
@@ -58,6 +58,7 @@ let version = "0.116.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "openai",


### PR DESCRIPTION
## Update codex `0.116.0` → `0.130.0`

**Source:** `github:openai/codex`
**Release:** https://github.com/openai/codex/releases/tag/rust-v0.130.0
**Changelog:** https://github.com/openai/codex/compare/rust-v0.116.0...rust-v0.130.0
**Released:** 4 days ago (2026-05-08)

> [!CAUTION]
> **Pkgscan: 1 new signal introduced by this update** (risk score 10.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | **CRITICAL** | `scripts/install/install.sh` | 237 | `persistence/filesystem` | `/.bash_profile` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.116.0` | `0.130.0` |
| **SHA256** | `37affa694148a0fd...` | `13fac7f7aa8ef2e2...` |
| **Size** |  | 7.6 MB |
| **Source** | `https://github.com/openai/codex/archive/refs/tags/rust-v0.116.0.tar.gz` | `https://github.com/openai/codex/archive/refs/tags/rust-v0.130.0.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain to a newer version for improved performance and stability.
  * Added explicit license metadata to the package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->