### PR TITLE
mono: migrate source to GitHub tag via gs:// mirror (6.12.0.199 → 6.12.0.206)

### DIFF
--- a/packages/mono/build.ncl
+++ b/packages/mono/build.ncl
@@ -6,6 +6,7 @@ let cmake = import "../cmake/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let libtool = import "../libtool/build.ncl" in
+let m4 = import "../m4/build.ncl" in
 let make = import "../make/build.ncl" in
 let perl = import "../perl/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
@@ -13,20 +14,27 @@ let python = import "../python/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "6.12.0.199" in
+let version = "6.12.0.206" in
 {
   name = "mono",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "https://download.mono-project.com/sources/mono/mono-%{version}.tar.xz",
-      sha256 = "c0850d545353a6ba2238d45f0914490c6a14a0017f151d3905b558f033478ef5",
+      # Sourced from the GitHub tag `mono-%{version}` (commit 0cbf0e2),
+      # mirrored to our archive bucket. The mono/mono GitHub repo has no
+      # release asset, and download.mono-project.com is Microsoft-archived
+      # infra (last touched 2024) that may disappear; this is a prepared
+      # `git archive --recurse-submodules` of the tag (source + the
+      # external/ submodules bundled, autotools generated at build time).
+      url = "gs://minimal-staging-archives/mono/mono/mono-%{version}.tar.gz",
+      sha256 = "c4074f319f801711f23aad8e52c8d8752405b2966d2566bccd2ab23e326ff146",
     } | Source,
     autoconf,
     automake,
     base,
     cmake,
     libtool,
+    m4,
     make,
     perl,
     pkgconf,

--- a/packages/mono/build.sh
+++ b/packages/mono/build.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 set -e
 
-tar -xof "mono-${MINIMAL_ARG_VERSION}.tar.xz"
+tar -xof "mono-${MINIMAL_ARG_VERSION}.tar.gz"
 cd "mono-${MINIMAL_ARG_VERSION}"
+
+# The prepared tarball was archived on macOS, which scatters AppleDouble
+# "._*" sidecar files through the tree. mono's C# build globs `*.cs` and
+# feeds these binary sidecars to the compiler (CS1056 "unexpected character"
+# on e.g. external/cecil/Mono.Cecil.PE/._TextMap.cs). Strip them all.
+find . -name '._*' -type f -delete
 
 # Provide a 'which' shim (not present in the sandbox, needed by BTLS Makefile)
 mkdir -p shims
@@ -34,6 +40,10 @@ sed -i 's/cmake_minimum_required (VERSION 2\.8\.10)/cmake_minimum_required (VERS
   mono/btls/CMakeLists.txt \
   external/boringssl/CMakeLists.txt
 
+# The GitHub-sourced tarball ships the raw tag tree (no generated
+# `configure`), so regenerate the autotools build system first. mono's
+# autogen.sh runs autoreconf and then invokes ./configure with "$@".
+NOCONFIGURE=1 ./autogen.sh
 ./configure \
   --prefix=/usr \
   --sysconfdir=/usr/etc \


### PR DESCRIPTION
## mono: migrate source to GitHub tag + gs:// mirror

Migrates mono off `download.mono-project.com` — a Microsoft-archived Azure blob (last modified 2024-05) that could vanish and leave the package unsourceable — to our archive bucket, sourced from the GitHub tag. (task #134)

### What changed
- **Source** → `gs://minimal-staging-archives/mono/mono/mono-%{version}.tar.gz`, a prepared `git archive --recurse-submodules` of GitHub tag `mono-6.12.0.206` (commit `0cbf0e2`). The mono/mono repo has **no release asset** and the GitHub auto-archive **omits the `external/` submodules**, so the prepared tarball bundles the full source + submodule trees (boringssl / bdwgc / llvm-project / cecil / …). sha256 pinned.
- **Version** `6.12.0.199 → 6.12.0.206`. `.199` only ever existed as a mono-project.com release blob, so it can't be sourced from GitHub at all; moved to the latest tag (a 7-commit patch range).
- **`build.sh`**:
  - `.tar.xz` → `.tar.gz`.
  - The prepared tarball ships the raw tag tree (**no generated `configure`**), so it now runs `NOCONFIGURE=1 ./autogen.sh` first to regenerate the autotools build system (+ `m4` build dep, matching `packages/check`).
  - Strips the AppleDouble `._*` sidecar files the macOS archiver scattered through the tree — mono's `*.cs` glob otherwise feeds these binary sidecars to the C# compiler (`CS1056 "unexpected character"` on e.g. `external/cecil/Mono.Cecil.PE/._TextMap.cs`).

### Verification (built locally before opening)
Clean-room build (`minimal package mono`, arm64/linux) verified end-to-end through **fetch → sha256 verify → extract → `._*` strip → `autogen.sh` → `configure` → `make`**, past the `external/cecil` class-lib compile that the `._*` strip fixes. Handing the full build to buildbot from here (faster than a local machine for mono).

### Reviewer notes
- The `._*` strip is defensive and recurrence-safe (protects any future macOS-prepared mono tarball). The alternative is re-uploading a cleaned tarball with a new sha256 — happy to switch if you'd rather the hosted artifact be `._*`-free at rest.
- `source_provenance` stays `GithubRepo mono/mono` (consistent with how `age`/`acl`/etc. declare a GithubRepo provenance while sourcing the bytes from the `gs://` mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mono runtime to version 6.12.0.206.
  * Improved build process with updated package source and extraction method.
  * Enhanced build system configuration for compatibility with source distribution format.
  * Removed macOS-specific sidecar files during build to prevent potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->