### PR TITLE
Update redis to 8.6.4

### DIFF
--- a/packages/redis/build.ncl
+++ b/packages/redis/build.ncl
@@ -10,14 +10,14 @@ let linux_headers = import "../linux_headers/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
 
-let version = "8.6.3" in
+let version = "8.6.4" in
 {
   name = "redis",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/redis/redis/%{version}.tar.gz",
-      sha256 = "58d0d1eb49a1ea6c2179659707fec171b1e2e2b8d5157ed2ec59d1d66ad5a654",
+      sha256 = "a2029c96311ab1ec2ae489076ae900b6497b3beaa7dc379de26b5df48f696f6c",
       extract = true,
       strip_prefix = "redis-%{version}",
     } | Source,


### PR DESCRIPTION
## Update redis `8.6.3` → `8.6.4`

**Source:** `github:redis/redis:operator-pinned`
**Release:** https://github.com/redis/redis/releases/tag/8.6.4
**Changelog:** https://github.com/redis/redis/compare/8.6.3...8.6.4
**Released:** unknown _(non-GitHub source or tag-only fallback)_

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `redis` | `8.6.3` | `8.6.4` |
| ~ | `redis-upstream` | `8.6.3` | `8.6.4` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `8.6.3` | `8.6.4` |
| **SHA256** | `58d0d1eb49a1ea6c...` | `a2029c96311ab1ec...` |
| **Size** | 4.3 MB | 4.3 MB |
| **Source** | `gs://minimal-staging-archives/redis/redis/8.6.3.tar.gz` | `gs://minimal-staging-archives/redis/redis/8.6.4.tar.gz` |

### Quality suggestions

- **Missing `tests` block.** This package has no standalone tests, so the buildbot will only verify compilation — not functional correctness. Consider adding a minimal smoke test (e.g., a `--version` or small round-trip invocation) as part of this PR so future bumps catch regressions. See `packages/python/build.ncl` for a simple example.

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
