### PR TITLE
Update cups to 2.4.19

### DIFF
--- a/packages/cups/build.ncl
+++ b/packages/cups/build.ncl
@@ -8,14 +8,14 @@ let openssl = import "../openssl/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.4.18" in
+let version = "2.4.19" in
 {
   name = "cups",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/cups-%{version}-source.tar.gz",
-      sha256 = "8fe23bf4905f8889f4bd5ebf375e81916e84754bfc59eccc88cfd7b1e97a741b",
+      sha256 = "820984b12a67f98705785aae2dd1347fe0ac097828001d4583ff64574aed6389",
       extract = true,
       strip_prefix = "cups-%{version}",
     } | Source,


### PR DESCRIPTION
## Update cups `2.4.18` → `2.4.19`

**Source:** `github:OpenPrinting/cups`
**Release:** https://github.com/OpenPrinting/cups/releases/tag/v2.4.19
**Changelog:** https://github.com/OpenPrinting/cups/compare/v2.4.18...v2.4.19
**Released:** 39 days ago (2026-04-27)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `cups` | `2.4.18` | `2.4.19` |
| ~ | `cups-upstream` | `2.4.18` | `2.4.19` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.4.18` | `2.4.19` |
| **SHA256** | `8fe23bf4905f8889...` | `820984b12a67f987...` |
| **Size** | 8.2 MB | 8.0 MB |
| **Source** | `gs://minimal-staging-archives/cups-2.4.18-source.tar.gz` | `gs://minimal-staging-archives/cups-2.4.19-source.tar.gz` |

- **License:** `Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUPS printing system component from version 2.4.18 to 2.4.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->