### PR TITLE
Update libjpeg-turbo to 3.1.4.1

### DIFF
--- a/packages/libjpeg-turbo/build.ncl
+++ b/packages/libjpeg-turbo/build.ncl
@@ -5,15 +5,15 @@ let make = import "../make/build.ncl" in
 let cmake = import "../cmake/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.0.1" in
+let version = "3.1.4.1" in
 {
   name = "libjpeg-turbo",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-3.0.1.tar.gz
+      # https://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-3.1.4.1.tar.gz
       url = "gs://minimal-staging-archives/libjpeg-turbo-%{version}.tar.gz",
-      sha256 = "22429507714ae147b3acacd299e82099fce5d9f456882fc28e252e4579ba2a75",
+      sha256 = "ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022",
       extract = true,
       strip_prefix = "libjpeg-turbo-%{version}",
     } | Source,

--- a/packages/libjpeg-turbo/build.sh
+++ b/packages/libjpeg-turbo/build.sh
@@ -19,7 +19,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr        \
       -D CMAKE_INSTALL_DEFAULT_LIBDIR=lib \
       -D CMAKE_POLICY_VERSION_MINIMUM=3.5 \
       -D CMAKE_SKIP_INSTALL_RPATH=ON      \
-      -D CMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-3.0.1 \
+      -D CMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-3.1.4.1 \
       ..
 make -j$(nproc)
 


### PR DESCRIPTION
## Update libjpeg-turbo `3.0.1` → `3.1.4.1`

**Source:** `github:libjpeg-turbo/libjpeg-turbo`
**Release:** https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.1.4.1
**Changelog:** https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.0.1...3.1.4.1
**Released:** 47 days ago (2026-03-27)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

> [!WARNING]
> **3 known vulnerabilities still affect `3.1.4.1` after this update.**
>
> | CVE / GHSA | Severity | Fixed in |
> |---|---|---|
> | OSV-2023-546 | MEDIUM | `95881ce8241deb2ca70dd35399009bbdfc99cff5` |
> | OSV-2024-1159 | MEDIUM | `0253e338861f1b15ccf530f83d0d2914d6235e0a` |
> | OSV-2024-1310 | MEDIUM | `0253e338861f1b15ccf530f83d0d2914d6235e0a` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `3.0.1` | `3.1.4.1` |
| **SHA256** | `22429507714ae147...` | `ecae8008e2cc9ade...` |
| **Size** | 2.8 MB | 2.5 MB |
| **Source** | `gs://minimal-staging-archives/libjpeg-turbo-3.0.1.tar.gz` | `gs://minimal-staging-archives/libjpeg-turbo-3.1.4.1.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated libjpeg-turbo dependency to version 3.1.4.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->