### PR TITLE
feat(govulncheck): add govulncheck package

### DIFF
--- a/packages/govulncheck/build.ncl
+++ b/packages/govulncheck/build.ncl
@@ -1,0 +1,46 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "1.1.4" in
+{
+  name = "govulncheck",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/golang/vuln/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "da1a7f3224cf874325814dd198eaa42897143fc871226a04944583cb121a15c9",
+      extract = true,
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    govulncheck = { glob = "usr/bin/govulncheck" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "golang",
+        repo = "vuln",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/govulncheck/build.sh
+++ b/packages/govulncheck/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+export GOROOT=/usr/go
+export GONOSUMCHECK=*
+export GONOSUMDB=*
+export CGO_ENABLED=0
+
+cd vuln-$MINIMAL_ARG_VERSION
+
+go build -ldflags="-s -w -buildid=" -o $OUTPUT_DIR/usr/bin/govulncheck ./cmd/govulncheck


### PR DESCRIPTION


## Summary

Adds a `govulncheck` package — the official Go vulnerability scanner
  from the Go team, which reports known vulnerabilities affecting code
  reachable in a Go project.

  - Pinned to **v1.1.4**, built from source (`github.com/golang/vuln`)
    using the packaged `go` toolchain rather than a prebuilt release binary.
  - `CGO_ENABLED=0` for a static, glibc-light binary; `glibc` kept as a
    runtime dep.
  - Reproducible link flags: `-s -w -buildid=`.
  - Declares `dns`/`internet` sandbox capabilities for Go module fetching.

  ## Testing

  - `min check --packages govulncheck`
  - `min patched-build govulncheck`

  ## Testing

  - `min check --packages golangci-lint`
  - `min patched-build golangci-lint`

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

## Changes
  - Add new package **govulncheck** at **v1.1.4**.
  - Source: `https://github.com/golang/vuln/archive/refs/tags/v1.1.4.tar.gz`
    (built from source via the packaged `go` toolchain, not a prebuilt release binary).
  - Builds `./cmd/govulncheck` with `CGO_ENABLED=0` and reproducible link
    flags (`-s -w -buildid=`).
  - `glibc` runtime dep; declares `dns`/`internet` for Go module fetching.
  - Verified with `min check --packages govulncheck` and `min patched-build govulncheck`.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [ ] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to, known limitations, follow-up work, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added build support for the govulncheck package, enabling compilation and packaging of the vulnerability checking tool through the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->