### PR TITLE
Update pulumi to 3.239.0

### DIFF
--- a/packages/pulumi/build.ncl
+++ b/packages/pulumi/build.ncl
@@ -4,14 +4,14 @@ let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "3.230.0" in
+let version = "3.239.0" in
 {
   name = "pulumi",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/pulumi/pulumi/v%{version}.tar.gz",
-      sha256 = "bc9e749c3833e46ca7cb3879ed99b8ce58afbb050151a866fc8ddc26a908a57a",
+      sha256 = "de5c91b980619702c67451f8e5e8f3c3729b8f4b1f91ed6925261f2887d699fb",
       extract = true,
       strip_prefix = "pulumi-%{version}",
     } | Source,


### PR DESCRIPTION
## Update pulumi `3.230.0` → `3.239.0`

**Source:** `github:pulumi/pulumi`
**Release:** https://github.com/pulumi/pulumi/releases/tag/v3.239.0
**Changelog:** https://github.com/pulumi/pulumi/compare/v3.230.0...v3.239.0
**Released:** 3 days ago (2026-05-14)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `3.230.0` | `3.239.0` |
| **SHA256** | `bc9e749c3833e46c...` | `de5c91b980619702...` |
| **Size** | 20.3 MB | 21.0 MB |
| **Source** | `gs://minimal-staging-archives/pulumi/pulumi/v3.230.0.tar.gz` | `gs://minimal-staging-archives/pulumi/pulumi/v3.239.0.tar.gz` |

- **License:** `Apache-2.0` ⚠️ GitHub says `Apache-2.0`, tarball says `Pixar`

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Pulumi runtime to version 3.239.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->