### PR TITLE
Simplify GHC packaging by extracting bootstrap and build tools

### DIFF
--- a/packages/alex/build.ncl
+++ b/packages/alex/build.ncl
@@ -1,0 +1,43 @@
+let { BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bash = import "../bash/build.ncl" in
+let ghc-bootstrap = import "../ghc-bootstrap/build.ncl" in
+let gmp = import "../gmp/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "3.5.1.0" in
+{
+  name = "alex",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://hackage.haskell.org/package/alex-%{version}/alex-%{version}.tar.gz",
+      sha256 = "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      extract = true,
+      strip_prefix = "alex-%{version}",
+    } | Source,
+    base,
+    bash,
+    ghc-bootstrap,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    base,
+    gmp,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+  },
+
+  attrs = {
+    upstream_version = version,
+  },
+} | BuildSpec

--- a/packages/alex/build.ncl
+++ b/packages/alex/build.ncl
@@ -33,7 +33,7 @@ let version = "3.5.1.0" in
   },
 
   outputs = {
-    bins = { glob = "usr/bin/*" } | OutputBin,
+    alex = { glob = "usr/bin/alex" } | OutputBin,
   },
 
   attrs = {

--- a/packages/alex/build.ncl
+++ b/packages/alex/build.ncl
@@ -15,7 +15,6 @@ let version = "3.5.1.0" in
       url = "https://hackage.haskell.org/package/alex-%{version}/alex-%{version}.tar.gz",
       sha256 = "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
       extract = true,
-      strip_prefix = "alex-%{version}",
     } | Source,
     base,
     bash,

--- a/packages/alex/build.sh
+++ b/packages/alex/build.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ ! -f Setup.hs ] && [ ! -f Setup.lhs ]; then
+cd "alex-$MINIMAL_ARG_VERSION"
+
+# Determine setup file
+SETUP_FILE="Setup.hs"
+if [ -f Setup.lhs ]; then
+  SETUP_FILE="Setup.lhs"
+elif [ ! -f Setup.hs ]; then
   echo "import Distribution.Simple" > Setup.hs
   echo "main = defaultMain" >> Setup.hs
+  SETUP_FILE="Setup.hs"
 fi
 
-ghc --make Setup.hs
+ghc --make "$SETUP_FILE"
 ./Setup configure --prefix=/usr
 ./Setup build
 ./Setup copy --destdir="$OUTPUT_DIR"

--- a/packages/alex/build.sh
+++ b/packages/alex/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ ! -f Setup.hs ] && [ ! -f Setup.lhs ]; then
+  echo "import Distribution.Simple" > Setup.hs
+  echo "main = defaultMain" >> Setup.hs
+fi
+
+ghc --make Setup.hs
+./Setup configure --prefix=/usr
+./Setup build
+./Setup copy --destdir="$OUTPUT_DIR"

--- a/packages/ghc-bootstrap/build.ncl
+++ b/packages/ghc-bootstrap/build.ncl
@@ -4,6 +4,7 @@ let base = import "../base/build.ncl" in
 let bash = import "../bash/build.ncl" in
 let gmp = import "../gmp/build.ncl" in
 let make = import "../make/build.ncl" in
+let ncurses = import "../ncurses/build.ncl" in
 let perl = import "../perl/build.ncl" in
 let tar = import "../tar/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
@@ -33,6 +34,7 @@ let version = "9.8.1" in
     bash,
     gmp,
     make,
+    ncurses,
     perl,
     tar,
     toolchain,
@@ -42,6 +44,7 @@ let version = "9.8.1" in
   runtime_deps = [
     base,
     gmp,
+    ncurses,
   ],
 
   cmd = "./build.sh",

--- a/packages/ghc-bootstrap/build.ncl
+++ b/packages/ghc-bootstrap/build.ncl
@@ -1,0 +1,61 @@
+let { BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let bash = import "../bash/build.ncl" in
+let gmp = import "../gmp/build.ncl" in
+let make = import "../make/build.ncl" in
+let perl = import "../perl/build.ncl" in
+let tar = import "../tar/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let xz = import "../xz/build.ncl" in
+
+let version = "9.8.1" in
+{
+  name = "ghc-bootstrap",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://downloads.haskell.org/~ghc/%{version}/ghc-%{version}-x86_64-deb11-linux.tar.xz",
+          sha256 = "ca4dde3a6f34f1fe6d0783767671f02e862f1b0222ef2dc2c5c68cc2abc1abae",
+          extract = false,
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://downloads.haskell.org/~ghc/%{version}/ghc-%{version}-aarch64-deb10-linux.tar.xz",
+          sha256 = "aab7af72614f8bf9ca624407aa4dbc69bc009c2b4cc1a0f3c062008db81bdb95",
+          extract = false,
+        } | Source,
+    } target,
+    base,
+    bash,
+    gmp,
+    make,
+    perl,
+    tar,
+    toolchain,
+    xz,
+  ],
+
+  runtime_deps = [
+    base,
+    gmp,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+    libs = { glob = "usr/lib/ghc-%{version}/**", allow_executable = true } | OutputData,
+    libtinfo = { glob = "usr/lib/*.so*" } | OutputLib,
+  },
+
+  attrs = {
+    upstream_version = version,
+  },
+} | BuildSpec

--- a/packages/ghc-bootstrap/build.sh
+++ b/packages/ghc-bootstrap/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+BOOTSTRAP_ARCH="$(uname -m)"
+case "$BOOTSTRAP_ARCH" in
+  x86_64)
+    BOOTSTRAP_TAR="ghc-${MINIMAL_ARG_VERSION}-x86_64-deb11-linux.tar.xz"
+    ;;
+  aarch64)
+    BOOTSTRAP_TAR="ghc-${MINIMAL_ARG_VERSION}-aarch64-deb10-linux.tar.xz"
+    ;;
+  *)
+    echo "Unsupported architecture: $BOOTSTRAP_ARCH"
+    exit 1
+    ;;
+esac
+
+# Extract prebuilt GHC
+mkdir -p bootstrap-src
+tar -xof "$BOOTSTRAP_TAR" -C bootstrap-src --strip-components=1
+
+# Configure and install GHC to $OUTPUT_DIR/usr
+cd bootstrap-src
+./configure --prefix=/usr
+make install_bin install_lib update_package_db DESTDIR="$OUTPUT_DIR"
+
+# We also need a libtinfo.so.6, which GHC expects. We copy /usr/lib/libncursesw.so.6.
+mkdir -p "$OUTPUT_DIR/usr/lib"
+cp -p /usr/lib/libncursesw.so.6 "$OUTPUT_DIR/usr/lib/libtinfo.so.6"
+
+# Let's also copy it in the GHC lib directory:
+GHC_LIB_DIR="$OUTPUT_DIR/usr/lib/ghc-${MINIMAL_ARG_VERSION}/lib"
+if [ -d "$GHC_LIB_DIR" ]; then
+  cp -p /usr/lib/libncursesw.so.6 "$GHC_LIB_DIR/libtinfo.so.6"
+fi
+
+# Modify bootstrap settings to use standard ld instead of ld.gold
+SETTINGS_FILE="$OUTPUT_DIR/usr/lib/ghc-${MINIMAL_ARG_VERSION}/lib/settings"
+if [ -f "$SETTINGS_FILE" ]; then
+  sed -i 's/-fuse-ld=gold//g' "$SETTINGS_FILE"
+  sed -i 's|/usr/bin/ld.gold|/usr/bin/ld|g' "$SETTINGS_FILE"
+fi

--- a/packages/ghc-bootstrap/build.sh
+++ b/packages/ghc-bootstrap/build.sh
@@ -24,14 +24,62 @@ cd bootstrap-src
 ./configure --prefix=/usr
 make install_bin install_lib update_package_db DESTDIR="$OUTPUT_DIR"
 
-# We also need a libtinfo.so.6, which GHC expects. We copy /usr/lib/libncursesw.so.6.
+# Find the real ncurses library dynamically
+NCURSES_PATH=""
+for path in \
+  /usr/lib/libncursesw.so.6 \
+  /usr/lib/libncurses.so.6 \
+  /usr/lib64/libncursesw.so.6 \
+  /usr/lib64/libncurses.so.6 \
+  /lib/*/libncursesw.so.6 \
+  /lib/*/libncurses.so.6 \
+  /usr/lib/*/libncursesw.so.6 \
+  /usr/lib/*/libncurses.so.6 \
+  /lib/libncursesw.so.6 \
+  /lib/libncurses.so.6; do
+  if [ -f "$path" ]; then
+    NCURSES_PATH="$path"
+    break
+  fi
+done
+
+if [ -z "$NCURSES_PATH" ]; then
+  if command -v gcc >/dev/null 2>&1; then
+    for libname in libncursesw.so.6 libncurses.so.6; do
+      GCC_FOUND_PATH="$(gcc -print-file-name=$libname)"
+      if [ -f "$GCC_FOUND_PATH" ]; then
+        NCURSES_PATH="$GCC_FOUND_PATH"
+        break
+      fi
+    done
+  fi
+fi
+
+if [ -z "$NCURSES_PATH" ]; then
+  if command -v ldconfig >/dev/null 2>&1; then
+    for libname in libncursesw.so.6 libncurses.so.6; do
+      LDCONFIG_PATH="$(ldconfig -p | grep "$libname" | head -n1 | awk '{print $NF}')"
+      if [ -f "$LDCONFIG_PATH" ]; then
+        NCURSES_PATH="$LDCONFIG_PATH"
+        break
+      fi
+    done
+  fi
+fi
+
+if [ -z "$NCURSES_PATH" ]; then
+  echo "Error: Could not locate libncursesw.so.6 or libncurses.so.6" >&2
+  exit 1
+fi
+
+# We also need a libtinfo.so.6, which GHC expects.
 mkdir -p "$OUTPUT_DIR/usr/lib"
-cp -p /usr/lib/libncursesw.so.6 "$OUTPUT_DIR/usr/lib/libtinfo.so.6"
+cp -p "$NCURSES_PATH" "$OUTPUT_DIR/usr/lib/libtinfo.so.6"
 
 # Let's also copy it in the GHC lib directory:
 GHC_LIB_DIR="$OUTPUT_DIR/usr/lib/ghc-${MINIMAL_ARG_VERSION}/lib"
 if [ -d "$GHC_LIB_DIR" ]; then
-  cp -p /usr/lib/libncursesw.so.6 "$GHC_LIB_DIR/libtinfo.so.6"
+  cp -p "$NCURSES_PATH" "$GHC_LIB_DIR/libtinfo.so.6"
 fi
 
 # Modify bootstrap settings to use standard ld instead of ld.gold

--- a/packages/ghc-bootstrap/build.sh
+++ b/packages/ghc-bootstrap/build.sh
@@ -58,7 +58,7 @@ fi
 if [ -z "$NCURSES_PATH" ]; then
   if command -v ldconfig >/dev/null 2>&1; then
     for libname in libncursesw.so.6 libncurses.so.6; do
-      LDCONFIG_PATH="$(ldconfig -p | grep "$libname" | head -n1 | awk '{print $NF}')"
+      LDCONFIG_PATH="$(ldconfig -p | awk -v lib="$libname" '$0 ~ lib {print $NF; exit}')"
       if [ -f "$LDCONFIG_PATH" ]; then
         NCURSES_PATH="$LDCONFIG_PATH"
         break

--- a/packages/ghc/build.ncl
+++ b/packages/ghc/build.ncl
@@ -1,4 +1,5 @@
 let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let alex = import "../alex/build.ncl" in
 let base = import "../base/build.ncl" in
 let bash = import "../bash/build.ncl" in
 let binutils = import "../binutils/build.ncl" in
@@ -15,6 +16,8 @@ let automake = import "../automake/build.ncl" in
 let m4 = import "../m4/build.ncl" in
 let curl = import "../curl/build.ncl" in
 let make = import "../make/build.ncl" in
+let ghc-bootstrap = import "../ghc-bootstrap/build.ncl" in
+let happy = import "../happy/build.ncl" in
 
 let version = "9.10.3" in
 {
@@ -28,32 +31,15 @@ let version = "9.10.3" in
       extract = false,
     } | Source,
     {
-      url = "https://downloads.haskell.org/~ghc/9.8.1/ghc-9.8.1-x86_64-deb11-linux.tar.xz",
-      sha256 = "ca4dde3a6f34f1fe6d0783767671f02e862f1b0222ef2dc2c5c68cc2abc1abae",
-      extract = false,
-    } | Source,
-    {
-      url = "https://downloads.haskell.org/~ghc/9.8.1/ghc-9.8.1-aarch64-deb10-linux.tar.xz",
-      sha256 = "aab7af72614f8bf9ca624407aa4dbc69bc009c2b4cc1a0f3c062008db81bdb95",
-      extract = false,
-    } | Source,
-    {
       url = "https://downloads.haskell.org/~ghc/%{version}/hadrian-bootstrap-sources/hadrian-bootstrap-sources-9.8.1.tar.gz",
       sha256 = "eec7233763bc31801fcbc996edc9c1f5abae707c1661deb8b22f0a7c2780b5e9",
       extract = false,
     } | Source,
-    {
-      url = "https://hackage.haskell.org/package/alex-3.5.1.0/alex-3.5.1.0.tar.gz",
-      sha256 = "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-      extract = false,
-    } | Source,
-    {
-      url = "https://hackage.haskell.org/package/happy-1.20.1.1/happy-1.20.1.1.tar.gz",
-      sha256 = "8b4e7dc5a6c5fd666f8f7163232931ab28746d0d17da8fa1cbd68be9e878881b",
-      extract = false,
-    } | Source,
+    alex,
     base,
     bash,
+    ghc-bootstrap,
+    happy,
     perl,
     python,
     gmp,

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -42,7 +42,11 @@ python3 hadrian/bootstrap/bootstrap.py -w "$(command -v ghc)" --bootstrap-source
 # Add pseudostore lib dirs to LD_LIBRARY_PATH so bootstrapped tools can find their dependencies
 PSEUDO_LIBS="$(find _build/pseudostore -name "*.so*" -exec dirname {} \; | sort -u | paste -sd : || true)"
 if [ -n "$PSEUDO_LIBS" ]; then
-  export LD_LIBRARY_PATH="$PSEUDO_LIBS:${LD_LIBRARY_PATH:-}"
+  if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+    export LD_LIBRARY_PATH="$PSEUDO_LIBS:$LD_LIBRARY_PATH"
+  else
+    export LD_LIBRARY_PATH="$PSEUDO_LIBS"
+  fi
 fi
 
 # Now we can configure GHC.

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -9,87 +9,19 @@ cd "ghc-${MINIMAL_ARG_VERSION}"
 sed -i 's/extern void\* malloc();/extern void\* malloc(long unsigned int);/' utils/hp2ps/Utilities.c
 sed -i 's/extern void \*realloc();/extern void \*realloc(void \*, long unsigned int);/' utils/hp2ps/Utilities.c
 
-# Detect architecture for bootstrap binary selection
-BOOTSTRAP_ARCH="$(uname -m)"
-case "$BOOTSTRAP_ARCH" in
-  x86_64) BOOTSTRAP_TAR="ghc-9.8.1-x86_64-deb11-linux.tar.xz"; BOOTSTRAP_LIB_ARCH="x86_64-linux-ghc-9.8.1" ;;
-  aarch64) BOOTSTRAP_TAR="ghc-9.8.1-aarch64-deb10-linux.tar.xz"; BOOTSTRAP_LIB_ARCH="aarch64-linux-ghc-9.8.1" ;;
-  *) echo "Unsupported architecture: $BOOTSTRAP_ARCH"; exit 1 ;;
-esac
-
-# Extract bootstrap GHC source and install it properly
-mkdir -p ../bootstrap-src
-tar -xof "../${BOOTSTRAP_TAR}" -C ../bootstrap-src --strip-components=1
-export BOOTSTRAP_DIR="$PWD/../bootstrap"
-mkdir -p "$BOOTSTRAP_DIR"
-
-# Configure and install the bootstrap GHC
-(
-  cd ../bootstrap-src
-  ./configure --prefix="$BOOTSTRAP_DIR"
-  make install_bin install_lib update_package_db
-)
-
-# To run the bootstrap GHC, we need to set LD_LIBRARY_PATH so it can find its own libraries
-export LD_LIBRARY_PATH="$BOOTSTRAP_DIR/lib/${BOOTSTRAP_LIB_ARCH}"
-
-# Ensure the bootstrap GHC and the build-produced tools (like alex/happy) are in PATH
-export PATH="$BOOTSTRAP_DIR/bin:$PWD/_build/bin:$PATH"
-
-# We also need a libtinfo.so.6, which GHC expects but we don't have. We can link it to the system libncursesw.so.6.
-mkdir -p "$BOOTSTRAP_DIR/lib"
-ln -sf /usr/lib/libncursesw.so.6 "$BOOTSTRAP_DIR/lib/libtinfo.so.6"
-export LD_LIBRARY_PATH="$BOOTSTRAP_DIR/lib:$LD_LIBRARY_PATH"
-
-# Modify bootstrap settings to use standard ld instead of ld.gold
-if [ -f "$BOOTSTRAP_DIR/lib/settings" ]; then
-  sed -i 's/-fuse-ld=gold//g' "$BOOTSTRAP_DIR/lib/settings"
-  sed -i 's|/usr/bin/ld.gold|/usr/bin/ld|g' "$BOOTSTRAP_DIR/lib/settings"
-fi
-
-# Extract and build alex
-mkdir -p ../alex-src
-tar -xof ../alex-3.5.1.0.tar.gz -C ../alex-src --strip-components=1
-(
-  cd ../alex-src
-  if [ ! -f Setup.hs ] && [ ! -f Setup.lhs ]; then
-    echo "import Distribution.Simple" > Setup.hs
-    echo "main = defaultMain" >> Setup.hs
-  fi
-  "$BOOTSTRAP_DIR/bin/ghc" --make Setup.hs
-  ./Setup configure --prefix="$BOOTSTRAP_DIR"
-  ./Setup build
-  ./Setup install
-)
-
-# Extract and build happy
-mkdir -p ../happy-src
-tar -xof ../happy-1.20.1.1.tar.gz -C ../happy-src --strip-components=1
-(
-  cd ../happy-src
-  if [ ! -f Setup.hs ] && [ ! -f Setup.lhs ]; then
-    echo "import Distribution.Simple" > Setup.hs
-    echo "main = defaultMain" >> Setup.hs
-  fi
-  "$BOOTSTRAP_DIR/bin/ghc" --make Setup.hs
-  ./Setup configure --prefix="$BOOTSTRAP_DIR"
-  ./Setup build
-  ./Setup install
-)
-
-# Create stubs for tools ./configure checks for but aren't strictly needed
-# hadrian bootstrap will download the real cabal via internet access
-mkdir -p "$BOOTSTRAP_DIR/bin"
+# Create stubs for tools ./configure / bootstrap.py checks for but aren't strictly needed
+STUB_DIR="$PWD/../stub-bin"
+mkdir -p "$STUB_DIR"
 
 # Cabal stub - ./configure just checks it exists via AC_PATH_PROG(CABAL,cabal)
-cat << 'EOF' > "$BOOTSTRAP_DIR/bin/cabal"
+cat << 'EOF' > "$STUB_DIR/cabal"
 #!/bin/sh
 exit 0
 EOF
-chmod +x "$BOOTSTRAP_DIR/bin/cabal"
+chmod +x "$STUB_DIR/cabal"
 
 # Sphinx stub - skip actual doc generation
-cat << 'EOF' > "$BOOTSTRAP_DIR/bin/sphinx-build"
+cat << 'EOF' > "$STUB_DIR/sphinx-build"
 #!/bin/sh
 if [ "$1" = "--version" ]; then
   echo "sphinx-build 4.0.0"
@@ -97,27 +29,28 @@ if [ "$1" = "--version" ]; then
 fi
 exit 0
 EOF
-chmod +x "$BOOTSTRAP_DIR/bin/sphinx-build"
+chmod +x "$STUB_DIR/sphinx-build"
+
+# Ensure stubs and build-produced tools are in PATH
+export PATH="$STUB_DIR:$PWD/_build/bin:$PATH"
 
 # Bootstrap Hadrian
 # We must explicitly pass the bootstrap GHC path and also pass --bootstrap-sources to force
 # the bootstrap.py script to use the local offline tarballs instead of downloading them.
-python3 hadrian/bootstrap/bootstrap.py -w "$BOOTSTRAP_DIR/bin/ghc" --bootstrap-sources ../hadrian-bootstrap-sources-9.8.1.tar.gz
+python3 hadrian/bootstrap/bootstrap.py -w "$(command -v ghc)" --bootstrap-sources ../hadrian-bootstrap-sources-9.8.1.tar.gz
 
-# Add pseudostore lib dirs to LD_LIBRARY_PATH so bootstrapped tools (like alex/happy) can find their dependencies
+# Add pseudostore lib dirs to LD_LIBRARY_PATH so bootstrapped tools can find their dependencies
 PSEUDO_LIBS="$(find _build/pseudostore -name "*.so*" -exec dirname {} \; | sort -u | paste -sd : || true)"
 if [ -n "$PSEUDO_LIBS" ]; then
-  export LD_LIBRARY_PATH="$PSEUDO_LIBS:$LD_LIBRARY_PATH"
+  export LD_LIBRARY_PATH="$PSEUDO_LIBS:${LD_LIBRARY_PATH:-}"
 fi
 
 # Now we can configure GHC.
-# Since alex/happy are now in _build/bin, configure will detect them correctly!
 ./configure \
   --prefix=/usr \
-  GHC="$BOOTSTRAP_DIR/bin/ghc"
+  GHC=ghc
 
 # Now we can run the build!
-# GHC 9.10.3 uses Hadrian to build.
 _build/bin/hadrian -j"$(nproc)" --flavour=quickest --docs=none
 
 # And install!

--- a/packages/happy/build.ncl
+++ b/packages/happy/build.ncl
@@ -15,7 +15,6 @@ let version = "1.20.1.1" in
       url = "https://hackage.haskell.org/package/happy-%{version}/happy-%{version}.tar.gz",
       sha256 = "8b4e7dc5a6c5fd666f8f7163232931ab28746d0d17da8fa1cbd68be9e878881b",
       extract = true,
-      strip_prefix = "happy-%{version}",
     } | Source,
     base,
     bash,

--- a/packages/happy/build.ncl
+++ b/packages/happy/build.ncl
@@ -1,0 +1,43 @@
+let { BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bash = import "../bash/build.ncl" in
+let ghc-bootstrap = import "../ghc-bootstrap/build.ncl" in
+let gmp = import "../gmp/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "1.20.1.1" in
+{
+  name = "happy",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://hackage.haskell.org/package/happy-%{version}/happy-%{version}.tar.gz",
+      sha256 = "8b4e7dc5a6c5fd666f8f7163232931ab28746d0d17da8fa1cbd68be9e878881b",
+      extract = true,
+      strip_prefix = "happy-%{version}",
+    } | Source,
+    base,
+    bash,
+    ghc-bootstrap,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    base,
+    gmp,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+  },
+
+  attrs = {
+    upstream_version = version,
+  },
+} | BuildSpec

--- a/packages/happy/build.ncl
+++ b/packages/happy/build.ncl
@@ -33,7 +33,7 @@ let version = "1.20.1.1" in
   },
 
   outputs = {
-    bins = { glob = "usr/bin/*" } | OutputBin,
+    happy = { glob = "usr/bin/happy" } | OutputBin,
   },
 
   attrs = {

--- a/packages/happy/build.sh
+++ b/packages/happy/build.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ ! -f Setup.hs ] && [ ! -f Setup.lhs ]; then
+cd "happy-$MINIMAL_ARG_VERSION"
+
+# Determine setup file
+SETUP_FILE="Setup.hs"
+if [ -f Setup.lhs ]; then
+  SETUP_FILE="Setup.lhs"
+elif [ ! -f Setup.hs ]; then
   echo "import Distribution.Simple" > Setup.hs
   echo "main = defaultMain" >> Setup.hs
+  SETUP_FILE="Setup.hs"
 fi
 
-ghc --make Setup.hs
+ghc --make "$SETUP_FILE"
 ./Setup configure --prefix=/usr
 ./Setup build
 ./Setup copy --destdir="$OUTPUT_DIR"

--- a/packages/happy/build.sh
+++ b/packages/happy/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ ! -f Setup.hs ] && [ ! -f Setup.lhs ]; then
+  echo "import Distribution.Simple" > Setup.hs
+  echo "main = defaultMain" >> Setup.hs
+fi
+
+ghc --make Setup.hs
+./Setup configure --prefix=/usr
+./Setup build
+./Setup copy --destdir="$OUTPUT_DIR"


### PR DESCRIPTION
## Summary

This PR significantly simplifies the `ghc` package by extracting its inline bootstrap compiler and Haskell-based build tools (`alex` and `happy`) into their own dedicated, reusable packages.

### Changes

1. **Created `ghc-bootstrap` (`packages/ghc-bootstrap/build.ncl`, `packages/ghc-bootstrap/build.sh`)**:
   - Packages the prebuilt GHC 9.8.1 binary for both `x86_64` and `aarch64` architectures.
   - Handles extraction, linking of `libtinfo.so.6`, and linker configuration in an isolated way.
2. **Created `alex` (`packages/alex/build.ncl`, `packages/alex/build.sh`)**:
   - Standalone package for the `alex` lexical analyzer generator, built from source using `ghc-bootstrap`.
3. **Created `happy` (`packages/happy/build.ncl`, `packages/happy/build.sh`)**:
   - Standalone package for the `happy` parser generator, built from source using `ghc-bootstrap`.
4. **Simplified `ghc` (`packages/ghc/build.ncl`, `packages/ghc/build.sh`)**:
   - Removed inline downloading and extraction of GHC 9.8.1 bootstrap binaries.
   - Removed inline source compilation of `alex` and `happy`.
   - Shrunk `packages/ghc/build.sh` from 130 lines to 63 lines.
   - The main `ghc` package now simply depends on `ghc-bootstrap`, `alex`, and `happy` as standard build dependencies.

### Verification

- Run `min check --packages ghc-bootstrap,alex,happy,ghc` to verify Nickel schemas and formatting.
- Run `min patched-build ghc-bootstrap` to verify bootstrap compiler extraction and linking.
- Run `min patched-build alex` and `min patched-build happy` to verify they compile successfully using `ghc-bootstrap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local build specs and build scripts to provide alex, happy, and a GHC bootstrap toolchain as build artifacts.

* **Refactor**
  * GHC build now uses the local tooling and lightweight stubs instead of remote prebuilt archives, simplifying bootstrap and improving robustness (library handling and linker/configuration fixes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->