### PR TITLE
microvm-rootfs: don't delete libssl with the e2fsprogs cleanup

### DIFF
--- a/packages/microvm-rootfs/build.sh
+++ b/packages/microvm-rootfs/build.sh
@@ -31,7 +31,9 @@ if [ -d "$STAGE/usr/sbin" ] && [ ! -L "$STAGE/usr/sbin" ]; then
 fi
 rm -f "$STAGE"/usr/bin/chattr "$STAGE"/usr/bin/lsattr "$STAGE"/usr/bin/uuidgen \
       "$STAGE"/usr/bin/compile_et "$STAGE"/usr/bin/mk_cmds
-rm -f "$STAGE"/usr/lib/libext2fs*.so* "$STAGE"/usr/lib/libe2p*.so* "$STAGE"/usr/lib/libss*.so*
+# Note: `libss.so*` (not `libss*.so*`) — the latter also matches openssl's
+# libssl.so, which socat needs at runtime.
+rm -f "$STAGE"/usr/lib/libext2fs.so* "$STAGE"/usr/lib/libe2p.so* "$STAGE"/usr/lib/libss.so*
 
 mkdir -p "$STAGE/bin" "$STAGE/sbin" "$STAGE/etc/microvm"
 


### PR DESCRIPTION
Follow-up to #229. The e2fsprogs lib-removal glob `libss*.so*` greedily matched openssl's `libssl.so.3` (socat links it), so the built `microvm-rootfs` image shipped a `socat` that failed at load:

```
socat: error while loading shared libraries: libssl.so.3: cannot open shared object file
```

The guest init never emitted READY → microVM boot times out. Caught while wiring the downstream consumer to the merged package.

**Fix:** tighten the glob to `libss.so*` (e2fsprogs's `libss.so.2` only, not `libssl`). Tightened the other two e2fs libs to `lib<name>.so*` for precision too.

**Verified** against a rebuilt image: `libssl.so.3`/`libcrypto.so.3` present, e2fsprogs `libss.so`/`libext2fs`/`mke2fs` still excluded, and the image boots to READY under libkrun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build script for more precise handling of staged runtime libraries during rootfs generation, with improved documentation of the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->