### PR TITLE
feat(virtio-linux): EFI-bootable kernel + vmlinuz-efi output

### DIFF
--- a/packages/virtio-linux/build.ncl
+++ b/packages/virtio-linux/build.ncl
@@ -43,6 +43,7 @@ let version = "6.12.43" in
 
   outputs = {
     vmlinuz = { glob = "usr/share/virtio-linux/vmlinuz" } | OutputData,
+    vmlinuz_efi = { glob = "usr/share/virtio-linux/vmlinuz-efi" } | OutputData,
     config = { glob = "usr/share/virtio-linux/config" } | OutputData,
     system_map = { glob = "usr/share/virtio-linux/System.map" } | OutputData,
   },

--- a/packages/virtio-linux/build.sh
+++ b/packages/virtio-linux/build.sh
@@ -14,6 +14,10 @@ case "$(uname -m)" in
     # means the inner compression is gzip — no external wrap needed.
     KERNEL_TARGET=bzImage
     KERNEL_ARTIFACT=arch/x86/boot/bzImage
+    # bzImage already carries the EFI stub, so the EFI artifact is the same
+    # self-extracting image — no uncompressed variant needed on x86.
+    KERNEL_EFI_TARGET=bzImage
+    KERNEL_EFI_ARTIFACT=arch/x86/boot/bzImage
     HAS_KVM_GUEST_FRAGMENT=1
     ;;
   aarch64)
@@ -21,6 +25,10 @@ case "$(uname -m)" in
     # that qemu/cloud-hypervisor/firecracker all accept.
     KERNEL_TARGET=Image.gz
     KERNEL_ARTIFACT=arch/arm64/boot/Image.gz
+    # EFI firmware (e.g. OVMF) loads the kernel as a PE/COFF application and
+    # cannot unwrap the gzip, so the EFI artifact is the uncompressed Image.
+    KERNEL_EFI_TARGET=Image
+    KERNEL_EFI_ARTIFACT=arch/arm64/boot/Image
     HAS_KVM_GUEST_FRAGMENT=0
     ;;
   *)
@@ -135,10 +143,25 @@ $CFG --enable KVM_AMD
 $CFG --enable KVM_XFER_TO_GUEST_WORK
 $CFG --enable KVM_GENERIC_DIRTYLOG_READ_PROTECT
 
+# --- EFI boot ----------------------------------------------------------------
+# Make the kernel directly bootable by EFI firmware (e.g. OVMF, as used by
+# libkrun-efi / krunkit). Purely additive: an EFI-capable kernel still boots
+# the existing direct-kernel-load VMMs (qemu/cloud-hypervisor/firecracker)
+# unchanged — this only adds the PE/COFF EFI stub entry point. ACPI/DMI are
+# enabled because EFI firmware hands the guest ACPI tables rather than a DT.
+$CFG --enable EFI
+$CFG --enable EFI_STUB
+$CFG --enable ACPI
+$CFG --enable DMI
+$CFG --enable EFIVAR_FS
+
 # Resolve any new dependencies / silently drop options renamed upstream.
 make olddefconfig
 
-make -j"$JOBS" "$KERNEL_TARGET"
+# Build the standard artifact plus the EFI one. On x86 these are the same
+# bzImage; on arm64 the EFI target is the uncompressed `Image` (firmware
+# cannot unwrap the gzip in Image.gz). make de-dupes identical targets.
+make -j"$JOBS" "$KERNEL_TARGET" "$KERNEL_EFI_TARGET"
 
 OUT=$OUTPUT_DIR/usr/share/virtio-linux
 mkdir -p "$OUT"
@@ -146,5 +169,10 @@ mkdir -p "$OUT"
 # per-arch (bzImage on x86, Image.gz on arm64) but the path is uniform so
 # consumers don't need to care.
 cp "$KERNEL_ARTIFACT" "$OUT/vmlinuz"
+# `vmlinuz-efi` is the EFI-firmware-bootable form (uncompressed PE/COFF on
+# arm64; identical bzImage on x86). EFI consumers must still supply a kernel
+# cmdline (via their bootloader / UKI / a built-in cmdline) — this kernel
+# bakes none, staying substrate-agnostic.
+cp "$KERNEL_EFI_ARTIFACT" "$OUT/vmlinuz-efi"
 cp .config "$OUT/config"
 cp System.map "$OUT/System.map"

--- a/packages/virtio-linux/build.sh
+++ b/packages/virtio-linux/build.sh
@@ -155,6 +155,21 @@ $CFG --enable ACPI
 $CFG --enable DMI
 $CFG --enable EFIVAR_FS
 
+# --- built-in kernel cmdline -------------------------------------------------
+# This is a purpose-built microVM kernel for the Minimal VM image, whose disk
+# convention is a GPT { p1=ESP, p2=ext4 root } on the first virtio-blk device
+# (/dev/vda). EFI firmware (OVMF) launches the EFI-stub kernel with *empty*
+# LoadOptions, so without a built-in cmdline the kernel has no root= and panics
+# ("Unable to mount root fs"). CMDLINE_FORCE overrides the empty bootloader
+# cmdline rather than the default *_FROM_BOOTLOADER (which would defer to the
+# empty one).
+#
+# init=/sbin/stub-init is the current boot-verification entrypoint; it becomes
+# the in-VM agent (/sbin/init) in a later iteration.
+$CFG --enable CMDLINE_BOOL
+$CFG --set-str CMDLINE "console=hvc0 root=/dev/vda2 rootfstype=ext4 ro init=/sbin/stub-init"
+$CFG --enable CMDLINE_FORCE
+
 # Resolve any new dependencies / silently drop options renamed upstream.
 make olddefconfig
 


### PR DESCRIPTION
Makes the `virtio-linux` kernel directly EFI-bootable, so it can boot under EFI firmware (e.g. OVMF, as used by `libkrun-efi`/`krunkit`) in addition to the existing direct-kernel-load VMMs.

**Changes:**
- Enable `CONFIG_EFI`, `CONFIG_EFI_STUB`, `CONFIG_ACPI`, `CONFIG_DMI`, `CONFIG_EFIVAR_FS` — adds the PE/COFF EFI-stub entry point and the ACPI/DMI support EFI firmware needs. Additive: the kernel still boots qemu/cloud-hypervisor/firecracker unchanged.
- New output `vmlinuz-efi`: the EFI-firmware-bootable image (uncompressed `Image` on arm64, since OVMF cannot unwrap `Image.gz`; the same `bzImage` on x86). The existing `vmlinuz` is unchanged.
- Bake a forced kernel cmdline (`CONFIG_CMDLINE_FORCE` + `console=hvc0 root=/dev/vda2 rootfstype=ext4 ro init=/sbin/stub-init`). OVMF launches the EFI-stub kernel with **empty** LoadOptions, so without a built-in cmdline the kernel has no `root=` and panics. This is a purpose-built microVM kernel for the Minimal VM image, whose disk convention is GPT { p1=ESP, p2=ext4 root } on `/dev/vda` — fair to bake. `init=/sbin/stub-init` is the current boot-verification entrypoint and becomes the in-VM agent (`/sbin/init`) later.

**Context:** consumed by the `alpine-virtio-linux` package, which assembles an EFI-bootable GPT disk (ESP + ext4 root) that krunkit boots.

**Validation:** validated end-to-end against krunkit 1.2.1 (libkrun-efi) on Apple Silicon — OVMF → kernel 6.12.43 → ext4 root → init. The `minimal build` CI check (external Linux build) is green, and `minimal check --packages virtio-linux` passes all 14 checkers locally (the artifact contains both `vmlinuz` and the EFI `vmlinuz-efi`).

