### PR TITLE
Update bun to 1.3.14

### DIFF
--- a/packages/bun/build.ncl
+++ b/packages/bun/build.ncl
@@ -19,11 +19,11 @@ let libtool = import "../libtool/build.ncl" in
 let unzip = import "../unzip/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.3.13" in
+let version = "1.3.14" in
 let dl_base = "https://github.com/oven-sh/bun/releases/download/bun-v%{version}" in
 let { amd64_sha256, arm64_sha256 } = {
-  amd64_sha256 = "79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a",
-  arm64_sha256 = "70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22",
+  amd64_sha256 = "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f",
+  arm64_sha256 = "a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b",
 }
 in
 {
@@ -32,7 +32,7 @@ in
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/oven-sh/bun/archive/refs/tags/bun-v%{version}.tar.gz",
-      sha256 = "8cd7b2fd45df28546155f921541c35d2df265a591483853c7c54961ddfbcef7c",
+      sha256 = "112a5915992807f04b183854d360c2bf87ac7c1587fb5da3c560bdbb75b8c92e",
       extract = true,
       strip_prefix = "bun-bun-v%{version}",
     } | Source,

--- a/packages/bun/build.sh
+++ b/packages/bun/build.sh
@@ -29,9 +29,16 @@ export CFLAGS="$MARCH -O3 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
 
-# Remove rust-toolchain.toml to avoid rustup nightly requirement;
-# our stable rust is sufficient for lol-html
+# bun pins a nightly toolchain via rust-toolchain.toml; remove it so the build
+# uses minimal's stable rust. As of 1.3.14 that alone isn't enough — the release
+# lol-html build opts into -Zbuild-std + -Cpanic=immediate-abort (nightly-only,
+# to shave ~230KB). Route lol-html to bun's existing stable -Cpanic=abort path
+# (precompiled std) instead; the verify-grep makes a future bun build-script
+# change fail loudly rather than silently revert to the broken nightly path.
+# See gominimal/pkgs#228.
 rm -f rust-toolchain.toml
+sed -i 's|if (cfg.release && canBuildStdImmediateAbort) {|if (false) { // minimal: stable rust, no -Zbuild-std (pkgs#228)|' scripts/build/deps/lolhtml.ts
+grep -q 'no -Zbuild-std (pkgs#228)' scripts/build/deps/lolhtml.ts || { echo "ERROR: lol-html stable-build patch did not apply — bun's build scripts changed; revisit gominimal/pkgs#228." >&2; exit 1; }
 
 # Initialize a git repo so nested dep version generation works
 # (it runs "git rev-parse HEAD" to get version strings for bundled packages)


### PR DESCRIPTION
## Update bun `1.3.13` → `1.3.14`

**Source:** `github:oven-sh/bun`
**Release:** https://github.com/oven-sh/bun/releases/tag/bun-v1.3.14
**Changelog:** https://github.com/oven-sh/bun/compare/bun-v1.3.13...bun-v1.3.14
**Released:** 23 days ago (2026-05-13)

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `bun` | `1.3.13` | `1.3.14` |
| ~ | `bun-upstream` | `1.3.13` | `1.3.14` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `1.3.13` | `1.3.14` |
| **SHA256** | `8cd7b2fd45df2854...` | `951ee2aee855f085...` |
| **Size** |  | 36.0 MB |
| **Source** | `https://github.com/oven-sh/bun/archive/refs/tags/bun-v1.3.13.tar.gz` | `%{dl_base}/bun-linux-x64.zip` |

### Per-arch sources

| Arch | New SHA256 | Size | URL |
|---|---|---|---|
| `Amd64` | `951ee2aee855f085...` (was `79c0771fa8b92c33...`) | 36.0 MB | `%{dl_base}/bun-linux-x64.zip` |
| `Arm64` | `a27ffb63a8310375...` (was `70bae41b3908b0a1...`) | 35.7 MB | `%{dl_base}/bun-linux-aarch64.zip` |

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Bun package to version 1.3.14 with corresponding checksums.
  * Adjusted the build process to enforce stable toolchain compatibility and ensure reproducible builds, with safeguards that stop the build if expected patching is not applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->