### PR TITLE
claude-code: bump to 2.1.145 (latest stable)

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -11,9 +11,9 @@ let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
-  version = "2.1.128",
-  amd64_sha256 = "770c81373ad42970ef576676da78d6be60413f4ade23abadbf1343ca0809bb3e",
-  arm64_sha256 = "e2a31879b7433f658d915e6716249f10b913b467873950e8e7e066ba7c4d96e9",
+  version = "2.1.145",
+  amd64_sha256 = "b3ffbc12689bfe81389d6577787fcea4cab81bd3b6bba9b719e73770b62d720e",
+  arm64_sha256 = "75ad61d690d79440c82b5841444e1b42caae55736af37c97dd0e068ef20ce390",
 }
 in
 


### PR DESCRIPTION
Authoritative `stable` file in the Anthropic GCS bucket says
2.1.145; previous pin was 2.1.128 (May 2026 baseline).

## Verification

Both linux SHAs verified against actual GCS downloads (not just the
manifest):

```
$ curl -sL .../2.1.145/linux-x64/claude   | shasum -a 256
b3ffbc12689bfe81389d6577787fcea4cab81bd3b6bba9b719e73770b62d720e  -

$ curl -sL .../2.1.145/linux-arm64/claude | shasum -a 256
75ad61d690d79440c82b5841444e1b42caae55736af37c97dd0e068ef20ce390  -
```

Matches the new pins in build.ncl.

## Notable changes in the 2.1.128 → 2.1.145 window

**Security (the operator-facing reason to take this):**
- Fixed a permission-prompt bypass where bare variable assignments
  to non-allowlisted environment variables in Bash commands were
  auto-approved.

**Reliability:**
- Fixed startup hanging up to 75s when api.anthropic.com is
  unreachable (captive portal / firewall / VPN).
- Self-heals from terminal corruption after missed window-resize
  events (no more Ctrl+L dance).
- Fixed Edit/Write refusing right after detaching a background
  session that was already editing in place.
- Fixed `claude mcp list` silently reporting no servers when
  .mcp.json fails to parse — now shows the parse error.
- Fixed MCP servers with paginated `tools/list` responses only
  returning the first page.
- Better recovery from rare pre-response stream stalls.

**Feature additions worth knowing:**
- `claude agents --json` for scripting (tmux-resurrect, status bars,
  session pickers).
- `agent_id` / `parent_agent_id` on `claude_code.tool` OTEL spans
  with corrected trace parenting for background subagents.
- Status line JSON input now includes GitHub repo + PR info when
  detected.
- `/plugin` Discover/Browse screens preview commands, agents,
  skills, hooks, and MCP/LSP servers before installing.
- `claude --bg` / agent view sessions now resumable via `/resume`.

Full changelog:
https://github.com/anthropics/claude-code/blob/v2.1.145/CHANGELOG.md

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated claude-code tool to version 2.1.145 with corresponding binary validation checksums.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/pkgs/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->