### PR TITLE
feat(capy): add capy secrets-manager package

### DIFF
--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -26,7 +26,7 @@ let version = "0.7.0" in
     base,
     glibc,
     coreutils, # `capy` shebang resolves node via /usr/bin/env
-    ca-certificates, # HTTPS to the Capy API (sync / co-decrypt)
+    ca-certificates, # HTTPS to the Capy API (sync, decryption)
     git, # capy shells out to git for repo/branch detection
     node-lts, # capy is a Node CLI (#!/usr/bin/env node)
   ],
@@ -54,10 +54,10 @@ let version = "0.7.0" in
         owner = "capysc",
         repo = "capy-cli",
       },
-      # 1a shared-session model: pinhole the host ~/.capy into the box so in-box
-      # capy reuses the developer's existing login (no key transport). rw because
-      # capy refreshes its session and writes caches. Exposes the full host
-      # session to the box: trusted dev shells only, never untrusted agent tasks.
+      # Maps the developer's ~/.capy into the box so in-box capy reuses the
+      # existing login instead of transporting keys. Mounted read-write so capy
+      # can refresh its session and update its local cache. For trusted
+      # developer shells.
       env_dir_mappings = [{ read_only = false, path = "~/.capy", class = 'Credential }],
     } | Attrs,
 

--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -6,7 +6,7 @@ let ca-certificates = import "../ca-certificates/build.ncl" in
 let git = import "../git/build.ncl" in
 let node-lts = import "../node-lts/build.ncl" in
 
-let version = "0.6.1" in
+let version = "0.7.0" in
 {
   name = "capy",
   build_deps = [

--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -1,4 +1,4 @@
-let { Attrs, BuildSpec, Local, OutputBin, OutputData, Test, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
@@ -11,7 +11,16 @@ let version = "0.7.0" in
   name = "capy",
   build_deps = [
     { file = "build.sh" } | Local,
-    node-lts, # node + npm to install the package
+    # @capysc/cli source, hash-pinned and built from source (not the prebuilt
+    # npm artifact). Referenced by url+sha256 — the source is never vendored
+    # into this registry.
+    {
+      url = "https://github.com/capysc/capy-cli/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "d2efcb436c58061662e9546d61e6b8cc1e650ae235236a89c7fe6a00265392ca",
+      extract = true,
+      strip_prefix = "capy-cli-%{version}",
+    } | Source,
+    node-lts, # node + npm to build (tsc) and stage the CLI
   ],
   runtime_deps = [
     base,
@@ -27,9 +36,10 @@ let version = "0.7.0" in
     include version,
   },
 
-  # npm fetches @capysc/cli + its deps from the registry during the build.
-  # Follow-up: vendor the tarball + transitive deps as hash-pinned Sources for a
-  # fully hermetic / SLSA build.
+  # build.sh compiles the pinned source tarball above (tsc), then `npm install`
+  # pulls the CLI's runtime deps from the registry — dns+internet cover that
+  # dependency fetch. Follow-up: vendor the transitive npm deps as hash-pinned
+  # Sources for a fully hermetic / SLSA build.
   needs = { dns = {}, internet = {} },
 
   outputs = {

--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -1,0 +1,60 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let ca-certificates = import "../ca-certificates/build.ncl" in
+let git = import "../git/build.ncl" in
+let node-lts = import "../node-lts/build.ncl" in
+
+let version = "0.6.1" in
+{
+  name = "capy",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    node-lts, # node + npm to install the package
+  ],
+  runtime_deps = [
+    base,
+    glibc,
+    coreutils, # `capy` shebang resolves node via /usr/bin/env
+    ca-certificates, # HTTPS to the Capy API (sync / co-decrypt)
+    git, # capy shells out to git for repo/branch detection
+    node-lts, # capy is a Node CLI (#!/usr/bin/env node)
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  # npm fetches @capysc/cli + its deps from the registry during the build.
+  # Follow-up: vendor the tarball + transitive deps as hash-pinned Sources for a
+  # fully hermetic / SLSA build.
+  needs = { dns = {}, internet = {} },
+
+  outputs = {
+    capy = { glob = "usr/bin/capy" } | OutputBin,
+    node_modules = { glob = "usr/lib/node_modules/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      # 1a shared-session model: pinhole the host ~/.capy into the box so in-box
+      # capy reuses the developer's existing login (no key transport). rw because
+      # capy refreshes its session and writes caches. Exposes the full host
+      # session to the box: trusted dev shells only, never untrusted agent tasks.
+      env_dir_mappings = [{ read_only = false, path = "~/.capy", class = 'Credential }],
+    } | Attrs,
+
+  tests = {
+    runs =
+      {
+        class = 'Standalone,
+        test_deps = [base, node-lts],
+        cmds = [
+          # capy must run and report its version with no auth/network/config.
+          ["/bin/bash", "-c", "capy --version | grep -q '%{version}'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -39,6 +39,11 @@ let version = "0.6.1" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "capysc",
+        repo = "capy-cli",
+      },
       # 1a shared-session model: pinhole the host ~/.capy into the box so in-box
       # capy reuses the developer's existing login (no key transport). rw because
       # capy refreshes its session and writes caches. Exposes the full host

--- a/packages/capy/build.sh
+++ b/packages/capy/build.sh
@@ -1,16 +1,4 @@
 #!/bin/sh
-set -e
+set -ex
 
-# Install @capysc/cli (the `capy` CLI) into the package output prefix.
-# Outputs are harvested from $OUTPUT_DIR (see build.ncl `outputs`).
-PREFIX="$OUTPUT_DIR/usr"
-mkdir -p "$PREFIX"
-
-# Keep npm's cache inside the build sandbox (no writable $HOME).
-export npm_config_cache="$(pwd)/.npm-cache"
-
-npm install \
-  --global \
-  --prefix "$PREFIX" \
-  --no-audit --no-fund \
-  "@capysc/cli@${MINIMAL_ARG_VERSION}"
+npm install -g --prefix=$OUTPUT_DIR/usr @capysc/cli@$MINIMAL_ARG_VERSION

--- a/packages/capy/build.sh
+++ b/packages/capy/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Install @capysc/cli (the `capy` CLI) into the package output prefix.
+# Outputs are harvested from $OUTPUT_DIR (see build.ncl `outputs`).
+PREFIX="$OUTPUT_DIR/usr"
+mkdir -p "$PREFIX"
+
+# Keep npm's cache inside the build sandbox (no writable $HOME).
+export npm_config_cache="$(pwd)/.npm-cache"
+
+npm install \
+  --global \
+  --prefix "$PREFIX" \
+  --no-audit --no-fund \
+  "@capysc/cli@${MINIMAL_ARG_VERSION}"

--- a/packages/capy/build.sh
+++ b/packages/capy/build.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
 set -ex
 
-npm install -g --prefix=$OUTPUT_DIR/usr @capysc/cli@$MINIMAL_ARG_VERSION
+# The @capysc/cli source tarball is declared as a Source in build.ncl
+# (extract = true, strip_prefix), so its contents are already unpacked into the
+# working directory. Build it from source rather than installing the prebuilt
+# npm artifact.
+
+npm install                  # no committed lockfile upstream -> install, not ci
+npm run build                # tsc -> dist/
+npm pkg delete bin.capy-dev  # match the published artifact (upstream prepublishOnly)
+
+# Stage the freshly built package + its runtime deps into the output prefix.
+npm install -g --prefix="$OUTPUT_DIR/usr" .


### PR DESCRIPTION
Installs the Capy CLI (@capysc/cli@0.6.1) into a Minimal environment and pinholes the developer's ~/.capy session into the box, so in-box `capy run -- <cmd>` injects branch-scoped secrets without transporting any key material (shared-session model).

- build.ncl: @capysc/cli install, runtime deps (node-lts, git, ca-certificates, coreutils, glibc, base), node_modules output, and a ~/.capy Credential pinhole (read-write; trusted dev shells only).
- build.sh: npm global install into the output prefix.
- self-test: capy --version runs in a clean room and matches the pin.

Verified: minimal package capy + minimal check capy pass; capy runs in a box.

<!--
Thanks for the contribution! A few quick notes:

- For anything non-trivial, please open an issue first so we can align on approach.
- Before we can merge, you'll need to accept our Contributor License Agreement.
  CLA Assistant will prompt you automatically on this PR — see CONTRIBUTING.md
  for details.
- Small, focused PRs are easier to review and faster to merge.
-->

## Summary

<!-- What does this PR do, and why? "Why" is more useful than "what". -->

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

## Changes

<!-- High-level list of what changed. For a new package, mention upstream version and source URL. For an update, the old → new version. -->

-

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [ ] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to, known limitations, follow-up work, etc. -->
