### PR TITLE
Update deno to 2.8.2

### DIFF
--- a/packages/deno/build.ncl
+++ b/packages/deno/build.ncl
@@ -5,7 +5,7 @@ let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let python = import "../python/build.ncl" in
 
-let version = "2.8.1" in
+let version = "2.8.2" in
 {
   name = "deno",
   build_deps = [
@@ -14,12 +14,12 @@ let version = "2.8.1" in
       { arch = 'Amd64, .. } =>
         {
           url = "https://github.com/denoland/deno/releases/download/v%{version}/deno-x86_64-unknown-linux-gnu.zip",
-          sha256 = "2d7bb6195226ac832e0bf7109a115f0af65ee69ac797a4bbde5b27a06cc242d9",
+          sha256 = "184da7a5267ab649bc08821b3bc3ce6805d8e6985fb82707cb8d5e9fd6535362",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "https://github.com/denoland/deno/releases/download/v%{version}/deno-aarch64-unknown-linux-gnu.zip",
-          sha256 = "67e9df91870fd0af700df924173e3009ea7ff6956e2c3c3bb86065d6070d0fd6",
+          sha256 = "48647189aee6454ed9b9852fa700a77f92b39465c04c625901d165bc8e937afc",
         } | Source,
     } target,
     base,


### PR DESCRIPTION
## Update deno `2.8.1` → `2.8.2`

**Source:** `github:denoland/deno`
**Release:** https://github.com/denoland/deno/releases/tag/v2.8.2
**Changelog:** https://github.com/denoland/deno/compare/v2.8.1...v2.8.2
**Released:** 2 days ago (2026-06-03)

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `deno` | `2.8.1` | `2.8.2` |
| ~ | `deno-upstream` | `2.8.1` | `2.8.2` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `2.8.1` | `2.8.2` |
| **SHA256** | `67e9df91870fd0af...` | `184da7a5267ab649...` |
| **Size** |  | 43.8 MB |
| **Source** | `https://github.com/denoland/deno/releases/download/v2.8.1/deno-aarch64-unknown-linux-gnu.zip` | `https://github.com/denoland/deno/releases/download/v2.8.2/deno-x86_64-unknown-linux-gnu.zip` |

- **License:** `MIT` _(source: GitHub + tarball)_

### Per-arch sources

| Arch | New SHA256 | Size | URL |
|---|---|---|---|
| `Amd64` | `184da7a5267ab649...` (was `2d7bb6195226ac83...`) | 43.8 MB | `https://github.com/denoland/deno/releases/download/v2.8.2/deno-x86_64-unknown-linux-gnu.zip` |
| `Arm64` | `48647189aee6454e...` (was `67e9df91870fd0af...`) | 42.1 MB | `https://github.com/denoland/deno/releases/download/v2.8.2/deno-aarch64-unknown-linux-gnu.zip` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
