### PR TITLE
Update ffmpeg to 8.1.1

### DIFF
--- a/packages/ffmpeg/build.ncl
+++ b/packages/ffmpeg/build.ncl
@@ -21,14 +21,14 @@ let openssl = import "../openssl/build.ncl" in
 let xz = import "../xz/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "8.1" in
+let version = "8.1.1" in
 {
   name = "ffmpeg",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://ffmpeg.org/releases/ffmpeg-%{version}.tar.xz",
-      sha256 = "b072aed6871998cce9b36e7774033105ca29e33632be5b6347f3206898e0756a",
+      sha256 = "b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3",
       extract = true,
       strip_prefix = "ffmpeg-%{version}",
     } | Source,
@@ -70,6 +70,7 @@ let version = "8.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)",
       repology_project = "ffmpeg",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
## Update ffmpeg `8.1` → `8.1.1`

**Source:** `github:FFmpeg/FFmpeg:tag`
**Release:** https://github.com/FFmpeg/FFmpeg/releases/tag/n8.1.1
**Changelog:** https://github.com/FFmpeg/FFmpeg/compare/n8.1...n8.1.1
**Released:** 32 days ago (2026-05-03)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `ffmpeg` | `8.1` | `8.1.1` |
| ~ | `ffmpeg-upstream` | `8.1` | `8.1.1` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `8.1` | `8.1.1` |
| **SHA256** | `b072aed6871998cc...` | `b6863adde98898f4...` |
| **Size** |  | 11.7 MB |
| **Source** | `https://ffmpeg.org/releases/ffmpeg-8.1.tar.xz` | `https://ffmpeg.org/releases/ffmpeg-8.1.1.tar.xz` |

- **License:** `(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)` _(source: tarball)_

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
