### PR TITLE
Update fd to 10.4.2

### DIFF
--- a/packages/fd/build.ncl
+++ b/packages/fd/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "10.3.0" in
+let version = "10.4.2" in
 {
   name = "fd",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/sharkdp/fd/v%{version}.tar.gz",
-      sha256 = "2edbc917a533053855d5b635dff368d65756ce6f82ddefd57b6c202622d791e9",
+      sha256 = "3a7e027af8c8e91c196ac259c703d78cd55c364706ddafbc66d02c326e57a456",
       extract = true,
       strip_prefix = "fd-%{version}",
     } | Source,
@@ -35,6 +35,7 @@ let version = "10.3.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT OR Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "sharkdp",


### PR DESCRIPTION
## Update fd `10.3.0` → `10.4.2`

**Source:** `github:sharkdp/fd`
**Release:** https://github.com/sharkdp/fd/releases/tag/v10.4.2
**Changelog:** https://github.com/sharkdp/fd/compare/v10.3.0...v10.4.2
**Released:** 87 days ago (2026-03-10)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `fd` | `10.3.0` | `10.4.2` |
| ~ | `fd-upstream` | `10.3.0` | `10.4.2` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `10.3.0` | `10.4.2` |
| **SHA256** | `2edbc917a5330538...` | `3a7e027af8c8e91c...` |
| **Size** | 131 KB | 146 KB |
| **Source** | `gs://minimal-staging-archives/sharkdp/fd/v10.3.0.tar.gz` | `gs://minimal-staging-archives/sharkdp/fd/v10.4.2.tar.gz` |

- **License:** `MIT OR Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated fd package to version 10.4.2 with updated source archives and security verification. Added comprehensive license metadata (MIT OR Apache-2.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->