### PR TITLE
Add cloud-sql-proxy package

### DIFF
--- a/packages/cloud-sql-proxy/build.ncl
+++ b/packages/cloud-sql-proxy/build.ncl
@@ -1,0 +1,52 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "2.22.0" in
+{
+  name = "cloud-sql-proxy",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/GoogleCloudPlatform/cloud-sql-proxy/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "03748bca4bfee26c79743c8a1ff90df7daf871a8abf1912e093ec64adf40fcb9",
+      extract = true,
+      strip_prefix = "cloud-sql-proxy-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    cloud-sql-proxy = { glob = "usr/bin/cloud-sql-proxy" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "GoogleCloudPlatform",
+        repo = "cloud-sql-proxy",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/cloud-sql-proxy/build.sh
+++ b/packages/cloud-sql-proxy/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+export GOROOT=/usr/go
+
+go build -trimpath -ldflags "-buildid= -w -s -X 'github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.versionString=${MINIMAL_ARG_VERSION}'" -o cloud-sql-proxy .
+
+mkdir -p $OUTPUT_DIR/usr/bin
+install -m 755 cloud-sql-proxy $OUTPUT_DIR/usr/bin/cloud-sql-proxy

--- a/packages/cloud-sql-proxy/build.sh
+++ b/packages/cloud-sql-proxy/build.sh
@@ -2,6 +2,8 @@
 set -ex
 
 export GOROOT=/usr/go
+export GONOSUMCHECK=*
+export GONOSUMDB=*
 
 go build -trimpath -ldflags "-buildid= -w -s -X 'github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.versionString=${MINIMAL_ARG_VERSION}'" -o cloud-sql-proxy .
 


### PR DESCRIPTION
## Summary

Packages [Cloud SQL Auth Proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy) v2.22.0 — Google Cloud's IAM-authenticated mTLS proxy for connecting to Cloud SQL instances.

## Why

Cloud SQL Auth Proxy is the standard way to reach Cloud SQL when network ACLs (`AuthorizedNetworks`) aren't an option — the boundary becomes IAM + mTLS issued by the proxy after a `cloudsql.client` permission check. Useful in any environment that talks to Cloud SQL: local dev tools, CI jobs, Cloud Run / GKE workloads that prefer the connector over private IP.

Until this lands, the only way to get the proxy into a Minimal sandbox is to grab the prebuilt binary from GitHub releases, which doesn't compose with `min add` / `minimal run` tasks.

## Build

- Source: `github.com/GoogleCloudPlatform/cloud-sql-proxy` archive tarball at `v2.22.0` (sha256 `03748bca…fcb9`)
- Toolchain: `go` (1.26.2 in pkgs satisfies upstream's `go 1.25.7` requirement)
- Built with `-trimpath` + `-ldflags "-buildid= -w -s -X 'github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.versionString=…'"` — same hardening pattern as `gh` and `yq`, with the upstream's package-level `versionString` variable stamped so `--version` reports the packaged release
- `GONOSUMCHECK=* GONOSUMDB=*` in the build script to match the existing Go-build convention in this repo (e.g. `yq`)
- Output: `usr/bin/cloud-sql-proxy`
- License: Apache-2.0

`min check --packages cloud-sql-proxy` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)