### PR TITLE
feat(golangci-lint): add golangci-lint 2.12.2

### DIFF
--- a/packages/golangci-lint/build.ncl
+++ b/packages/golangci-lint/build.ncl
@@ -1,0 +1,46 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "2.12.2" in
+{
+  name = "golangci-lint",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/golangci/golangci-lint/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "568cfb0ad40832177826608003065a976254415509dd8b4e3ba19ee586388b94",
+      extract = true,
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    golangci-lint = { glob = "usr/bin/golangci-lint" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "golangci",
+        repo = "golangci-lint",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/golangci-lint/build.sh
+++ b/packages/golangci-lint/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+export GOROOT=/usr/go
+export GONOSUMCHECK=*
+export GONOSUMDB=*
+export CGO_ENABLED=0
+
+cd golangci-lint-$MINIMAL_ARG_VERSION
+
+go build -ldflags="-s -w -X main.version=$MINIMAL_ARG_VERSION -buildid=" -o $OUTPUT_DIR/usr/bin/golangci-lint ./cmd/golangci-lint


### PR DESCRIPTION
Package the golangci-lint Go meta-linter, built from source with the packaged Go toolchain. Pins v2.12.2, builds the cmd/golangci-lint entry point with CGO disabled and a stripped/reproducible build (-s -w, -buildid=), and stamps main.version via ldflags.

<!--
Thanks for the contribution! A few quick notes:

- For anything non-trivial, please open an issue first so we can align on approach.
- Before we can merge, you'll need to accept our Contributor License Agreement.
  CLA Assistant will prompt you automatically on this PR — see CONTRIBUTING.md
  for details.
- Small, focused PRs are easier to review and faster to merge.
-->

## Summary

Adds a `golangci-lint` package — the popular Go meta-linter that runs
  many Go linters in parallel.

  - Pinned to **v2.12.2**, built from source (`github.com/golangci/golangci-lint`)
    using the packaged `go` toolchain rather than a prebuilt release binary.
  - `CGO_ENABLED=0` for a static, glibc-light binary; `glibc` kept as a
    runtime dep.
  - Reproducible link flags: `-s -w -buildid=`, with the version stamped
    into `main.version`.
  - Declares `dns`/`internet` sandbox capabilities for Go module fetching.

  ## Testing

  - `min check --packages golangci-lint`
  - `min patched-build golangci-lint`

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

## Changes
- Add new package **golangci-lint** at **v2.12.2**.
  - Source: `https://github.com/golangci/golangci-lint/archive/refs/tags/v2.12.2.tar.gz`
    (built from source via the packaged `go` toolchain, not a prebuilt release binary).
  - Builds `./cmd/golangci-lint` with `CGO_ENABLED=0` and reproducible link
    flags (`-s -w -buildid=`); stamps the version into `main.version`.
  - `glibc` runtime dep; declares `dns`/`internet` for Go module fetching.
  - Verified with `min check --packages golangci-lint` and `min patched-build golangci-lint`.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [x] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to, known limitations, follow-up work, etc. -->
