### PR TITLE
Add hunk package

### DIFF
--- a/packages/hunk/build.ncl
+++ b/packages/hunk/build.ncl
@@ -1,0 +1,59 @@
+let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bun = import "../bun/build.ncl" in
+
+let git = import "../git/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.14.0" in
+{
+  name = "hunk",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/modem-dev/hunk/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "8cb99e7366eddc82d1ccc754c9cdf4b55c64244929094e49571fad1b80ce759c",
+      extract = true,
+      strip_prefix = "hunk-%{version}",
+    } | Source,
+    base,
+    bun,
+  ],
+
+  runtime_deps = [
+    glibc,
+    git,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    hunk = { glob = "usr/bin/hunk" } | OutputBin,
+    hunkdiff = { glob = "usr/bin/hunkdiff" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "modem-dev",
+        repo = "hunk",
+      },
+      build_cost_multiple = 2,
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/hunk --version",
+  },
+} | BuildSpec

--- a/packages/hunk/build.sh
+++ b/packages/hunk/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p .bun-tmp .bun-install
+export BUN_TMPDIR="$PWD/.bun-tmp"
+export BUN_INSTALL="$PWD/.bun-install"
+
+bun install --frozen-lockfile --ignore-scripts
+
+bun build --compile ./src/main.tsx --outfile hunk
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 hunk "$OUTPUT_DIR/usr/bin/hunk"
+ln -s hunk "$OUTPUT_DIR/usr/bin/hunkdiff"


### PR DESCRIPTION
  ## Summary

  Packages [hunk](https://github.com/modem-dev/hunk), a terminal diff viewer, so it's
  available in the registry. Built from source with the `bun` toolchain rather than
  shipping the prebuilt release binary, giving us a real supply-chain guarantee and the
  ability to tweak build flags. The package exposes both the `hunk` and `hunkdiff`
  binaries (the latter is a symlink to `hunk`, matching upstream's launcher behavior).

  ## Related issues

  <!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

  ## Changes

  - New package `hunk` at upstream version **0.14.0**.
  - Source: `https://github.com/modem-dev/hunk/archive/refs/tags/v0.14.0.tar.gz`
    (`sha256 = 8cb99e7366eddc82d1ccc754c9cdf4b55c64244929094e49571fad1b80ce759c`).
  - Build: `bun install --frozen-lockfile --ignore-scripts` then
    `bun build --compile ./src/main.tsx` to produce a single binary; needs `dns`/`internet`
    to fetch JS dependencies during the build.
  - Build deps: `base`, `bun`. Runtime deps: `glibc`, `git`.
  - Outputs: `usr/bin/hunk` and a `usr/bin/hunkdiff` symlink to it.
  - `source_provenance` → GitHub `modem-dev/hunk`; `license_spdx = MIT`.
  - Smoke test runs `hunk --version`.

  ## Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
  - [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my
  employer's time). CLA Assistant will prompt me on this PR if I haven't already.
  - [x] `min check` passes for the affected packages/harnesses.
  - [x] `min patched-build <name>` succeeds for any package I added or modified.
  - [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt
   release binary) where the required toolchain is available.
  - [x] For version bumps: I've verified the new `sha256` against the upstream archive.

  ## Notes for reviewers

  - The build needs network access (`needs.dns` / `needs.internet`) for `bun install`.
  - `hunkdiff` is shipped as a relative symlink to `hunk`; both names are declared as
    separate `OutputBin` globs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build configuration and scripts to support the hunk package v0.14.0.
  * Package now includes two executable tools and configured runtime dependencies, along with verification testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->