### PR TITLE
Update libuv to 1.52.1

### DIFF
--- a/packages/libuv/build.ncl
+++ b/packages/libuv/build.ncl
@@ -10,14 +10,14 @@ let autoconf = import "../autoconf/build.ncl" in
 let libtool = import "../libtool/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.52.0" in
+let version = "1.52.1" in
 {
   name = "libuv",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/libuv/libuv/v%{version}.tar.gz",
-      sha256 = "eee139c05f7c868f5ae7a54b1e155fd5b6ed13a22329958d2ba711faad016353",
+      sha256 = "478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c",
       extract = true,
       strip_prefix = "libuv-%{version}",
     } | Source,


### PR DESCRIPTION
## Update libuv `1.52.0` → `1.52.1`

**Source:** `github:libuv/libuv`
**Release:** https://github.com/libuv/libuv/releases/tag/v1.52.1
**Changelog:** https://github.com/libuv/libuv/compare/v1.52.0...v1.52.1
**Released:** 90 days ago (2026-03-06)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `libuv` | `1.52.0` | `1.52.1` |
| ~ | `libuv-upstream` | `1.52.0` | `1.52.1` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.52.0` | `1.52.1` |
| **SHA256** | `eee139c05f7c868f...` | `478baf2599bfbc88...` |
| **Size** | 1.4 MB | 1.4 MB |
| **Source** | `gs://minimal-staging-archives/libuv/libuv/v1.52.0.tar.gz` | `gs://minimal-staging-archives/libuv/libuv/v1.52.1.tar.gz` |

- **License:** `MIT` ⚠️ GitHub says `MIT`, tarball says `(CC-BY-4.0 AND MIT)`

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated libuv dependency to version 1.52.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->