### PR TITLE
crane: add new package (google/go-containerregistry CLI)

### DIFF
--- a/packages/crane/build.ncl
+++ b/packages/crane/build.ncl
@@ -1,0 +1,53 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.21.5" in
+{
+  name = "crane",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/google/go-containerregistry/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "c2291876a087f93a61b561594a389e6543091c0c5c50f16b5f9c14417d2fc947",
+      extract = true,
+      strip_prefix = "go-containerregistry-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    crane = { glob = "usr/bin/crane" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      repology_project = "go-containerregistry",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "google",
+        repo = "go-containerregistry",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/crane/build.sh
+++ b/packages/crane/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -ex
+
+export GOROOT=/usr/go
+
+# Inject version via the ldflag path crane's own .goreleaser.yml uses,
+# so `crane version` reports the tag we built from rather than the
+# Go-module fallback ("(devel)" for archive-tarball builds).
+go build -trimpath \
+  -ldflags "-buildid= -w -s -X 'github.com/google/go-containerregistry/cmd/crane/cmd.Version=${MINIMAL_ARG_VERSION}'" \
+  -o crane ./cmd/crane
+
+mkdir -p $OUTPUT_DIR/usr/bin
+install -m 755 crane $OUTPUT_DIR/usr/bin/crane


### PR DESCRIPTION
## Summary

New `crane` package — CLI for working with container images (push, pull, manifest manipulation), from `github.com/google/go-containerregistry`.

## Why

Used today as a host tool by pkgmgr-rs's Cloud Run Job deploy flow (`crane push`, per gominimal/pkgmgr-rs#135). Packaging it lets future `minimal run` tasks consume it via standard package resolution instead of host installs. Cleaner ownership + reproducibility — same arc as `gh` and `kubectl` packages.

## Build

Built from source via the existing go harness (same shape as `packages/gh`):
- v0.21.5 (current latest, published 2026-04-11)
- Source: `gh release download v0.21.5 --repo google/go-containerregistry --archive=tar.gz`
- sha256 verified locally
- Version-inject ldflag (`-X github.com/google/go-containerregistry/cmd/crane/cmd.Version=...`) mirrors the upstream `.goreleaser.yml` so `crane version` reports the tag instead of `"(devel)"`

## Test plan

- [x] `minimal check --packages crane` — all 12 checks pass
- [x] `minimal package crane` — builds clean, produces 11 MB ARM64 ELF at `usr/bin/crane`
- [ ] After merge: any future `minimal run` task can list `crane` in its `packages` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added complete build and packaging infrastructure for the crane tool, including automated compilation and installation with proper dependency management and version tracking capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->