### PR TITLE
Update openssh to 10.3p1

### DIFF
--- a/packages/openssh/build.ncl
+++ b/packages/openssh/build.ncl
@@ -7,14 +7,14 @@ let pkgconf = import "../pkgconf/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 
-let version = "10.2p1" in
+let version = "10.3p1" in
 {
   name = "openssh",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/openssh-%{version}.tar.gz",
-      sha256 = "ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2",
+      sha256 = "c1a4420b1a25ba7336f62afd42ed5974d93455a2ab8c769b5e8e0c8ff8eedadc",
       extract = true,
       strip_prefix = "openssh-%{version}",
     } | Source,


### PR DESCRIPTION
## Update openssh `10.2p1` → `10.3p1`

**Source:** `github:openssh/openssh-portable:tag`
**Release:** https://github.com/openssh/openssh-portable/releases/tag/V_10_3_P1
**Changelog:** https://github.com/openssh/openssh-portable/compare/10.2p1...V_10_3_P1
**Released:** 41 days ago (2026-04-02)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

> [!WARNING]
> **4 known vulnerabilities still affect `10.3p1` after this update.**
>
> | CVE / GHSA | CPE | Severity | Fixed in |
> |---|---|---|---|
> | CVE-2026-35385 | `(openbsd, openssh)` | **HIGH** | `10.3` |
> | CVE-2026-35386 | `(openbsd, openssh)` | LOW | `10.3` |
> | CVE-2026-35387 | `(openbsd, openssh)` | LOW | `10.3` |
> | CVE-2026-35388 | `(openbsd, openssh)` | LOW | `10.3` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `10.2p1` | `10.3p1` |
| **SHA256** | `ccc42c0419937959...` | `c1a4420b1a25ba73...` |
| **Size** | 2.0 MB | 2.0 MB |
| **Source** | `gs://minimal-staging-archives/openssh-10.2p1.tar.gz` | `gs://minimal-staging-archives/openssh-10.3p1.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenSSH to version 10.3p1 (previously 10.2p1).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/180)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->