### PR TITLE
Update gcloud to 568.0.0

### DIFF
--- a/packages/gcloud/build.ncl
+++ b/packages/gcloud/build.ncl
@@ -6,18 +6,18 @@ let glibc = import "../glibc/build.ncl" in
 let sqlite = import "../sqlite/build.ncl" in
 
 let version = "568.0.0" in
-# Google's immutable per-version GCS bucket. The previous rapid-
-# channel URL (`dl.google.com/dl/cloudsdk/channels/rapid/downloads`)
-# serves moving content under the same filename — bytes that hash
-# to one SHA today can hash to a different SHA tomorrow when Google
-# republishes a build fix. cloud-sdk-release is content-stable
-# (verified via `last-modified` + `etag` headers); each upload
-# pins the version forever.
+# Google's per-version GCS bucket; explicit per-version path. The
+# previous rapid-channel URL
+# (dl.google.com/dl/cloudsdk/channels/rapid/downloads) has the
+# version in the filename but is technically a release-channel
+# pointer; cloud-sdk-release exposes the same content under an
+# explicit storage path with stable etag metadata. Use this for
+# clearer attribution + better resistance to channel rotation.
 let dl_base = "https://storage.googleapis.com/cloud-sdk-release" in
 
 let { amd64_sha256, arm64_sha256 } = {
-  amd64_sha256 = "b788b7f752b49f802c0682ba7f2e3d37f20fca73e67fad354deb70186b2838b8",
-  arm64_sha256 = "632a0bf414670b991e06385fc4b8d393e9c6a1968ae3852c608a277809ceb985",
+  amd64_sha256 = "ee39a260f5d30486c654be018b0e99f396a9c061617d206becaca4456e84ff94",
+  arm64_sha256 = "0b31153517665f12a664675b48571938f0beeec46450485e966a4dce7b125cf6",
 }
 in
 
@@ -74,7 +74,14 @@ in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND MIT-0 AND Pixar AND Python-2.0.1)",
+      # `Pixar` + `Python-2.0.1` from auto-scan were false positives:
+      # `Pixar` matched a docstring in pygments' USD lexer (the file
+      # itself is BSD-licensed; "Pixar" is the format it parses), and
+      # `Python-2.0.1` matched a literal in packaging's SPDX-IDs
+      # database file (data table, not licensed code). The
+      # `Python-2.0` here is the bundled CPython interpreter's real
+      # license. Tracked at pkgmgr-rs#129.
+      license_spdx = "(Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND MIT-0 AND Python-2.0)",
       env_dir_mappings = [{ read_only = false, path = "~/.config/gcloud", class = 'Credential }],
     } | Attrs,
 } | BuildSpec

--- a/packages/gcloud/build.ncl
+++ b/packages/gcloud/build.ncl
@@ -6,11 +6,18 @@ let glibc = import "../glibc/build.ncl" in
 let sqlite = import "../sqlite/build.ncl" in
 
 let version = "568.0.0" in
-let dl_base = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads" in
+# Google's immutable per-version GCS bucket. The previous rapid-
+# channel URL (`dl.google.com/dl/cloudsdk/channels/rapid/downloads`)
+# serves moving content under the same filename — bytes that hash
+# to one SHA today can hash to a different SHA tomorrow when Google
+# republishes a build fix. cloud-sdk-release is content-stable
+# (verified via `last-modified` + `etag` headers); each upload
+# pins the version forever.
+let dl_base = "https://storage.googleapis.com/cloud-sdk-release" in
 
 let { amd64_sha256, arm64_sha256 } = {
-  amd64_sha256 = "e80517d8f1d690ade1920b600db2594cb5f18e0a61cb5c579f60a9fd8112cc1f",
-  arm64_sha256 = "02a91349f72c35d65ba33b5dd7d1ccf44fa2c40a358207c50017465ab9eea5cd",
+  amd64_sha256 = "b788b7f752b49f802c0682ba7f2e3d37f20fca73e67fad354deb70186b2838b8",
+  arm64_sha256 = "632a0bf414670b991e06385fc4b8d393e9c6a1968ae3852c608a277809ceb985",
 }
 in
 
@@ -22,12 +29,12 @@ in
       { arch = 'Amd64, .. } =>
         {
           url = "%{dl_base}/google-cloud-cli-%{version}-linux-x86_64.tar.gz",
-          sha256 = "ee39a260f5d30486c654be018b0e99f396a9c061617d206becaca4456e84ff94",
+          sha256 = amd64_sha256,
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "%{dl_base}/google-cloud-cli-%{version}-linux-arm.tar.gz",
-          sha256 = "0b31153517665f12a664675b48571938f0beeec46450485e966a4dce7b125cf6",
+          sha256 = arm64_sha256,
         } | Source,
     } target,
     base,

--- a/packages/gcloud/build.ncl
+++ b/packages/gcloud/build.ncl
@@ -5,7 +5,7 @@ let python = import "../python/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let sqlite = import "../sqlite/build.ncl" in
 
-let version = "559.0.0" in
+let version = "568.0.0" in
 let dl_base = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads" in
 
 let { amd64_sha256, arm64_sha256 } = {
@@ -22,12 +22,12 @@ in
       { arch = 'Amd64, .. } =>
         {
           url = "%{dl_base}/google-cloud-cli-%{version}-linux-x86_64.tar.gz",
-          sha256 = amd64_sha256,
+          sha256 = "ee39a260f5d30486c654be018b0e99f396a9c061617d206becaca4456e84ff94",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "%{dl_base}/google-cloud-cli-%{version}-linux-arm.tar.gz",
-          sha256 = arm64_sha256,
+          sha256 = "0b31153517665f12a664675b48571938f0beeec46450485e966a4dce7b125cf6",
         } | Source,
     } target,
     base,
@@ -67,6 +67,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND MIT-0 AND Pixar AND Python-2.0.1)",
       env_dir_mappings = [{ read_only = false, path = "~/.config/gcloud", class = 'Credential }],
     } | Attrs,
 } | BuildSpec


### PR DESCRIPTION
## Update gcloud `559.0.0` → `568.0.0`

**Source:** `by-pkg-name:gcloud`
**Released:** unknown _(non-GitHub source or tag-only fallback)_

### Changes

| | Old | New |
|---|---|---|
| **Version** | `559.0.0` | `568.0.0` |
| **SHA256** | `02a91349f72c35d6...` | `ee39a260f5d30486...` |
| **Size** |  | 87.4 MB |
| **Source** | `https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-559.0.0-linux-arm.tar.gz` | `%{dl_base}/google-cloud-cli-568.0.0-linux-x86_64.tar.gz` |

- **License:** `(Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND MIT-0 AND Pixar AND Python-2.0.1)` _(source: tarball)_

### Per-arch sources

| Arch | New SHA256 | Size | URL |
|---|---|---|---|
| `Amd64` | `ee39a260f5d30486...` (was `e80517d8f1d690ad...`) | 87.4 MB | `%{dl_base}/google-cloud-cli-568.0.0-linux-x86_64.tar.gz` |
| `Arm64` | `0b31153517665f12...` (was `02a91349f72c35d6...`) | 60.4 MB | `%{dl_base}/google-cloud-cli-568.0.0-linux-arm.tar.gz` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Cloud SDK to version 568.0.0 with corresponding checksum updates for all architectures.
  * Switched Cloud SDK download source to the per-version cloud storage bucket.
  * Added explicit license metadata to the build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/179)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->