### PR TITLE
Update uv to 0.11.19

### DIFF
--- a/packages/uv/build.ncl
+++ b/packages/uv/build.ncl
@@ -6,14 +6,14 @@ let make = import "../make/build.ncl" in
 let rust = import "../rust/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "0.11.15" in
+let version = "0.11.19" in
 {
   name = "uv",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/uv-%{version}.tar.gz",
-      sha256 = "78d3070b6add2d8f5a28d5781c938b75d2e861736cfe6bf7a88757c395f10a2e"
+      sha256 = "316a5fb9fca079064265a8007979e0057b68317b6a6693e15554d3d9112cce9c"
     } | Source,
     base,
     make,


### PR DESCRIPTION
## Update uv `0.11.15` → `0.11.19`

**Source:** `github:astral-sh/uv`
**Release:** https://github.com/astral-sh/uv/releases/tag/0.11.19
**Changelog:** https://github.com/astral-sh/uv/compare/0.11.15...0.11.19
**Released:** 1 days ago (2026-06-03)

> [!WARNING]
> **Pkgscan: 1 new signal introduced by this update** (risk score 2.0).
> Diff against the prior version surfaced patterns that weren't present before. Review carefully before merging — supply-chain attacks land via version-bump injection.
>
> | Severity | File | Line | Capability (MBC) | Pattern |
> |---|---|---:|---|---|
> | MEDIUM | `uv (upstream release)` | 0 | `metadata/recent-bump` | `upstream release <48h ago` |

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `uv` | `0.11.15` | `0.11.19` |
| ~ | `uv-upstream` | `0.11.15` | `0.11.19` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `0.11.15` | `0.11.19` |
| **SHA256** | `78d3070b6add2d8f...` | `316a5fb9fca07906...` |
| **Size** | 5.3 MB | 5.4 MB |
| **Source** | `gs://minimal-staging-archives/uv-0.11.15.tar.gz` | `gs://minimal-staging-archives/uv-0.11.19.tar.gz` |

- **License:** `MIT OR Apache-2.0` _(source: GitHub + tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
