### PR TITLE
Update openssh to 10.3p1

### DIFF
--- a/packages/openssh/build.ncl
+++ b/packages/openssh/build.ncl
@@ -7,14 +7,14 @@ let pkgconf = import "../pkgconf/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 
-let version = "10.2p1" in
+let version = "10.3p1" in
 {
   name = "openssh",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/openssh-%{version}.tar.gz",
-      sha256 = "ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2",
+      sha256 = "56682a36bb92dcf4b4f016fd8ec8e74059b79a8de25c15d670d731e7d18e45f4",
       extract = true,
       strip_prefix = "openssh-%{version}",
     } | Source,


### PR DESCRIPTION
## Update openssh `10.2p1` → `10.3p1`

**Source:** `github:openssh/openssh-portable:tag`
**Release:** https://github.com/openssh/openssh-portable/releases/tag/V_10_3_P1
**Changelog:** https://github.com/openssh/openssh-portable/compare/10.2p1...V_10_3_P1
**Released:** 41 days ago (2026-04-02)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

> [!NOTE]
> Original body claimed "4 still affecting" — that framing comes from a `compare_versions` quirk where `10.3p1` is read as less-than `10.3` (the `p1` suffix is treated as a pre-release marker, but openssh's convention is the opposite: `<X>.<Y>pN` is the Nth *portable patch* of release `<X>.<Y>`, so `10.3p1` ≥ `10.3`).
>
> | Advisory | Fix per NVD | Verdict |
> |---|---|---|
> | CVE-2026-35385 (HIGH) | `10.3` | **cleared** — 10.3p1 is the first 10.3 portable release (2026-04-02), all fixes are in |
> | CVE-2026-35386 (LOW)  | `10.3` | **cleared** — same |
> | CVE-2026-35387 (LOW)  | `10.3` | **cleared** — same |
> | CVE-2026-35388 (LOW)  | `10.3` | **cleared** — same |
>
> Followup task tracked: teach `compare_versions` that `<num>pN` is a post-release patch, not a pre-release marker. Not blocking this update.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `10.2p1` | `10.3p1` |
| **SHA256** | `ccc42c0419937959...` | `56682a36bb92dcf4...` |
| **Size** | 2.0 MB | 2.0 MB |
| **Source** | `gs://minimal-staging-archives/openssh-10.2p1.tar.gz` | `gs://minimal-staging-archives/openssh-10.3p1.tar.gz` |

> [!TIP]
> The mirrored tarball at `gs://.../openssh-10.3p1.tar.gz` was sourced from `cdn.openbsd.org`'s canonical-shape distribution (top-level dir `openssh-10.3p1/` matching the existing `strip_prefix`), not GitHub auto-archive — pkgmgr-rs#125 added the routing that closed the strip-prefix-failed loop from the earlier PR 180.

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
