### PR TITLE
Exclude legal/ from CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Exclude the verbatim legal documents (ICLA / CCLA) from CodeRabbit review.
+# These files are legal text reproduced verbatim from the canonical source —
+# they are not code and are not subject to code review. Everything else in
+# the repository is still reviewed normally.
+reviews:
+  path_filters:
+    - "!legal/**"


### PR DESCRIPTION
Adds a `.coderabbit.yaml` that excludes `legal/**` from CodeRabbit review.

On the CLA docs PR (#187), CodeRabbit reviewed the verbatim `legal/ICLA.md` and `legal/CCLA.md` — but those are legal text reproduced verbatim from the canonical source, not code, and not something a code reviewer should be commenting on. This config tells CodeRabbit to skip that folder.

```yaml
reviews:
  path_filters:
    - "!legal/**"
```

Only `legal/**` is excluded — everything else in the repo (recipes, harnesses, `CONTRIBUTING.md`, etc.) is still reviewed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
