### PR TITLE
feat(alpine-minirootfs): add Alpine guest rootfs (with socat readline/libncursesw deps)

### DIFF
--- a/minimal.toml
+++ b/minimal.toml
@@ -3,7 +3,7 @@ minimum_version = "0.0.11"
 
 [tasks.shell]
 interactive = true
-packages = ["base", "bash", "claude-code", "curl"]
+packages = ["base", "bash", "claude-code", "curl", "alpine-minirootfs"]
 exec = "bash --noprofile -l"
 
 [tasks.claude]

--- a/packages/alpine-minirootfs/build.ncl
+++ b/packages/alpine-minirootfs/build.ncl
@@ -12,6 +12,9 @@ let tar = import "../tar/build.ncl" in
 let version = "3.21.7" in
 let major_minor = "3.21" in
 let socat_version = "1.8.0.3-r0" in
+# socat's transitive shared-lib deps (see the socat Source comment below).
+let readline_version = "8.2.13-r0" in
+let libncursesw_version = "6.5_p20241006-r3" in
 
 let releases = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/releases" in
 let main_repo = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/main" in
@@ -36,8 +39,11 @@ let main_repo = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/main" in
         } | Source,
     } target,
 
-    # socat (vsock-capable, 1.8.0.x). Single .apk: per APKINDEX it depends only
-    # on so:libc.musl, already provided by the base minirootfs.
+    # socat (vsock-capable, 1.8.0.x). socat1 links libreadline.so.8,
+    # libssl.so.3 and libcrypto.so.3; ssl/crypto ship in the base minirootfs,
+    # but readline (and its libncursesw.so.6) do not — so they are pinned below
+    # and overlaid alongside socat. Without them the guest init dies with a
+    # missing-.so exit 127.
     match {
       { arch = 'Amd64, .. } =>
         {
@@ -48,6 +54,35 @@ let main_repo = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/main" in
         {
           url = "%{main_repo}/aarch64/socat-%{socat_version}.apk",
           sha256 = "7cc3f5bade7fba9cd828b94560ce9f35de61246e19ecb595098110e81cf1c9ae",
+        } | Source,
+    } target,
+
+    # readline — socat's libreadline.so.8 (and headers-free runtime).
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "%{main_repo}/x86_64/readline-%{readline_version}.apk",
+          sha256 = "fa4ff2347886f5516d021b9064a00259b29fc6e2608eac5588a339de244acf12",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "%{main_repo}/aarch64/readline-%{readline_version}.apk",
+          sha256 = "7dad49f83ecbcfa00c5c7df044a5566b928ac1995651cfff219e1df1c2b93871",
+        } | Source,
+    } target,
+
+    # libncursesw — readline's libncursesw.so.6 (the `ncurses-libs` package is
+    # an empty metapackage at this version; the .so lives in `libncursesw`).
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "%{main_repo}/x86_64/libncursesw-%{libncursesw_version}.apk",
+          sha256 = "3919cf673e841d91865213799ccfd5f77a48f5f9f5402723167470295ee32a49",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "%{main_repo}/aarch64/libncursesw-%{libncursesw_version}.apk",
+          sha256 = "c1a5a3a552ad4d44c94454555f38de71b151dc2d608ea2246d92b3bd845b7f3a",
         } | Source,
     } target,
     base,
@@ -62,6 +97,8 @@ let main_repo = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/main" in
   build_args = {
     include version,
     include socat_version,
+    include readline_version,
+    include libncursesw_version,
   },
 
   # The whole guest root tree is the output. allow_executable keeps busybox,

--- a/packages/alpine-minirootfs/build.ncl
+++ b/packages/alpine-minirootfs/build.ncl
@@ -1,0 +1,84 @@
+let { Attrs, BuildSpec, Local, OutputData, Source, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let tar = import "../tar/build.ncl" in
+
+# Upstream Alpine minirootfs, version-pinned + sha256-verified. This packages a
+# foreign (musl/busybox) userland as a guest rootfs — it is deliberately NOT
+# built from source (there is no "build Alpine from source" path; consume the
+# pinned upstream minirootfs instead). The build is pure file assembly (extract
+# + overlay + write), so it runs without executing any guest binary and is
+# host-arch-agnostic.
+let version = "3.21.7" in
+let major_minor = "3.21" in
+let socat_version = "1.8.0.3-r0" in
+
+let releases = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/releases" in
+let main_repo = "https://dl-cdn.alpinelinux.org/alpine/v%{major_minor}/main" in
+{
+  name = "alpine-minirootfs",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+
+    # Base Alpine minirootfs (per-arch tarball). Not auto-extracted — build.sh
+    # unpacks it straight into $OUTPUT_DIR so the captured tree IS the guest /.
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "%{releases}/x86_64/alpine-minirootfs-%{version}-x86_64.tar.gz",
+          sha256 = "8cba1ea3e8b500ea986a313d8eecf3d5952a2a0d23a69117bb81c023d9ceac05",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "%{releases}/aarch64/alpine-minirootfs-%{version}-aarch64.tar.gz",
+          sha256 = "d1d1a3fae5f4d6146e9742790a47fcb116199622cfb8439f218a4d5fbe5000da",
+        } | Source,
+    } target,
+
+    # socat (vsock-capable, 1.8.0.x). Single .apk: per APKINDEX it depends only
+    # on so:libc.musl, already provided by the base minirootfs.
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "%{main_repo}/x86_64/socat-%{socat_version}.apk",
+          sha256 = "caaad9c79573220fe100aad81487b20306c0745cb96baf5813f45fb212e8be90",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "%{main_repo}/aarch64/socat-%{socat_version}.apk",
+          sha256 = "7cc3f5bade7fba9cd828b94560ce9f35de61246e19ecb595098110e81cf1c9ae",
+        } | Source,
+    } target,
+    base,
+    tar,
+  ],
+
+  # The minirootfs is a self-contained foreign userland; nothing from the
+  # Minimal (glibc) graph is injected into the guest.
+  runtime_deps = [],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include socat_version,
+  },
+
+  # The whole guest root tree is the output. allow_executable keeps busybox,
+  # socat and ld-musl executable. Empty mountpoint dirs (proc/sys/dev/tmp/run)
+  # are materialised with a sentinel by build.sh so they survive glob capture.
+  outputs = {
+    rootfs =
+      {
+        glob = "{bin,sbin,lib,etc,usr,root,home,opt,srv,media,mnt,var,run,proc,sys,dev,tmp}/**",
+        allow_executable = true,
+      } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      # Alpine is neither a GithubRepo nor a GnuProject, so source_provenance
+      # is intentionally omitted (provenance is the pinned sha256 above).
+    } | Attrs,
+} | BuildSpec

--- a/packages/alpine-minirootfs/build.sh
+++ b/packages/alpine-minirootfs/build.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Assemble the Alpine minirootfs guest tree directly into $OUTPUT_DIR.
+#
+# The captured output IS the guest root (consumed in directory form). No guest
+# binaries are executed here — pure extract + overlay + write — so this builds
+# identically regardless of host arch.
+set -euo pipefail
+
+mkdir -p "$OUTPUT_DIR"
+
+# 1. Base Alpine minirootfs (per-arch tarball, fetched + sha256-verified by the
+#    build graph). The arch suffix is globbed so build.sh stays arch-agnostic.
+tar -xzf alpine-minirootfs-"$MINIMAL_ARG_VERSION"-*.tar.gz -C "$OUTPUT_DIR"
+
+# 2. socat overlay. apk is a gzip tarball; extract to scratch and copy only the
+#    payload (usr/), leaving the .apk metadata dotfiles out of the rootfs.
+mkdir -p socat-extract
+tar -xzf socat-"$MINIMAL_ARG_SOCAT_VERSION".apk -C socat-extract
+cp -a socat-extract/usr/. "$OUTPUT_DIR/usr/"
+
+# 3. Stub guest workload for VM boot verification. Both vsock ports LISTEN
+#    inside the guest; the host is expected to connect inward.
+cat > "$OUTPUT_DIR/sbin/stub-init" <<'STUB'
+#!/bin/sh
+# Stub guest workload — pid-1 for VM boot verification.
+#
+#   vsock 7350  READY marker — every host connection receives "READY\n"; the
+#               host blocks on this read to confirm boot completion.
+#   vsock 2222  echo bridge  — each host connection is cat-looped.
+set -eu
+
+# Mount /proc and /sys defensively in case the host init didn't already
+# (already-mounted is non-fatal).
+mount -t proc  proc /proc 2>/dev/null || true
+mount -t sysfs sys  /sys  2>/dev/null || true
+
+# READY marker. Per-connection children are reaped by this socat, not pid-1 —
+# acceptable for a stub.
+socat VSOCK-LISTEN:7350,fork SYSTEM:'echo READY' &
+
+# Echo bridge. Becomes pid-1 via exec; reaps its own per-connection children.
+exec socat VSOCK-LISTEN:2222,fork EXEC:cat
+STUB
+chmod 0755 "$OUTPUT_DIR/sbin/stub-init"
+
+# 4. Guest-side contract, machine- and human-readable.
+mkdir -p "$OUTPUT_DIR/etc/stub"
+cat > "$OUTPUT_DIR/etc/stub/manifest" <<MANIFEST
+# Stub guest rootfs contract
+#
+# format=directory
+# exec_target=/sbin/stub-init
+#
+# vsock_port_ready=7350    guest LISTENs; emits "READY\n" per connection
+# vsock_port_bridge=2222   guest LISTENs; echoes (cat) per connection
+alpine=$MINIMAL_ARG_VERSION
+socat=$MINIMAL_ARG_SOCAT_VERSION
+MANIFEST
+
+# 5. Standard mountpoint dirs. A file-glob won't capture an empty dir, so drop
+#    a sentinel; the host mounts proc/sys/dev over these at boot. Alpine ships
+#    proc/sys/dev as 0555, so make the dir writable before the sentinel.
+for d in proc sys dev tmp run; do
+  mkdir -p "$OUTPUT_DIR/$d"
+  chmod u+w "$OUTPUT_DIR/$d"
+  : > "$OUTPUT_DIR/$d/keep"
+done
+
+# Stub procfs target referenced by Alpine's /etc/mtab -> ../proc/mounts compat
+# symlink. The sandbox check requires the link to resolve to something inside
+# the output tree; at runtime procfs is mounted over this directory and the
+# stub is shadowed.
+: > "$OUTPUT_DIR/proc/mounts"
+
+# 6. Rewrite in-rootfs absolute symlinks to relative form. Alpine ships busybox
+#    multi-call links like /usr/sbin/ether-wake -> /bin/busybox; absolute
+#    targets look like host-escapes to the build sandbox even though they
+#    resolve correctly once the tree is mounted as /. Relative form preserves
+#    the semantics and keeps the sandbox check happy.
+cd "$OUTPUT_DIR"
+find . -type l -print0 | while IFS= read -r -d '' link; do
+  target=$(readlink "$link")
+  case "$target" in
+    /*)
+      link_dir=$(dirname "$link")
+      rel=$(realpath -m -s --relative-to="$link_dir" "./${target#/}")
+      ln -sfn "$rel" "$link"
+      ;;
+  esac
+done
+cd - >/dev/null

--- a/packages/alpine-minirootfs/build.sh
+++ b/packages/alpine-minirootfs/build.sh
@@ -12,11 +12,22 @@ mkdir -p "$OUTPUT_DIR"
 #    build graph). The arch suffix is globbed so build.sh stays arch-agnostic.
 tar -xzf alpine-minirootfs-"$MINIMAL_ARG_VERSION"-*.tar.gz -C "$OUTPUT_DIR"
 
-# 2. socat overlay. apk is a gzip tarball; extract to scratch and copy only the
-#    payload (usr/), leaving the .apk metadata dotfiles out of the rootfs.
+# 2. socat overlay + its transitive shared libs (readline -> ncurses-libs).
+#    apks are gzip tarballs; extract to scratch and copy only the payload
+#    (usr/), leaving the .apk metadata dotfiles out of the rootfs. Without
+#    libreadline.so.8 / libncursesw.so.6, socat (guest pid-1) fails to load
+#    with exit 127 and the VM panics on init.
 mkdir -p socat-extract
 tar -xzf socat-"$MINIMAL_ARG_SOCAT_VERSION".apk -C socat-extract
 cp -a socat-extract/usr/. "$OUTPUT_DIR/usr/"
+
+mkdir -p readline-extract
+tar -xzf readline-"$MINIMAL_ARG_READLINE_VERSION".apk -C readline-extract
+cp -a readline-extract/usr/. "$OUTPUT_DIR/usr/"
+
+mkdir -p libncursesw-extract
+tar -xzf libncursesw-"$MINIMAL_ARG_LIBNCURSESW_VERSION".apk -C libncursesw-extract
+cp -a libncursesw-extract/usr/. "$OUTPUT_DIR/usr/"
 
 # 3. Stub guest workload for VM boot verification. Both vsock ports LISTEN
 #    inside the guest; the host is expected to connect inward.


### PR DESCRIPTION
Introduces the **alpine-minirootfs** package: a pinned Alpine 3.21.7 (musl/busybox) guest root tree for the Minimal VM, plus a `socat`-based `stub-init` pid-1 used to verify VM boot (vsock 7350 emits `READY`, 2222 is a cat bridge). Pure file assembly — no guest binary is executed at build time, so it is host-arch-agnostic.

Combined branch into `main` (the package was developed on `add-alpine-minirootfs`), including the socat dependency fix below.

**socat transitive-deps fix (the load-bearing change):** `socat1` links `libreadline.so.8`, which in turn needs `libncursesw.so.6`. Neither ships in the base minirootfs, so the guest init failed to load with **exit 127** and the VM panicked on init. Both runtime apks are now pinned as `Source`s and overlaid alongside socat:
- `readline` 8.2.13-r0
- `libncursesw` 6.5_p20241006-r3 — note the `.so` lives in the **`libncursesw`** package; `ncurses-libs` is an empty metapackage at this version.

(`libssl.so.3`/`libcrypto.so.3`, socat's other `NEEDED`, already ship in the base minirootfs.)

**Validation:** the boot path was validated end-to-end against krunkit 1.2.1 (libkrun-efi) on Apple Silicon — with these deps present, the assembled rootfs boots to `stub-init` and answers `READY` on vsock 7350; without them it was the exit-127 panic. The Linux sandbox/CI build is authoritative for the package itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Alpine minirootfs as a new package option for building minimal root filesystem images optimized for VM environments.
  * Includes built-in initialization and vsock communication capabilities for VM boot verification and system interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->