### PR TITLE
Update go to 1.26.4

### DIFF
--- a/packages/go/build.ncl
+++ b/packages/go/build.ncl
@@ -3,7 +3,7 @@ let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "1.26.2" in
+let version = "1.26.4" in
 let variants = {
   amd64_url = "https://go.dev/dl/go%{version}.linux-amd64.tar.gz",
   amd64_sha256 = "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282",
@@ -23,12 +23,12 @@ in
       { arch = 'Amd64, .. } =>
         {
           url = variants.amd64_url,
-          sha256 = variants.amd64_sha256,
+          sha256 = "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = variants.arm64_url,
-          sha256 = variants.arm64_sha256,
+          sha256 = "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768",
         } | Source,
     } target,
     {
@@ -74,6 +74,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       repology_project = "go",
 
       # When Go is used in a task environment, a `gocache` directory is created

--- a/packages/go/build.ncl
+++ b/packages/go/build.ncl
@@ -6,13 +6,13 @@ let toolchain = import "../toolchain/build.ncl" in
 let version = "1.26.4" in
 let variants = {
   amd64_url = "https://go.dev/dl/go%{version}.linux-amd64.tar.gz",
-  amd64_sha256 = "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282",
+  amd64_sha256 = "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f",
 
   arm64_url = "https://go.dev/dl/go%{version}.linux-arm64.tar.gz",
-  arm64_sha256 = "c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23",
+  arm64_sha256 = "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768",
 
   source_url = "https://go.dev/dl/go%{version}.src.tar.gz",
-  source_sha256 = "2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b",
+  source_sha256 = "4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d",
 }
 in
 {
@@ -23,12 +23,12 @@ in
       { arch = 'Amd64, .. } =>
         {
           url = variants.amd64_url,
-          sha256 = "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f",
+          sha256 = variants.amd64_sha256,
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = variants.arm64_url,
-          sha256 = "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768",
+          sha256 = variants.arm64_sha256,
         } | Source,
     } target,
     {


### PR DESCRIPTION
## Update go `1.26.2` → `1.26.4`

**Source:** `github:golang/go:tag`
**Release:** https://github.com/golang/go/releases/tag/go1.26.4
**Changelog:** https://github.com/golang/go/compare/go1.26.2...go1.26.4
**Released:** 3 days ago (2026-06-02)

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `go` | `1.26.2` | `1.26.4` |
| ~ | `go-upstream` | `1.26.2` | `1.26.4` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.26.2` | `1.26.4` |
| **SHA256** | `c958a1fe1b361391...` | `1153d3d50e0ac764...` |
| **Size** |  | 66.9 MB |
| **Source** | `https://go.dev/dl/go1.26.2.linux-arm64.tar.gz` | `variants.amd64_url` |

- **License:** `BSD-3-Clause` _(source: GitHub + tarball)_

### Per-arch sources

| Arch | New SHA256 | Size | URL |
|---|---|---|---|
| `Amd64` | `1153d3d50e0ac764...` (was `990e6b4bbba816dc...`) | 66.9 MB | `variants.amd64_url` |
| `Arm64` | `ef758ae7c6cf9267...` (was `c958a1fe1b361391...`) | 63.7 MB | `variants.arm64_url` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
