### PR TITLE
build.ncl: declare + cross-source audit license_spdx (282 declared, 38 corrected; infra#193 follow-up)

### DIFF
--- a/packages/abseil-cpp/build.ncl
+++ b/packages/abseil-cpp/build.ncl
@@ -41,6 +41,7 @@ let version = "20250814.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "abseil",

--- a/packages/acl/build.ncl
+++ b/packages/acl/build.ncl
@@ -54,6 +54,7 @@ let version = "2.3.2" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "(GPL-2.0-only AND LGPL-2.1-only)",
   },
 
   replace_on_cycle =

--- a/packages/actions-runner/build.ncl
+++ b/packages/actions-runner/build.ncl
@@ -67,6 +67,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       env_state_wiring = {
         env_var = "RUNNER_HOME",
         prefix = "actions-runner",

--- a/packages/age/build.ncl
+++ b/packages/age/build.ncl
@@ -40,6 +40,7 @@ let version = "1.3.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "FiloSottile",

--- a/packages/agent-browser/build.ncl
+++ b/packages/agent-browser/build.ncl
@@ -52,6 +52,7 @@ let version = "0.15.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "vercel-labs",

--- a/packages/alex/build.ncl
+++ b/packages/alex/build.ncl
@@ -38,5 +38,6 @@ let version = "3.5.1.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-3-Clause",
   },
 } | BuildSpec

--- a/packages/alsa-lib/build.ncl
+++ b/packages/alsa-lib/build.ncl
@@ -43,6 +43,7 @@ let version = "1.2.15.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1-only",
       repology_project = "alsa-lib",
     } | Attrs,
 } | BuildSpec

--- a/packages/ast-grep/build.ncl
+++ b/packages/ast-grep/build.ncl
@@ -40,6 +40,7 @@ let version = "0.42.1" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "MIT",
     source_provenance = {
       category = 'GithubRepo,
       owner = "ast-grep",

--- a/packages/at-spi2-core/build.ncl
+++ b/packages/at-spi2-core/build.ncl
@@ -44,5 +44,6 @@ let version = "2.54.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1-only",
     } | Attrs,
 } | BuildSpec

--- a/packages/atk/build.ncl
+++ b/packages/atk/build.ncl
@@ -50,5 +50,6 @@ let version = "2.38.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.0-only",
     } | Attrs,
 } | BuildSpec

--- a/packages/attr/build.ncl
+++ b/packages/attr/build.ncl
@@ -55,6 +55,7 @@ let version = "2.5.2" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "(GPL-2.0-only AND LGPL-2.1-only)",
   },
 
   replace_on_cycle =

--- a/packages/atuin/build.ncl
+++ b/packages/atuin/build.ncl
@@ -35,6 +35,7 @@ let version = "18.12.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "atuinsh",

--- a/packages/autoconf/build.ncl
+++ b/packages/autoconf/build.ncl
@@ -33,7 +33,7 @@ let version = "2.73" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-3.0-or-later WITH Autoconf-exception-generic-3.0",
+      license_spdx = "GPL-3.0-or-later WITH Autoconf-exception-3.0",
       source_provenance = {
         category = 'GnuProject,
         name = "autoconf",

--- a/packages/autoconf/build.ncl
+++ b/packages/autoconf/build.ncl
@@ -33,6 +33,7 @@ let version = "2.73" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "autoconf",

--- a/packages/autoconf/build.ncl
+++ b/packages/autoconf/build.ncl
@@ -33,7 +33,7 @@ let version = "2.73" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
+      license_spdx = "GPL-3.0-or-later WITH Autoconf-exception-generic-3.0",
       source_provenance = {
         category = 'GnuProject,
         name = "autoconf",

--- a/packages/automake/build.ncl
+++ b/packages/automake/build.ncl
@@ -47,6 +47,7 @@ let version = "1.18.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       repology_project = "automake",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/bash-bootstrap/build.ncl
+++ b/packages/bash-bootstrap/build.ncl
@@ -49,6 +49,7 @@ let version = "5.3" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-3.0-only",
   },
 
   replace_on_cycle =

--- a/packages/bash-language-server/build.ncl
+++ b/packages/bash-language-server/build.ncl
@@ -34,5 +34,6 @@ let version = "5.4.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/bash/build.ncl
+++ b/packages/bash/build.ncl
@@ -58,6 +58,7 @@ let version = "5.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "bash",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/bat/build.ncl
+++ b/packages/bat/build.ncl
@@ -42,6 +42,7 @@ let version = "0.26.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "sharkdp",

--- a/packages/bc/build.ncl
+++ b/packages/bc/build.ncl
@@ -35,6 +35,7 @@ let version = "7.0.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
       repology_project = "bc-gh",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/biff/build.ncl
+++ b/packages/biff/build.ncl
@@ -35,6 +35,7 @@ let version = "0.1.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Unlicense",
       source_provenance = {
         category = 'GithubRepo,
         owner = "BurntSushi",

--- a/packages/binutils-arm-none-eabi/build.ncl
+++ b/packages/binutils-arm-none-eabi/build.ncl
@@ -41,6 +41,7 @@ let version = "2.43.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.0-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "binutils",

--- a/packages/binutils/build.ncl
+++ b/packages/binutils/build.ncl
@@ -85,6 +85,7 @@ let version = "2.46.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.0-only)",
       repology_project = "binutils",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/bison/build.ncl
+++ b/packages/bison/build.ncl
@@ -71,6 +71,7 @@ let version = "3.8.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "bison",

--- a/packages/bottom/build.ncl
+++ b/packages/bottom/build.ncl
@@ -37,6 +37,7 @@ let version = "0.12.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "bottom",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/bun/build.ncl
+++ b/packages/bun/build.ncl
@@ -87,6 +87,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       env_state_wiring = {
         env_var = "BUN_INSTALL_CACHE_DIR",
         prefix = "bun-cache",

--- a/packages/bzip2/build.ncl
+++ b/packages/bzip2/build.ncl
@@ -68,6 +68,7 @@ let version = "1.0.8" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "bzip2-1.0.6",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libarchive",

--- a/packages/bzip3/build.ncl
+++ b/packages/bzip3/build.ncl
@@ -48,6 +48,7 @@ let version = "1.5.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-3.0",
       repology_project = "bzip3",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/bzip3/build.ncl
+++ b/packages/bzip3/build.ncl
@@ -48,7 +48,7 @@ let version = "1.5.3" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-3.0",
+      license_spdx = "LGPL-3.0-only",
       repology_project = "bzip3",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/c-ares/build.ncl
+++ b/packages/c-ares/build.ncl
@@ -37,6 +37,7 @@ let version = "1.34.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "c-ares",

--- a/packages/ca-certificates/build.ncl
+++ b/packages/ca-certificates/build.ncl
@@ -19,6 +19,7 @@ let openssl = import "../openssl/build.ncl" in
 
   attrs =
     {
+      license_spdx = "MPL-2.0",
       needed_for_internet = {},
     } | Attrs,
 } | BuildSpec

--- a/packages/cabal/build.ncl
+++ b/packages/cabal/build.ncl
@@ -44,6 +44,7 @@ let version = "3.12.1.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "haskell",

--- a/packages/cairo/build.ncl
+++ b/packages/cairo/build.ncl
@@ -45,5 +45,5 @@ let version = "1.18.4" in
     includes = { glob = "usr/include/**" } | OutputData,
   },
   attrs.upstream_version = version,
-  attrs.license_spdx = "(LGPL-2.1-only AND MPL-1.1)",
+  attrs.license_spdx = "LGPL-2.1-only OR MPL-1.1",
 } | BuildSpec

--- a/packages/cairo/build.ncl
+++ b/packages/cairo/build.ncl
@@ -45,4 +45,5 @@ let version = "1.18.4" in
     includes = { glob = "usr/include/**" } | OutputData,
   },
   attrs.upstream_version = version,
+  attrs.license_spdx = "(LGPL-2.1-only AND MPL-1.1)",
 } | BuildSpec

--- a/packages/check/build.ncl
+++ b/packages/check/build.ncl
@@ -47,6 +47,7 @@ let version = "0.15.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libcheck",

--- a/packages/check/build.ncl
+++ b/packages/check/build.ncl
@@ -47,7 +47,7 @@ let version = "0.15.2" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-2.1",
+      license_spdx = "LGPL-2.1-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libcheck",

--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -141,6 +141,7 @@ let browser_version = "147.0.7727.15" in
   attrs =
     {
       upstream_version = browser_version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "microsoft",

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -123,6 +123,7 @@ let browser_version = "147.0.7727.15" in
   attrs =
     {
       upstream_version = browser_version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "microsoft",

--- a/packages/clipper2/build.ncl
+++ b/packages/clipper2/build.ncl
@@ -42,6 +42,7 @@ let version = "2.0.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSL-1.0",
       repology_project = "clipper2",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/cloud-hypervisor/build.ncl
+++ b/packages/cloud-hypervisor/build.ncl
@@ -51,6 +51,7 @@ let version = "52.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0 AND BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "cloud-hypervisor",

--- a/packages/cmake/build.ncl
+++ b/packages/cmake/build.ncl
@@ -57,6 +57,7 @@ let version = "4.2.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       repology_project = "cmake",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/coreutils/build.ncl
+++ b/packages/coreutils/build.ncl
@@ -114,6 +114,7 @@ let version = "9.10" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "coreutils",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/cython/build.ncl
+++ b/packages/cython/build.ncl
@@ -41,6 +41,7 @@ let version = "3.2.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "cython",

--- a/packages/dav1d/build.ncl
+++ b/packages/dav1d/build.ncl
@@ -39,5 +39,6 @@ let version = "1.5.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
     } | Attrs,
 } | BuildSpec

--- a/packages/dbus/build.ncl
+++ b/packages/dbus/build.ncl
@@ -51,6 +51,6 @@ let version = "1.16.2" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(BSD-3-Clause-HP AND FSFULLRWD)",
+      license_spdx = "(AFL-2.1 OR GPL-2.0-or-later) AND GPL-2.0-or-later",
     } | Attrs,
 } | BuildSpec

--- a/packages/dbus/build.ncl
+++ b/packages/dbus/build.ncl
@@ -51,5 +51,6 @@ let version = "1.16.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(BSD-3-Clause-HP AND FSFULLRWD)",
     } | Attrs,
 } | BuildSpec

--- a/packages/dejagnu/build.ncl
+++ b/packages/dejagnu/build.ncl
@@ -31,6 +31,7 @@ let version = "1.6.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "dejagnu",

--- a/packages/delta/build.ncl
+++ b/packages/delta/build.ncl
@@ -44,6 +44,7 @@ let version = "0.18.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "dandavison",

--- a/packages/dfu-util/build.ncl
+++ b/packages/dfu-util/build.ncl
@@ -44,5 +44,6 @@ let version = "0.11" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-2.0-only",
   },
 } | BuildSpec

--- a/packages/diffoscope/build.ncl
+++ b/packages/diffoscope/build.ncl
@@ -27,5 +27,6 @@ let version = "306" in
   },
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-3.0-only",
   },
 } | BuildSpec

--- a/packages/difftastic/build.ncl
+++ b/packages/difftastic/build.ncl
@@ -37,6 +37,7 @@ let version = "0.67.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Wilfred",

--- a/packages/diffutils/build.ncl
+++ b/packages/diffutils/build.ncl
@@ -59,6 +59,7 @@ let version = "3.12" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "diffutils",

--- a/packages/dnsutils/build.ncl
+++ b/packages/dnsutils/build.ncl
@@ -58,6 +58,7 @@ let version = "9.20.20" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MPL-2.0",
     } | Attrs,
 
   tests = {

--- a/packages/duf/build.ncl
+++ b/packages/duf/build.ncl
@@ -37,6 +37,7 @@ let version = "0.9.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "duf",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/dust/build.ncl
+++ b/packages/dust/build.ncl
@@ -35,6 +35,7 @@ let version = "1.2.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "bootandy",

--- a/packages/e2fsprogs/build.ncl
+++ b/packages/e2fsprogs/build.ncl
@@ -50,5 +50,6 @@ let version = "1.47.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only AND LGPL-2.0-only AND BSD-3-Clause AND MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/elfutils/build.ncl
+++ b/packages/elfutils/build.ncl
@@ -52,6 +52,7 @@ let version = "0.194" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GFDL-1.3-invariants-only AND GPL-2.0-only AND GPL-3.0-only)",
       repology_project = "elfutils",
     } | Attrs,
 

--- a/packages/emacs-config-dev1/build.ncl
+++ b/packages/emacs-config-dev1/build.ncl
@@ -187,5 +187,7 @@ let typescript-language-server = import "../typescript-language-server/build.ncl
   },
 
   attrs =
-    {} | Attrs,
+    {
+      license_spdx = "GPL-3.0",
+    } | Attrs,
 } | BuildSpec

--- a/packages/emacs-config-dev1/build.ncl
+++ b/packages/emacs-config-dev1/build.ncl
@@ -188,6 +188,6 @@ let typescript-language-server = import "../typescript-language-server/build.ncl
 
   attrs =
     {
-      license_spdx = "GPL-3.0",
+      license_spdx = "GPL-3.0-or-later",
     } | Attrs,
 } | BuildSpec

--- a/packages/emacs/build.ncl
+++ b/packages/emacs/build.ncl
@@ -101,6 +101,7 @@ let version = "30.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "emacs",

--- a/packages/eudev/build.ncl
+++ b/packages/eudev/build.ncl
@@ -36,7 +36,7 @@ let version = "3.2.14" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0",
+      license_spdx = "LGPL-2.1-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "eudev-project",

--- a/packages/eudev/build.ncl
+++ b/packages/eudev/build.ncl
@@ -36,6 +36,7 @@ let version = "3.2.14" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "eudev-project",

--- a/packages/expat/build.ncl
+++ b/packages/expat/build.ncl
@@ -39,6 +39,7 @@ let version = "2.7.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "expat",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/expect/build.ncl
+++ b/packages/expect/build.ncl
@@ -40,5 +40,6 @@ let version = "5.45.4" in
   },
   attrs = {
     upstream_version = version,
+    license_spdx = "NIST-PD",
   },
 } | BuildSpec

--- a/packages/eza/build.ncl
+++ b/packages/eza/build.ncl
@@ -37,6 +37,7 @@ let version = "0.23.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "EUPL-1.2",
       source_provenance = {
         category = 'GithubRepo,
         owner = "eza-community",

--- a/packages/file/build.ncl
+++ b/packages/file/build.ncl
@@ -82,5 +82,6 @@ let version = "5.47" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause-Darwin",
     } | Attrs,
 } | BuildSpec

--- a/packages/findutils/build.ncl
+++ b/packages/findutils/build.ncl
@@ -62,6 +62,7 @@ let version = "4.10.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "findutils",
     } | Attrs,
 

--- a/packages/fio/build.ncl
+++ b/packages/fio/build.ncl
@@ -41,6 +41,7 @@ let version = "3.42" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "axboe",

--- a/packages/fio/build.ncl
+++ b/packages/fio/build.ncl
@@ -41,7 +41,7 @@ let version = "3.42" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0",
+      license_spdx = "GPL-2.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "axboe",

--- a/packages/fish/build.ncl
+++ b/packages/fish/build.ncl
@@ -63,6 +63,7 @@ let version = "4.5.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "fish-shell",

--- a/packages/flex/build.ncl
+++ b/packages/flex/build.ncl
@@ -37,6 +37,7 @@ let version = "2.6.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause-flex",
       source_provenance = {
         category = 'GithubRepo,
         owner = "westes",

--- a/packages/flit-core/build.ncl
+++ b/packages/flit-core/build.ncl
@@ -30,6 +30,7 @@ let version = "3.12.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/fontconfig/build.ncl
+++ b/packages/fontconfig/build.ncl
@@ -52,4 +52,5 @@ let version = "2.17.1" in
     fc-data = { glob = "{etc,usr/share/fontconfig}/**" } | OutputData,
   },
   attrs.upstream_version = version,
+  attrs.license_spdx = "HPND-sell-variant",
 } | BuildSpec

--- a/packages/foundationdb/build.ncl
+++ b/packages/foundationdb/build.ncl
@@ -65,6 +65,7 @@ let version = "7.3.69" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "apple",

--- a/packages/freetype/build.ncl
+++ b/packages/freetype/build.ncl
@@ -42,4 +42,5 @@ let version = "2.14.1" in
     includes = { glob = "usr/include/**" } | OutputData,
   },
   attrs.upstream_version = version,
+  attrs.license_spdx = "FTL OR GPL-2.0-or-later",
 } | BuildSpec

--- a/packages/fribidi/build.ncl
+++ b/packages/fribidi/build.ncl
@@ -40,6 +40,7 @@ let version = "1.0.16" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1",
       source_provenance = {
         category = 'GithubRepo,
         owner = "fribidi",

--- a/packages/fribidi/build.ncl
+++ b/packages/fribidi/build.ncl
@@ -40,7 +40,7 @@ let version = "1.0.16" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-2.1",
+      license_spdx = "LGPL-2.1-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "fribidi",

--- a/packages/gawk-bootstrap/build.ncl
+++ b/packages/gawk-bootstrap/build.ncl
@@ -42,6 +42,7 @@ let version = "5.3.2" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-3.0-only",
   },
 
   replace_on_cycle =

--- a/packages/gawk/build.ncl
+++ b/packages/gawk/build.ncl
@@ -48,6 +48,7 @@ let version = "5.4.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "gawk",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/gcc-arm-none-eabi/build.ncl
+++ b/packages/gcc-arm-none-eabi/build.ncl
@@ -61,6 +61,7 @@ let newlib_version = "4.4.0.20231231" in
   attrs =
     {
       upstream_version = gcc_version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "gcc",

--- a/packages/gcc/build.ncl
+++ b/packages/gcc/build.ncl
@@ -113,6 +113,7 @@ let version = "15.2.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)",
       repology_project = "gcc",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/gdbm/build.ncl
+++ b/packages/gdbm/build.ncl
@@ -37,6 +37,7 @@ let version = "1.26" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "gdbm",

--- a/packages/gettext/build.ncl
+++ b/packages/gettext/build.ncl
@@ -55,6 +55,7 @@ let version = "1.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "gettext",

--- a/packages/ghc-bootstrap/build.ncl
+++ b/packages/ghc-bootstrap/build.ncl
@@ -60,5 +60,6 @@ let version = "9.8.1" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-3-Clause",
   },
 } | BuildSpec

--- a/packages/ghc/build.ncl
+++ b/packages/ghc/build.ncl
@@ -83,6 +83,7 @@ let version = "9.10.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       build_cost_multiple = 6,
     } | Attrs,
 

--- a/packages/ghostscript/build.ncl
+++ b/packages/ghostscript/build.ncl
@@ -52,6 +52,7 @@ let version = "10.06.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "AGPL-3.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "ArtifexSoftware",

--- a/packages/glib/build.ncl
+++ b/packages/glib/build.ncl
@@ -50,5 +50,6 @@ let version = "2.86.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1-or-later",
     } | Attrs,
 } | BuildSpec

--- a/packages/glibc/build.ncl
+++ b/packages/glibc/build.ncl
@@ -92,6 +92,7 @@ let version = "2.42" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND LGPL-2.1-only)",
       repology_project = "glibc",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/gmp/build.ncl
+++ b/packages/gmp/build.ncl
@@ -95,6 +95,7 @@ let version = "6.3.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "gmp",

--- a/packages/gmp/build.ncl
+++ b/packages/gmp/build.ncl
@@ -95,7 +95,7 @@ let version = "6.3.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
+      license_spdx = "LGPL-3.0-or-later OR GPL-2.0-or-later",
       source_provenance = {
         category = 'GnuProject,
         name = "gmp",

--- a/packages/gnutls/build.ncl
+++ b/packages/gnutls/build.ncl
@@ -54,5 +54,6 @@ let version = "3.8.9" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-3.0-only AND LGPL-2.1-only)",
     } | Attrs,
 } | BuildSpec

--- a/packages/golangci-lint/build.ncl
+++ b/packages/golangci-lint/build.ncl
@@ -37,6 +37,7 @@ let version = "2.12.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "golangci",

--- a/packages/gopls/build.ncl
+++ b/packages/gopls/build.ncl
@@ -37,6 +37,7 @@ let version = "0.21.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "golang",

--- a/packages/govulncheck/build.ncl
+++ b/packages/govulncheck/build.ncl
@@ -37,6 +37,7 @@ let version = "1.1.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "golang",

--- a/packages/gperf/build.ncl
+++ b/packages/gperf/build.ncl
@@ -34,6 +34,7 @@ let version = "3.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "gperf",

--- a/packages/gradle/build.ncl
+++ b/packages/gradle/build.ncl
@@ -34,6 +34,7 @@ let version = "9.3.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       env_state_wiring = {
         env_var = "GRADLE_USER_HOME",
         prefix = "gradle",

--- a/packages/grafana/build.ncl
+++ b/packages/grafana/build.ncl
@@ -51,6 +51,7 @@ let arm64_sha256 = "825e31eb0aafcf026d7f04dd540042eedef42cb81a3d2832c296b27dacf7
   attrs =
     {
       upstream_version = version,
+      license_spdx = "AGPL-3.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "grafana",

--- a/packages/grafana/build.ncl
+++ b/packages/grafana/build.ncl
@@ -51,7 +51,7 @@ let arm64_sha256 = "825e31eb0aafcf026d7f04dd540042eedef42cb81a3d2832c296b27dacf7
   attrs =
     {
       upstream_version = version,
-      license_spdx = "AGPL-3.0",
+      license_spdx = "AGPL-3.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "grafana",

--- a/packages/graphviz/build.ncl
+++ b/packages/graphviz/build.ncl
@@ -75,6 +75,7 @@ let version = "14.1.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "EPL-1.0",
       repology_project = "graphviz",
     } | Attrs,
 } | BuildSpec

--- a/packages/grep/build.ncl
+++ b/packages/grep/build.ncl
@@ -75,6 +75,7 @@ let version = "3.12" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "grep",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/groff/build.ncl
+++ b/packages/groff/build.ncl
@@ -50,6 +50,7 @@ let version = "1.23.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "groff",

--- a/packages/grpcurl/build.ncl
+++ b/packages/grpcurl/build.ncl
@@ -35,6 +35,7 @@ let version = "1.9.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "grpcurl",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/grype/build.ncl
+++ b/packages/grype/build.ncl
@@ -42,6 +42,7 @@ let version = "0.108.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "grype",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/gtest/build.ncl
+++ b/packages/gtest/build.ncl
@@ -41,6 +41,7 @@ let version = "1.17.0" in
   },
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-3-Clause",
     source_provenance = {
       category = 'GithubRepo,
       owner = "google",

--- a/packages/gurk/build.ncl
+++ b/packages/gurk/build.ncl
@@ -43,6 +43,7 @@ let version = "0.8.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "AGPL-3.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "boxdot",

--- a/packages/gurk/build.ncl
+++ b/packages/gurk/build.ncl
@@ -43,7 +43,7 @@ let version = "0.8.1" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "AGPL-3.0",
+      license_spdx = "AGPL-3.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "boxdot",

--- a/packages/gws/build.ncl
+++ b/packages/gws/build.ncl
@@ -36,6 +36,7 @@ let version = "0.11.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "googleworkspace",

--- a/packages/gzip/build.ncl
+++ b/packages/gzip/build.ncl
@@ -35,6 +35,7 @@ let version = "1.14" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "gzip",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/happy/build.ncl
+++ b/packages/happy/build.ncl
@@ -38,5 +38,6 @@ let version = "1.20.1.1" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-2-Clause",
   },
 } | BuildSpec

--- a/packages/helm/build.ncl
+++ b/packages/helm/build.ncl
@@ -36,6 +36,7 @@ let version = "4.1.4" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "Apache-2.0",
     source_provenance = {
       category = 'GithubRepo,
       owner = "helm",

--- a/packages/hex-patch/build.ncl
+++ b/packages/hex-patch/build.ncl
@@ -41,6 +41,7 @@ let version = "1.12.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Etto48",

--- a/packages/hexhog/build.ncl
+++ b/packages/hexhog/build.ncl
@@ -35,6 +35,7 @@ let version = "0.1.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "DVDTSB",

--- a/packages/iana-etc/build.ncl
+++ b/packages/iana-etc/build.ncl
@@ -20,6 +20,7 @@ let version = "20260424" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Mic92",

--- a/packages/icu/build.ncl
+++ b/packages/icu/build.ncl
@@ -41,6 +41,7 @@ let version = "78.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Unicode-3.0",
       repology_project = "icu",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/imgcatr/build.ncl
+++ b/packages/imgcatr/build.ncl
@@ -35,6 +35,7 @@ let version = "0.1.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "SilinMeng0510",

--- a/packages/inetutils/build.ncl
+++ b/packages/inetutils/build.ncl
@@ -29,6 +29,7 @@ let version = "2.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "inetutils",

--- a/packages/iproute2/build.ncl
+++ b/packages/iproute2/build.ncl
@@ -44,6 +44,7 @@ let version = "6.18.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       repology_project = "iproute2",
     } | Attrs,
 } | BuildSpec

--- a/packages/jansson/build.ncl
+++ b/packages/jansson/build.ncl
@@ -34,6 +34,7 @@ let version = "2.14" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "akheron",

--- a/packages/jaq/build.ncl
+++ b/packages/jaq/build.ncl
@@ -35,6 +35,7 @@ let version = "2.3.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "01mf02",

--- a/packages/jdk/build.ncl
+++ b/packages/jdk/build.ncl
@@ -59,6 +59,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only WITH Classpath-exception-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "adoptium",

--- a/packages/jnv/build.ncl
+++ b/packages/jnv/build.ncl
@@ -36,6 +36,7 @@ let version = "0.6.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "jnv",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/jq/build.ncl
+++ b/packages/jq/build.ncl
@@ -42,6 +42,7 @@ let version = "1.8.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "jq",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/jqfmt/build.ncl
+++ b/packages/jqfmt/build.ncl
@@ -30,6 +30,7 @@ let version = "0.1.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "noperator",

--- a/packages/jsongrep/build.ncl
+++ b/packages/jsongrep/build.ncl
@@ -35,6 +35,7 @@ let version = "0.7.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "MIT",
     source_provenance = {
       category = 'GithubRepo,
       owner = "micahkepe",

--- a/packages/kittyview/build.ncl
+++ b/packages/kittyview/build.ncl
@@ -35,6 +35,7 @@ let version = "0.1.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "gominimal",

--- a/packages/lcms2/build.ncl
+++ b/packages/lcms2/build.ncl
@@ -42,6 +42,7 @@ let version = "2.17" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "lcms",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/lean/build.ncl
+++ b/packages/lean/build.ncl
@@ -59,6 +59,7 @@ let version = "4.28.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "leanprover",

--- a/packages/less/build.ncl
+++ b/packages/less/build.ncl
@@ -36,6 +36,7 @@ let version = "692" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(BSD-2-Clause AND GPL-3.0-only)",
       # Home page: https://www.greenwoodsoftware.com/less/
     } | Attrs,
 } | BuildSpec

--- a/packages/less/build.ncl
+++ b/packages/less/build.ncl
@@ -36,7 +36,7 @@ let version = "692" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(BSD-2-Clause AND GPL-3.0-only)",
+      license_spdx = "BSD-2-Clause OR GPL-3.0-or-later",
       # Home page: https://www.greenwoodsoftware.com/less/
     } | Attrs,
 } | BuildSpec

--- a/packages/libaom/build.ncl
+++ b/packages/libaom/build.ncl
@@ -40,5 +40,6 @@ let version = "3.13.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
     } | Attrs,
 } | BuildSpec

--- a/packages/libass/build.ncl
+++ b/packages/libass/build.ncl
@@ -45,6 +45,7 @@ let version = "0.17.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "ISC",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libass",

--- a/packages/libcap-ng/build.ncl
+++ b/packages/libcap-ng/build.ncl
@@ -53,6 +53,7 @@ let version = "0.9.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "stevegrubb",

--- a/packages/libcap-ng/build.ncl
+++ b/packages/libcap-ng/build.ncl
@@ -53,7 +53,7 @@ let version = "0.9.3" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0",
+      license_spdx = "GPL-2.0-or-later AND LGPL-2.1-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "stevegrubb",

--- a/packages/libcap/build.ncl
+++ b/packages/libcap/build.ncl
@@ -50,6 +50,7 @@ let version = "2.78" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause OR GPL-2.0-only",
       repology_project = "libcap",
     } | Attrs,
 

--- a/packages/libdrm/build.ncl
+++ b/packages/libdrm/build.ncl
@@ -48,5 +48,6 @@ let version = "2.4.131" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/liberation-fonts/build.ncl
+++ b/packages/liberation-fonts/build.ncl
@@ -23,6 +23,7 @@ let version = "2.1.5" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "OFL-1.1",
     source_provenance = {
       category = 'GithubRepo,
       owner = "liberationfonts",

--- a/packages/libevent/build.ncl
+++ b/packages/libevent/build.ncl
@@ -45,6 +45,7 @@ let version = "2.1.12-stable" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libevent",

--- a/packages/libfdk-aac/build.ncl
+++ b/packages/libfdk-aac/build.ncl
@@ -36,5 +36,6 @@ let version = "2.0.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "FDK-AAC",
     } | Attrs,
 } | BuildSpec

--- a/packages/libffi/build.ncl
+++ b/packages/libffi/build.ncl
@@ -32,7 +32,7 @@ let version = "3.5.2" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(GPL-2.0-only AND MIT)",
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libffi",

--- a/packages/libffi/build.ncl
+++ b/packages/libffi/build.ncl
@@ -32,6 +32,7 @@ let version = "3.5.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND MIT)",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libffi",

--- a/packages/libfuse/build.ncl
+++ b/packages/libfuse/build.ncl
@@ -43,6 +43,7 @@ let version = "3.18.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1-only AND GPL-2.0-only",
       repology_project = "libfuse",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libgd/build.ncl
+++ b/packages/libgd/build.ncl
@@ -49,6 +49,7 @@ let version = "2.3.3" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "GD",
     source_provenance = {
       category = 'GithubRepo,
       owner = "libgd",

--- a/packages/libglvnd/build.ncl
+++ b/packages/libglvnd/build.ncl
@@ -60,6 +60,7 @@ let version = "1.7.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "NVIDIA",

--- a/packages/libidn2/build.ncl
+++ b/packages/libidn2/build.ncl
@@ -36,7 +36,7 @@ let version = "2.3.8" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
+      license_spdx = "GPL-3.0-or-later AND (GPL-2.0-or-later OR LGPL-3.0-or-later)",
       source_provenance = {
         category = 'GnuProject,
         name = "libidn2",

--- a/packages/libidn2/build.ncl
+++ b/packages/libidn2/build.ncl
@@ -36,6 +36,7 @@ let version = "2.3.8" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "libidn2",

--- a/packages/libjpeg-turbo/build.ncl
+++ b/packages/libjpeg-turbo/build.ncl
@@ -41,6 +41,7 @@ let version = "3.1.4.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "IJG AND BSD-3-Clause AND Zlib",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libjpeg-turbo",

--- a/packages/libopus/build.ncl
+++ b/packages/libopus/build.ncl
@@ -36,6 +36,7 @@ let version = "1.6.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "xiph",

--- a/packages/libpipeline/build.ncl
+++ b/packages/libpipeline/build.ncl
@@ -33,5 +33,6 @@ let version = "1.5.8" in
   },
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-3.0-only",
   },
 } | BuildSpec

--- a/packages/libpng/build.ncl
+++ b/packages/libpng/build.ncl
@@ -38,7 +38,7 @@ let version = "1.6.58" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "libpng-1.6.35",
+      license_spdx = "libpng-2.0",
       repology_project = "libpng",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libpng/build.ncl
+++ b/packages/libpng/build.ncl
@@ -38,6 +38,7 @@ let version = "1.6.58" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "libpng-1.6.35",
       repology_project = "libpng",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libpsl/build.ncl
+++ b/packages/libpsl/build.ncl
@@ -41,6 +41,7 @@ let version = "0.21.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "rockdaboot",

--- a/packages/libseccomp/build.ncl
+++ b/packages/libseccomp/build.ncl
@@ -40,6 +40,7 @@ let version = "2.6.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1",
       source_provenance = {
         category = 'GithubRepo,
         owner = "seccomp",

--- a/packages/libseccomp/build.ncl
+++ b/packages/libseccomp/build.ncl
@@ -40,7 +40,7 @@ let version = "2.6.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-2.1",
+      license_spdx = "LGPL-2.1-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "seccomp",

--- a/packages/libsodium/build.ncl
+++ b/packages/libsodium/build.ncl
@@ -46,6 +46,7 @@ let version = "1.0.21" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "ISC",
       repology_project = "libsodium",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libssh2/build.ncl
+++ b/packages/libssh2/build.ncl
@@ -46,6 +46,7 @@ let version = "1.11.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       repology_project = "libssh2",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libsvtav1/build.ncl
+++ b/packages/libsvtav1/build.ncl
@@ -41,6 +41,7 @@ let version = "4.0.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(BSD-2-Clause AND BSD-3-Clause-Clear)",
       source_provenance = {
         category = 'GithubRepo,
         owner = "AOMediaCodec",

--- a/packages/libtool/build.ncl
+++ b/packages/libtool/build.ncl
@@ -46,6 +46,7 @@ let version = "2.5.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "libtool",

--- a/packages/libunistring/build.ncl
+++ b/packages/libunistring/build.ncl
@@ -32,6 +32,7 @@ let version = "1.4.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "libunistring",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/liburcu/build.ncl
+++ b/packages/liburcu/build.ncl
@@ -43,6 +43,7 @@ let version = "0.15.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Boehm-GC",
       source_provenance = {
         category = 'GithubRepo,
         owner = "urcu",

--- a/packages/liburcu/build.ncl
+++ b/packages/liburcu/build.ncl
@@ -43,7 +43,7 @@ let version = "0.15.5" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "Boehm-GC",
+      license_spdx = "LGPL-2.1-or-later AND LGPL-2.1-only AND MIT AND Boehm-GC",
       source_provenance = {
         category = 'GithubRepo,
         owner = "urcu",

--- a/packages/libusb/build.ncl
+++ b/packages/libusb/build.ncl
@@ -35,7 +35,7 @@ let version = "1.0.29" in
 
   attrs = {
     upstream_version = version,
-    license_spdx = "LGPL-2.1",
+    license_spdx = "LGPL-2.1-or-later",
     source_provenance = {
       category = 'GithubRepo,
       owner = "libusb",

--- a/packages/libusb/build.ncl
+++ b/packages/libusb/build.ncl
@@ -35,6 +35,7 @@ let version = "1.0.29" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "LGPL-2.1",
     source_provenance = {
       category = 'GithubRepo,
       owner = "libusb",

--- a/packages/libuv/build.ncl
+++ b/packages/libuv/build.ncl
@@ -51,6 +51,7 @@ let version = "1.52.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libuv",

--- a/packages/libvips/build.ncl
+++ b/packages/libvips/build.ncl
@@ -56,7 +56,7 @@ let version = "8.18.2" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-2.1",
+      license_spdx = "LGPL-2.1-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libvips",

--- a/packages/libvips/build.ncl
+++ b/packages/libvips/build.ncl
@@ -56,6 +56,7 @@ let version = "8.18.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1",
       source_provenance = {
         category = 'GithubRepo,
         owner = "libvips",

--- a/packages/libvmaf/build.ncl
+++ b/packages/libvmaf/build.ncl
@@ -41,6 +41,7 @@ let version = "3.0.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause-Patent",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Netflix",

--- a/packages/libvpx/build.ncl
+++ b/packages/libvpx/build.ncl
@@ -44,6 +44,7 @@ let version = "1.16.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "webmproject",

--- a/packages/libwebp/build.ncl
+++ b/packages/libwebp/build.ncl
@@ -48,6 +48,7 @@ let version = "1.6.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-3-Clause",
     source_provenance = {
       category = 'GithubRepo,
       owner = "webmproject",

--- a/packages/libx11/build.ncl
+++ b/packages/libx11/build.ncl
@@ -43,5 +43,6 @@ let version = "1.8.12" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/libx264/build.ncl
+++ b/packages/libx264/build.ncl
@@ -39,5 +39,6 @@ let version = "0.165.3222" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
     } | Attrs,
 } | BuildSpec

--- a/packages/libx265/build.ncl
+++ b/packages/libx265/build.ncl
@@ -43,5 +43,6 @@ let version = "4.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxau/build.ncl
+++ b/packages/libxau/build.ncl
@@ -38,5 +38,6 @@ let version = "1.0.12" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT-open-group",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxcb/build.ncl
+++ b/packages/libxcb/build.ncl
@@ -46,5 +46,6 @@ let version = "1.17.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "X11-swapped",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxcomposite/build.ncl
+++ b/packages/libxcomposite/build.ncl
@@ -43,5 +43,6 @@ let version = "0.4.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxcrypt/build.ncl
+++ b/packages/libxcrypt/build.ncl
@@ -39,7 +39,7 @@ let version = "4.5.2" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-2.1",
+      license_spdx = "LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND 0BSD",
       repology_project = "libxcrypt",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libxcrypt/build.ncl
+++ b/packages/libxcrypt/build.ncl
@@ -39,6 +39,7 @@ let version = "4.5.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1",
       repology_project = "libxcrypt",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libxdamage/build.ncl
+++ b/packages/libxdamage/build.ncl
@@ -43,5 +43,6 @@ let version = "1.1.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "HPND-sell-variant",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxdmcp/build.ncl
+++ b/packages/libxdmcp/build.ncl
@@ -38,5 +38,6 @@ let version = "1.1.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT-open-group",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxext/build.ncl
+++ b/packages/libxext/build.ncl
@@ -41,5 +41,6 @@ let version = "1.3.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxfixes/build.ncl
+++ b/packages/libxfixes/build.ncl
@@ -40,5 +40,6 @@ let version = "6.0.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxkbcommon/build.ncl
+++ b/packages/libxkbcommon/build.ncl
@@ -51,6 +51,7 @@ let version = "1.13.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "xkbcommon",

--- a/packages/libxml2/build.ncl
+++ b/packages/libxml2/build.ncl
@@ -51,6 +51,7 @@ let version = "2.15.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "libxml2",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libxrandr/build.ncl
+++ b/packages/libxrandr/build.ncl
@@ -45,5 +45,6 @@ let version = "1.5.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxrender/build.ncl
+++ b/packages/libxrender/build.ncl
@@ -41,5 +41,6 @@ let version = "0.9.12" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxshmfence/build.ncl
+++ b/packages/libxshmfence/build.ncl
@@ -39,5 +39,6 @@ let version = "1.3.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "HPND-sell-variant",
     } | Attrs,
 } | BuildSpec

--- a/packages/libxslt/build.ncl
+++ b/packages/libxslt/build.ncl
@@ -46,6 +46,7 @@ let version = "1.1.45" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "libxslt",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/libyaml/build.ncl
+++ b/packages/libyaml/build.ncl
@@ -36,6 +36,7 @@ let version = "0.2.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "libyaml",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/lief/build.ncl
+++ b/packages/lief/build.ncl
@@ -46,6 +46,7 @@ let version = "0.17.6" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "lief-project",

--- a/packages/linux_headers/build.ncl
+++ b/packages/linux_headers/build.ncl
@@ -69,6 +69,7 @@ let version = "6.12.43" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0 WITH Linux-syscall-note",
       source_provenance = {
         category = 'GithubRepo,
         owner = "torvalds",

--- a/packages/linux_headers/build.ncl
+++ b/packages/linux_headers/build.ncl
@@ -69,7 +69,7 @@ let version = "6.12.43" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0 WITH Linux-syscall-note",
+      license_spdx = "GPL-2.0-only WITH Linux-syscall-note",
       source_provenance = {
         category = 'GithubRepo,
         owner = "torvalds",

--- a/packages/llvm-bootstrap/build.ncl
+++ b/packages/llvm-bootstrap/build.ncl
@@ -60,6 +60,7 @@ let version = "21.1.8" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "Apache-2.0",
     build_cost_multiple = 6,
   },
 } | BuildSpec

--- a/packages/llvm/build.ncl
+++ b/packages/llvm/build.ncl
@@ -94,6 +94,7 @@ let version = "21.1.8" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "llvm",

--- a/packages/lz4/build.ncl
+++ b/packages/lz4/build.ncl
@@ -82,6 +82,7 @@ let version = "1.10.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause AND GPL-2.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "lz4",

--- a/packages/m4/build.ncl
+++ b/packages/m4/build.ncl
@@ -64,6 +64,7 @@ let version = "1.4.21" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "m4",

--- a/packages/make/build.ncl
+++ b/packages/make/build.ncl
@@ -66,6 +66,7 @@ let version = "4.4.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "make",

--- a/packages/man-db/build.ncl
+++ b/packages/man-db/build.ncl
@@ -46,5 +46,6 @@ let version = "2.13.1" in
   },
   attrs = {
     upstream_version = version,
+    license_spdx = "(GPL-2.0-only AND GPL-3.0-only AND LGPL-2.1-only)",
   },
 } | BuildSpec

--- a/packages/manifold/build.ncl
+++ b/packages/manifold/build.ncl
@@ -44,6 +44,7 @@ let version = "3.4.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "manifold-geometry-library",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/maven/build.ncl
+++ b/packages/maven/build.ncl
@@ -32,6 +32,7 @@ let version = "3.9.12" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
     } | Attrs,
 
   tests = {

--- a/packages/mermaid-ascii/build.ncl
+++ b/packages/mermaid-ascii/build.ncl
@@ -30,6 +30,7 @@ let version = "1.1.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "AlexanderGrooff",

--- a/packages/mermaid-cli/build.ncl
+++ b/packages/mermaid-cli/build.ncl
@@ -51,6 +51,7 @@ let version = "11.12.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "mermaid-js",

--- a/packages/mesa/build.ncl
+++ b/packages/mesa/build.ncl
@@ -69,5 +69,6 @@ let version = "25.3.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT AND SGI-B-2.0",
     } | Attrs,
 } | BuildSpec

--- a/packages/meson-python/build.ncl
+++ b/packages/meson-python/build.ncl
@@ -37,6 +37,7 @@ let version = "0.18.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "mesonbuild",

--- a/packages/meson/build.ncl
+++ b/packages/meson/build.ncl
@@ -30,6 +30,7 @@ let version = "1.10.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "meson",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/mpc/build.ncl
+++ b/packages/mpc/build.ncl
@@ -99,6 +99,7 @@ let version = "1.4.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-3.0-or-later",
       source_provenance = {
         category = 'GnuProject,
         name = "mpc",

--- a/packages/mpfr/build.ncl
+++ b/packages/mpfr/build.ncl
@@ -98,6 +98,7 @@ let version = "4.2.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "mpfr",

--- a/packages/mtools/build.ncl
+++ b/packages/mtools/build.ncl
@@ -37,6 +37,7 @@ let version = "4.0.49" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "mtools",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/nano/build.ncl
+++ b/packages/nano/build.ncl
@@ -44,6 +44,7 @@ let version = "8.7" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GFDL-1.2-invariants-only AND GPL-3.0-only)",
       repology_project = "nano",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/nasm/build.ncl
+++ b/packages/nasm/build.ncl
@@ -31,5 +31,6 @@ let version = "3.01" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
     } | Attrs,
 } | BuildSpec

--- a/packages/nats-cli/build.ncl
+++ b/packages/nats-cli/build.ncl
@@ -42,6 +42,7 @@ let version = "0.3.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "nats-io",

--- a/packages/nats-server/build.ncl
+++ b/packages/nats-server/build.ncl
@@ -31,6 +31,7 @@ let version = "2.12.7" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "nats-io",

--- a/packages/ncurses/build.ncl
+++ b/packages/ncurses/build.ncl
@@ -43,6 +43,7 @@ let version = "6.5-20250830" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "X11-distribute-modifications-variant",
       source_provenance = {
         category = 'GnuProject,
         name = "ncurses",

--- a/packages/nettle/build.ncl
+++ b/packages/nettle/build.ncl
@@ -43,6 +43,7 @@ let version = "3.10.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
       source_provenance = {
         category = 'GnuProject,
         name = "nettle",

--- a/packages/nettle/build.ncl
+++ b/packages/nettle/build.ncl
@@ -43,7 +43,7 @@ let version = "3.10.1" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(GPL-2.0-only AND GPL-3.0-only)",
+      license_spdx = "GPL-2.0-or-later OR LGPL-3.0-or-later",
       source_provenance = {
         category = 'GnuProject,
         name = "nettle",

--- a/packages/nghttp2/build.ncl
+++ b/packages/nghttp2/build.ncl
@@ -45,6 +45,7 @@ let version = "1.68.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "nghttp2",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/nghttp3/build.ncl
+++ b/packages/nghttp3/build.ncl
@@ -37,6 +37,7 @@ let version = "1.15.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "ngtcp2",

--- a/packages/nginx/build.ncl
+++ b/packages/nginx/build.ncl
@@ -53,6 +53,7 @@ let version = "1.30.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
       repology_project = "nginx",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/ngspice/build.ncl
+++ b/packages/ngspice/build.ncl
@@ -46,6 +46,7 @@ let version = "46" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-3-Clause",
     source_provenance = {
       category = 'GithubRepo,
       owner = "ngspice",

--- a/packages/nickel-lsp/build.ncl
+++ b/packages/nickel-lsp/build.ncl
@@ -34,6 +34,7 @@ let version = "1.16.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "nickel-lang",

--- a/packages/nickel/build.ncl
+++ b/packages/nickel/build.ncl
@@ -35,6 +35,7 @@ let version = "1.16.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "MIT",
     source_provenance = {
       category = 'GithubRepo,
       owner = "nickel-lang",

--- a/packages/ninja/build.ncl
+++ b/packages/ninja/build.ncl
@@ -33,6 +33,7 @@ let version = "1.13.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "ninja",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/node-lts/build.ncl
+++ b/packages/node-lts/build.ncl
@@ -70,6 +70,7 @@ let version = "24.14.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       env_state_wiring = {
         env_var = "NPM_CONFIG_CACHE",
         prefix = "npm-cache",

--- a/packages/node/build.ncl
+++ b/packages/node/build.ncl
@@ -70,6 +70,7 @@ let version = "25.8.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       env_state_wiring = {
         env_var = "NPM_CONFIG_CACHE",
         prefix = "npm-cache",

--- a/packages/nspr/build.ncl
+++ b/packages/nspr/build.ncl
@@ -33,5 +33,6 @@ let version = "4.38.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MPL-2.0",
     } | Attrs,
 } | BuildSpec

--- a/packages/nss/build.ncl
+++ b/packages/nss/build.ncl
@@ -43,5 +43,6 @@ let version = "3.121" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MPL-2.0",
     } | Attrs,
 } | BuildSpec

--- a/packages/numpy/build.ncl
+++ b/packages/numpy/build.ncl
@@ -42,6 +42,7 @@ let version = "2.3.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "numpy",

--- a/packages/nushell/build.ncl
+++ b/packages/nushell/build.ncl
@@ -38,6 +38,7 @@ let version = "0.110.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "nushell",

--- a/packages/onetbb/build.ncl
+++ b/packages/onetbb/build.ncl
@@ -42,6 +42,7 @@ let version = "2022.3.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "onetbb",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/oniguruma/build.ncl
+++ b/packages/oniguruma/build.ncl
@@ -39,6 +39,7 @@ let version = "6.9.10" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "kkos",

--- a/packages/openblas/build.ncl
+++ b/packages/openblas/build.ncl
@@ -38,6 +38,7 @@ let version = "0.3.31" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       repology_project = "openblas",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/opencode/build.ncl
+++ b/packages/opencode/build.ncl
@@ -42,6 +42,7 @@ let version = "1.14.20" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       build_cost_multiple = 3,
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/opencv/build.ncl
+++ b/packages/opencv/build.ncl
@@ -56,6 +56,7 @@ let version = "4.13.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "opencv",

--- a/packages/openjpeg/build.ncl
+++ b/packages/openjpeg/build.ncl
@@ -46,6 +46,7 @@ let version = "2.5.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-2-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "uclouvain",

--- a/packages/openssh/build.ncl
+++ b/packages/openssh/build.ncl
@@ -43,6 +43,7 @@ let version = "10.3p1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "SSH-OpenSSH AND BSD-2-Clause AND BSD-3-Clause",
       repology_project = "openssh",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/openssl/build.ncl
+++ b/packages/openssl/build.ncl
@@ -47,6 +47,7 @@ let version = "3.6.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "openssl",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/or-tools/build.ncl
+++ b/packages/or-tools/build.ncl
@@ -58,6 +58,7 @@ let version = "9.15" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "google",

--- a/packages/otel-collector/build.ncl
+++ b/packages/otel-collector/build.ncl
@@ -42,6 +42,7 @@ let version = "0.150.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "open-telemetry",

--- a/packages/pango/build.ncl
+++ b/packages/pango/build.ncl
@@ -51,5 +51,6 @@ let version = "1.56.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.0-only",
     } | Attrs,
 } | BuildSpec

--- a/packages/pasta/build.ncl
+++ b/packages/pasta/build.ncl
@@ -34,5 +34,6 @@ let version = "2026_01_20.386b5f5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-or-later",
     } | Attrs,
 } | BuildSpec

--- a/packages/patch/build.ncl
+++ b/packages/patch/build.ncl
@@ -30,6 +30,7 @@ let version = "2.8" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "patch",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/patchelf/build.ncl
+++ b/packages/patchelf/build.ncl
@@ -33,6 +33,7 @@ let glibc = import "../glibc/build.ncl" in
   },
   attrs =
     {
+      license_spdx = "GPL-3.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "NixOS",

--- a/packages/patchelf/build.ncl
+++ b/packages/patchelf/build.ncl
@@ -33,7 +33,7 @@ let glibc = import "../glibc/build.ncl" in
   },
   attrs =
     {
-      license_spdx = "GPL-3.0",
+      license_spdx = "GPL-3.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "NixOS",

--- a/packages/pciutils/build.ncl
+++ b/packages/pciutils/build.ncl
@@ -37,6 +37,7 @@ let version = "3.14.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pciutils",

--- a/packages/pciutils/build.ncl
+++ b/packages/pciutils/build.ncl
@@ -37,7 +37,7 @@ let version = "3.14.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0",
+      license_spdx = "GPL-2.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pciutils",

--- a/packages/pcre2/build.ncl
+++ b/packages/pcre2/build.ncl
@@ -104,6 +104,7 @@ let version = "10.47" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause WITH PCRE2-exception",
       repology_project = "pcre2",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/perl/build.ncl
+++ b/packages/perl/build.ncl
@@ -66,7 +66,7 @@ let version = "5.42.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-1.0-only",
+      license_spdx = "Artistic-1.0-Perl OR GPL-1.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Perl",

--- a/packages/perl/build.ncl
+++ b/packages/perl/build.ncl
@@ -66,6 +66,7 @@ let version = "5.42.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-1.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Perl",

--- a/packages/picocom/build.ncl
+++ b/packages/picocom/build.ncl
@@ -37,6 +37,7 @@ let version = "3.1" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-2.0",
     source_provenance = {
       category = 'GithubRepo,
       owner = "npat-efault",

--- a/packages/picocom/build.ncl
+++ b/packages/picocom/build.ncl
@@ -37,7 +37,7 @@ let version = "3.1" in
 
   attrs = {
     upstream_version = version,
-    license_spdx = "GPL-2.0",
+    license_spdx = "GPL-2.0-or-later",
     source_provenance = {
       category = 'GithubRepo,
       owner = "npat-efault",

--- a/packages/pixman/build.ncl
+++ b/packages/pixman/build.ncl
@@ -38,4 +38,5 @@ let version = "0.46.4" in
     includes = { glob = "usr/include/**" } | OutputData,
   },
   attrs.upstream_version = version,
+  attrs.license_spdx = "MIT",
 } | BuildSpec

--- a/packages/pkgconf/build.ncl
+++ b/packages/pkgconf/build.ncl
@@ -38,6 +38,7 @@ let version = "2.5.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "pkgconf",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pkgconf",

--- a/packages/postgres/build.ncl
+++ b/packages/postgres/build.ncl
@@ -54,6 +54,7 @@ let version = "18.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "PostgreSQL",
       source_provenance = {
         category = 'GithubRepo,
         owner = "postgres",

--- a/packages/prek/build.ncl
+++ b/packages/prek/build.ncl
@@ -35,6 +35,7 @@ let version = "0.3.10" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "j178",

--- a/packages/probe-rs/build.ncl
+++ b/packages/probe-rs/build.ncl
@@ -47,6 +47,7 @@ let version = "0.31.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "Apache-2.0",
     source_provenance = {
       category = 'GithubRepo,
       owner = "probe-rs",

--- a/packages/procps-ng/build.ncl
+++ b/packages/procps-ng/build.ncl
@@ -35,5 +35,6 @@ let version = "4.0.5" in
   },
   attrs = {
     upstream_version = version,
+    license_spdx = "(GPL-2.0-only AND LGPL-2.0-only)",
   },
 } | BuildSpec

--- a/packages/procs/build.ncl
+++ b/packages/procs/build.ncl
@@ -36,6 +36,7 @@ let version = "0.14.10" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "dalance",

--- a/packages/pulumi/build.ncl
+++ b/packages/pulumi/build.ncl
@@ -45,6 +45,7 @@ let version = "3.239.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "pulumi",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/py-build/build.ncl
+++ b/packages/py-build/build.ncl
@@ -35,6 +35,7 @@ let version = "1.3.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/py-packaging/build.ncl
+++ b/packages/py-packaging/build.ncl
@@ -35,7 +35,7 @@ let version = "25.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(BSD-2-Clause AND Pixar)",
+      license_spdx = "Apache-2.0 OR BSD-2-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/py-packaging/build.ncl
+++ b/packages/py-packaging/build.ncl
@@ -35,6 +35,7 @@ let version = "25.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(BSD-2-Clause AND Pixar)",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/pyproject-hooks/build.ncl
+++ b/packages/pyproject-hooks/build.ncl
@@ -33,6 +33,7 @@ let version = "1.2.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/pyproject-metadata/build.ncl
+++ b/packages/pyproject-metadata/build.ncl
@@ -35,6 +35,7 @@ let version = "0.9.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/pyright/build.ncl
+++ b/packages/pyright/build.ncl
@@ -35,5 +35,6 @@ let version = "1.1.398" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
     } | Attrs,
 } | BuildSpec

--- a/packages/railway/build.ncl
+++ b/packages/railway/build.ncl
@@ -37,6 +37,7 @@ let version = "4.30.2" in
       # Wire up Railway's global state directory.
       env_dir_mappings = [{ read_only = false, path = "~/.railway", class = 'State }],
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "railwayapp",

--- a/packages/readline/build.ncl
+++ b/packages/readline/build.ncl
@@ -33,6 +33,7 @@ let version = "8.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "readline",

--- a/packages/redis/build.ncl
+++ b/packages/redis/build.ncl
@@ -49,6 +49,7 @@ let version = "8.6.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "AGPL-3.0-only OR SSPL-1.0",
       repology_project = "redis",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/ripgrep/build.ncl
+++ b/packages/ripgrep/build.ncl
@@ -37,6 +37,7 @@ let version = "15.1.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Unlicense",
       source_provenance = {
         category = 'GithubRepo,
         owner = "BurntSushi",

--- a/packages/rust-arm-embedded/build.ncl
+++ b/packages/rust-arm-embedded/build.ncl
@@ -31,6 +31,7 @@ let toolchain = import "../toolchain/build.ncl" in
   attrs =
     {
       upstream_version = rust.attrs.upstream_version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "rust-lang",

--- a/packages/screen/build.ncl
+++ b/packages/screen/build.ncl
@@ -45,6 +45,7 @@ let version = "5.0.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "screen",

--- a/packages/scrt/build.ncl
+++ b/packages/scrt/build.ncl
@@ -43,6 +43,7 @@ let version = "0.3.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "loderunner",

--- a/packages/sed/build.ncl
+++ b/packages/sed/build.ncl
@@ -53,6 +53,7 @@ let version = "4.9" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "sed",

--- a/packages/setuptools/build.ncl
+++ b/packages/setuptools/build.ncl
@@ -28,6 +28,7 @@ let version = "82.0.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pypa",

--- a/packages/shadow/build.ncl
+++ b/packages/shadow/build.ncl
@@ -44,6 +44,7 @@ let version = "4.18.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "shadow-maint",

--- a/packages/shellcheck/build.ncl
+++ b/packages/shellcheck/build.ncl
@@ -38,7 +38,7 @@ let version = "0.10.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-3.0",
+      license_spdx = "GPL-3.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "koalaman",

--- a/packages/shellcheck/build.ncl
+++ b/packages/shellcheck/build.ncl
@@ -38,6 +38,7 @@ let version = "0.10.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "koalaman",

--- a/packages/skopeo/build.ncl
+++ b/packages/skopeo/build.ncl
@@ -39,6 +39,7 @@ let version = "1.22.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "containers",

--- a/packages/socat/build.ncl
+++ b/packages/socat/build.ncl
@@ -47,6 +47,7 @@ let version = "1.8.1.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(GPL-2.0-only AND OpenSSL)",
     } | Attrs,
 
   tests.smoketest =

--- a/packages/socat/build.ncl
+++ b/packages/socat/build.ncl
@@ -47,7 +47,7 @@ let version = "1.8.1.1" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(GPL-2.0-only AND OpenSSL)",
+      license_spdx = "GPL-2.0-only WITH openvpn-openssl-exception",
     } | Attrs,
 
   tests.smoketest =

--- a/packages/spire/build.ncl
+++ b/packages/spire/build.ncl
@@ -72,6 +72,7 @@ let version = "1.14.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "spiffe",

--- a/packages/sqlite/build.ncl
+++ b/packages/sqlite/build.ncl
@@ -36,6 +36,7 @@ let version = "3.50.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "blessing",
       source_provenance = {
         category = 'GithubRepo,
         owner = "sqlite",

--- a/packages/stack/build.ncl
+++ b/packages/stack/build.ncl
@@ -45,6 +45,7 @@ let version = "3.9.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-3.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "commercialhaskell",

--- a/packages/stack/build.ncl
+++ b/packages/stack/build.ncl
@@ -45,7 +45,7 @@ let version = "3.9.3" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "LGPL-3.0-only",
+      license_spdx = "BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "commercialhaskell",

--- a/packages/starship/build.ncl
+++ b/packages/starship/build.ncl
@@ -46,6 +46,7 @@ let version = "1.25.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "ISC",
       source_provenance = {
         category = 'GithubRepo,
         owner = "starship",

--- a/packages/stlink/build.ncl
+++ b/packages/stlink/build.ncl
@@ -50,6 +50,7 @@ let version = "1.8.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "BSD-3-Clause",
     source_provenance = {
       category = 'GithubRepo,
       owner = "stlink-org",

--- a/packages/stm32flash/build.ncl
+++ b/packages/stm32flash/build.ncl
@@ -40,5 +40,6 @@ let version = "0.7" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "GPL-2.0-or-later",
   },
 } | BuildSpec

--- a/packages/strace/build.ncl
+++ b/packages/strace/build.ncl
@@ -32,6 +32,7 @@ let version = "6.17" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LGPL-2.1-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "strace",

--- a/packages/syft/build.ncl
+++ b/packages/syft/build.ncl
@@ -42,6 +42,7 @@ let version = "1.42.4" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       repology_project = "syft",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/tailscale/build.ncl
+++ b/packages/tailscale/build.ncl
@@ -46,6 +46,7 @@ let version = "1.94.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BSD-3-Clause",
       repology_project = "tailscale",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/tar/build.ncl
+++ b/packages/tar/build.ncl
@@ -39,6 +39,7 @@ let version = "1.35" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       repology_project = "tar",
       source_provenance = {
         category = 'GnuProject,

--- a/packages/tcl/build.ncl
+++ b/packages/tcl/build.ncl
@@ -38,7 +38,7 @@ let version = "8.6.16" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(SMLNJ AND TCL)",
+      license_spdx = "TCL",
       source_provenance = {
         category = 'GithubRepo,
         owner = "tcltk",

--- a/packages/tcl/build.ncl
+++ b/packages/tcl/build.ncl
@@ -38,6 +38,7 @@ let version = "8.6.16" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(SMLNJ AND TCL)",
       source_provenance = {
         category = 'GithubRepo,
         owner = "tcltk",

--- a/packages/teamtype/build.ncl
+++ b/packages/teamtype/build.ncl
@@ -35,6 +35,7 @@ let version = "0.9.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "AGPL-3.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "teamtype",

--- a/packages/teamtype/build.ncl
+++ b/packages/teamtype/build.ncl
@@ -35,7 +35,7 @@ let version = "0.9.1" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "AGPL-3.0",
+      license_spdx = "AGPL-3.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "teamtype",

--- a/packages/terraform/build.ncl
+++ b/packages/terraform/build.ncl
@@ -42,6 +42,7 @@ let version = "1.14.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "BUSL-1.1",
       repology_project = "terraform",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/time/build.ncl
+++ b/packages/time/build.ncl
@@ -30,6 +30,7 @@ let version = "1.9" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "time",

--- a/packages/tmux/build.ncl
+++ b/packages/tmux/build.ncl
@@ -53,6 +53,7 @@ let version = "3.6a" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "ISC",
       source_provenance = {
         category = 'GithubRepo,
         owner = "tmux",

--- a/packages/tree-sitter/build.ncl
+++ b/packages/tree-sitter/build.ncl
@@ -36,6 +36,7 @@ let version = "0.24.7" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "tree-sitter",

--- a/packages/typescript-language-server/build.ncl
+++ b/packages/typescript-language-server/build.ncl
@@ -36,5 +36,6 @@ let version = "4.3.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
     } | Attrs,
 } | BuildSpec

--- a/packages/typst/build.ncl
+++ b/packages/typst/build.ncl
@@ -39,6 +39,7 @@ let version = "0.14.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Apache-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "typst",

--- a/packages/unzip/build.ncl
+++ b/packages/unzip/build.ncl
@@ -39,6 +39,7 @@ let version = "6.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Info-ZIP",
       repology_project = "unzip",
     } | Attrs,
 

--- a/packages/ut/build.ncl
+++ b/packages/ut/build.ncl
@@ -35,6 +35,7 @@ let version = "0.6.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "ksdme",

--- a/packages/util-linux/build.ncl
+++ b/packages/util-linux/build.ncl
@@ -46,7 +46,7 @@ let version = "2.42.1" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0",
+      license_spdx = "GPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-3-Clause",
       source_provenance = {
         category = 'GithubRepo,
         owner = "util-linux",

--- a/packages/util-linux/build.ncl
+++ b/packages/util-linux/build.ncl
@@ -46,6 +46,7 @@ let version = "2.42.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "util-linux",

--- a/packages/varlock/build.ncl
+++ b/packages/varlock/build.ncl
@@ -35,6 +35,7 @@ let version = "0.2.3" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "dmno-dev",

--- a/packages/virtio-linux/build.ncl
+++ b/packages/virtio-linux/build.ncl
@@ -50,5 +50,6 @@ let version = "6.12.43" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0 WITH Linux-syscall-note",
     } | Attrs,
 } | BuildSpec

--- a/packages/virtio-linux/build.ncl
+++ b/packages/virtio-linux/build.ncl
@@ -50,6 +50,6 @@ let version = "6.12.43" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-2.0 WITH Linux-syscall-note",
+      license_spdx = "GPL-2.0-only WITH Linux-syscall-note",
     } | Attrs,
 } | BuildSpec

--- a/packages/weathr/build.ncl
+++ b/packages/weathr/build.ncl
@@ -35,7 +35,7 @@ let version = "1.3.0" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "GPL-3.0",
+      license_spdx = "GPL-3.0-or-later",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Veirt",

--- a/packages/weathr/build.ncl
+++ b/packages/weathr/build.ncl
@@ -35,6 +35,7 @@ let version = "1.3.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0",
       source_provenance = {
         category = 'GithubRepo,
         owner = "Veirt",

--- a/packages/wget/build.ncl
+++ b/packages/wget/build.ncl
@@ -48,6 +48,7 @@ let version = "1.25.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-only",
       source_provenance = {
         category = 'GnuProject,
         name = "wget",

--- a/packages/xcb-proto/build.ncl
+++ b/packages/xcb-proto/build.ncl
@@ -32,5 +32,6 @@ let version = "1.17.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "X11-swapped",
     } | Attrs,
 } | BuildSpec

--- a/packages/xorgproto/build.ncl
+++ b/packages/xorgproto/build.ncl
@@ -31,6 +31,6 @@ let version = "2025.1" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(BSD-2-Clause AND HPND AND HPND-sell-variant AND ICU AND MIT AND MIT-open-group AND SGI-B-2.0 AND SMLNJ AND X11 AND X11-swapped)",
+      license_spdx = "BSD-2-Clause AND HPND AND HPND-sell-variant AND ICU AND MIT AND MIT-open-group AND SGI-B-2.0 AND SMLNJ AND X11 AND X11-distribute-modifications-variant",
     } | Attrs,
 } | BuildSpec

--- a/packages/xorgproto/build.ncl
+++ b/packages/xorgproto/build.ncl
@@ -31,5 +31,6 @@ let version = "2025.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(BSD-2-Clause AND HPND AND HPND-sell-variant AND ICU AND MIT AND MIT-open-group AND SGI-B-2.0 AND SMLNJ AND X11 AND X11-swapped)",
     } | Attrs,
 } | BuildSpec

--- a/packages/xtrans/build.ncl
+++ b/packages/xtrans/build.ncl
@@ -29,5 +29,6 @@ let version = "1.6.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "X11",
     } | Attrs,
 } | BuildSpec

--- a/packages/yazi/build.ncl
+++ b/packages/yazi/build.ncl
@@ -38,6 +38,7 @@ let version = "26.1.22" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       repology_project = "yazi",
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/yq/build.ncl
+++ b/packages/yq/build.ncl
@@ -42,6 +42,7 @@ let version = "4.52.5" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "mikefarah",

--- a/packages/z3/build.ncl
+++ b/packages/z3/build.ncl
@@ -43,6 +43,7 @@ let version = "4.16.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "MIT",
     source_provenance = {
       category = 'GithubRepo,
       owner = "Z3Prover",

--- a/packages/zellij/build.ncl
+++ b/packages/zellij/build.ncl
@@ -38,6 +38,7 @@ let version = "0.43.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "zellij-org",

--- a/packages/zig/build.ncl
+++ b/packages/zig/build.ncl
@@ -41,6 +41,7 @@ let version = "0.16.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       env_state_wiring = [
         {
           env_var = "ZIG_LOCAL_CACHE_DIR",

--- a/packages/zizmor/build.ncl
+++ b/packages/zizmor/build.ncl
@@ -38,6 +38,7 @@ let version = "1.24.1" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT",
       source_provenance = {
         category = 'GithubRepo,
         owner = "zizmorcore",

--- a/packages/zlib/build.ncl
+++ b/packages/zlib/build.ncl
@@ -66,6 +66,7 @@ let version = "1.3.2" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "Zlib",
       source_provenance = {
         category = 'GithubRepo,
         owner = "madler",

--- a/packages/zstd/build.ncl
+++ b/packages/zstd/build.ncl
@@ -102,6 +102,7 @@ let version = "1.5.7" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(BSD-3-Clause AND GPL-2.0-only)",
       source_provenance = {
         category = 'GithubRepo,
         owner = "facebook",

--- a/packages/zstd/build.ncl
+++ b/packages/zstd/build.ncl
@@ -102,7 +102,7 @@ let version = "1.5.7" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "(BSD-3-Clause AND GPL-2.0-only)",
+      license_spdx = "BSD-3-Clause OR GPL-2.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "facebook",


### PR DESCRIPTION
## Declare + audit `license_spdx` across the package catalog (infra#193 follow-up)

Makes each package's license **explicit and authoritative** in `build.ncl` (a declared `license_spdx` trumps detection in the resolve chain), removes the per-build detection cost, and settles detector disagreements once and for all. What began as a 229-package backfill turned into a full cross-source license audit.

### What's in the PR

**1. Declared the detectable-but-undeclared set (229).** Values came from the resolved license already in `pkgsec.pkgs_commit_history.license` — the #193 **GitHub-wins** backfill — so the github-vs-tarball disagreements were already settled the safe way.

**2. Deep-dived the manual queue (53 of 56).** The "undetectable" packages askalono + the GitHub API miss — custom LICENSE text (`sqlite`=`blessing`, `postgres`=`PostgreSQL`), prebuilt binaries (`chromium-bin`=`BSD-3-Clause`, `jdk`=`GPL-2.0-only WITH Classpath-exception-2.0`, `pcre2`=`BSD-3-Clause WITH PCRE2-exception`), or no upstream metadata — declared via per-package upstream-LICENSE verification. Version-matched the relicensing traps (`terraform`=`BUSL-1.1`, `redis`=`AGPL-3.0-only OR SSPL-1.0`, `graphviz` held at `EPL-1.0` since the EPL-2.0 relicense postdates the pinned tag). Caught a provenance mislabel: `bc` is Gavin Howard's BSD-2 `bc`, not GNU `bc`.

**3. Audited the auto-detected declarations** and fixed three classes of askalono whole-tarball-scan artifact:
- **Compound false positives (13)** — the scan folds vendored / test / per-file / data-file license text into `AND`-joined expressions. `py-packaging (BSD-2-Clause AND Pixar)` → `Apache-2.0 OR BSD-2-Clause` (the `Pixar` match was in packaging's *own* `_spdx.py` id-lookup table); `dbus`, `tcl`, `libffi` likewise; `AND`→`OR` for choose-one duals (`cairo`, `gmp`, `nettle`, `less`, `zstd`).
- **Single-license false positives (3)** — scanner matched a secondary license, missed the primary: `liburcu` (`Boehm-GC` → `LGPL-2.1-or-later AND …`), `perl` (restored the Artistic arm), `stack` (`LGPL-3.0` → `BSD-3-Clause` — the LGPL/GPL text was a LICENSE appendix).
- **Deprecated id forms (22)** — bare `GPL-2.0`/`GPL-3.0`/`AGPL-3.0`/`LGPL-2.1` → modern `-only`/`-or-later`, decided per each upstream's "or later" clause (e.g. `linux_headers`/`virtio-linux` → `GPL-2.0-only WITH Linux-syscall-note`; `fio`/`libseccomp`/`grafana` are genuinely `-only`).

> **CodeRabbit's inline comments are folded in** — it independently flagged ~12 of the deprecated-form cases (plus `autoconf` → `GPL-3.0-or-later WITH Autoconf-exception-3.0` and `libpng` → `libpng-2.0`); the `isDeprecatedLicenseId` check found all 22, and `dbus`/`libidn2` were already corrected by the compound audit.

### Validation — five independent sources

Every declared id was checked against: (1) the **canonical SPDX list** (729 licenses + 85 exceptions — all valid), (2) the **SPDX `isDeprecatedLicenseId` flag** (zero deprecated remain), (3) **per-package upstream LICENSE files** (the audit workflows), (4) the **GitHub license API**, and (5) **Repology** distro consensus (235 license-family matches; the 9 disagreements all resolved as Repology project name-collisions or variant-naming where our value is confirmed correct — `jdk`=OpenJDK/Temurin vs Oracle, `mpc`=GNU MPC vs music-player client, `ut`=ksdme/ut vs boost-ext/ut). `minimal dump --packages` parses **all 368**.

### Coverage — 327/339 declared (96.5%)

The 12 undeclared are intentional, each with cause:
- **Internal / meta (7):** `base`, `base-bootstrap`, `toolchain`, `minimal-sshd`, `microvm-rootfs`, `resolver-quad8`, `virtio-kernel-raw`
- **Proprietary, no SPDX id (2):** `android-sdk` (Android SDK Terms), `claude-code` (`closed_source=true`)
- **Custom license, no SPDX id (1):** `zsh`
- **Separate PR (1):** `mono` (#233) — plus `py-markupsafe` (untracked WIP, not part of this PR)

### Flagged follow-up (out of scope)

`chromium-bin` / `chromium-headless-shell-bin` set `source_provenance` to `microsoft/playwright` — the binary's *download vehicle*, not the Chromium project. The license (`BSD-3-Clause`, matching the Alpine/plurality tag) is correct, but a **vuln scan would match Playwright's advisories and miss Chromium's CVEs**. Worth a provenance fix in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit SPDX license identifiers to package metadata across the catalog.
  * Improves license clarity and provenance for individual packages.
  * Enables better compliance reporting, auditing, and tooling that rely on standardized license metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
