### PR TITLE
Update caddy to 2.11.3

### DIFF
--- a/packages/caddy/build.ncl
+++ b/packages/caddy/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.11.2" in
+let version = "2.11.3" in
 {
   name = "caddy",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/caddyserver/caddy/v%{version}.tar.gz",
-      sha256 = "ee12f7b5f97308708de5067deebb3d3322fc24f6d54f906a47a0a4e8db799122",
+      sha256 = "de751e6b7ca769f0dc1f9b0a1949c7b149c115efde3aaf53182da2bf6a94c825",
       extract = true,
       strip_prefix = "caddy-%{version}",
     } | Source,
@@ -42,6 +42,7 @@ let version = "2.11.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "caddy",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update caddy `2.11.2` → `2.11.3`

**Source:** `github:caddyserver/caddy`
**Release:** https://github.com/caddyserver/caddy/releases/tag/v2.11.3
**Changelog:** https://github.com/caddyserver/caddy/compare/v2.11.2...v2.11.3
**Released:** 1 days ago (2026-05-12)

> [!WARNING]
> **Pkgscan: 1 new signal introduced by this update** (risk score 2.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | MEDIUM | `caddy (upstream release)` | 0 | `metadata/recent-bump` | `upstream release <48h ago` |

### Vulnerabilities fixed (3)

This update clears 3 vulnerabilities affecting `2.11.2`:

| CVE / GHSA | CPE | Severity | Fixed in |
|---|---|---|---|
| GHSA-wwhq-w58m-w29c | `(caddyserver, caddy)` | **HIGH** | _affected:_ `<=2.11.2` |
| GHSA-gx7w-56w6-g48x | `(caddyserver, caddy)` | MEDIUM | `v2.11.3` |
| GHSA-x5w9-xh9r-mvfc | `(caddyserver, caddy)` | MEDIUM | `v2.11.3` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.11.2` | `2.11.3` |
| **SHA256** | `ee12f7b5f9730870...` | `de751e6b7ca769f0...` |
| **Size** | 804 KB | 835 KB |
| **Source** | `gs://minimal-staging-archives/caddyserver/caddy/v2.11.2.tar.gz` | `gs://minimal-staging-archives/caddyserver/caddy/v2.11.3.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Caddy to version 2.11.3
  * Added Apache-2.0 license metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->