### PR TITLE
Update gh to 2.92.0

### DIFF
--- a/packages/gh/build.ncl
+++ b/packages/gh/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.90.0" in
+let version = "2.92.0" in
 {
   name = "gh",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/cli/cli/v%{version}.tar.gz",
-      sha256 = "87a6a3b3df1155e9d253ec6ae273d9e018773498b7ce7570f896a7cb75b64e39",
+      sha256 = "ad18928ce4e2695d7fc1adefa0f5e0496e570a430016cee4c22d7bf87e5d9c1d",
       extract = true,
       strip_prefix = "cli-%{version}",
     } | Source,
@@ -42,6 +42,7 @@ let version = "2.90.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "gh",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update gh `2.90.0` → `2.92.0`

**Source:** `github:cli/cli`
**Release:** https://github.com/cli/cli/releases/tag/v2.92.0
**Changelog:** https://github.com/cli/cli/compare/v2.90.0...v2.92.0
**Released:** 15 days ago (2026-04-28)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Vulnerabilities fixed (1)

This update clears 1 vulnerabilities affecting `2.90.0`:

| CVE / GHSA | Severity | Fixed in |
|---|---|---|
| GHSA-crc3-h8v6-qh57 | LOW | `v2.92.0` |

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.90.0` | `2.92.0` |
| **SHA256** | `87a6a3b3df1155e9...` | `ad18928ce4e2695d...` |
| **Size** | 14.6 MB | 14.6 MB |
| **Source** | `gs://minimal-staging-archives/cli/cli/v2.90.0.tar.gz` | `gs://minimal-staging-archives/cli/cli/v2.92.0.tar.gz` |

- **License:** `MIT` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `gh` tool to version 2.92.0 with corresponding integrity verification updates and license metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/182)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->