### PR TITLE
Update binutils 2.46.1 + coreutils 9.11 (base-soup bundle)

### DIFF
--- a/packages/binutils/build.ncl
+++ b/packages/binutils/build.ncl
@@ -16,13 +16,13 @@ let glibc = import "../glibc/build.ncl" in
 let linux_headers = import "../linux_headers/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "2.46.0" in
+let version = "2.46.1" in
 {
   name = "binutils",
   build_deps = [
     {
       url = "gs://minimal-staging-archives/binutils-%{version}.tar.xz",
-      sha256 = "d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2",
+      sha256 = "e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4",
       extract = true,
     } | Source,
     { file = "build.sh" } | Local,

--- a/packages/coreutils/build.ncl
+++ b/packages/coreutils/build.ncl
@@ -26,14 +26,14 @@ let attr = import "../attr/build.ncl" in
 let libcap = import "../libcap/build.ncl" in
 let gmp = import "../gmp/build.ncl" in
 
-let version = "9.10" in
+let version = "9.11" in
 {
   name = "coreutils",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/coreutils-%{version}.tar.xz",
-      sha256 = "16535a9adf0b10037364e2d612aad3d9f4eca3a344949ced74d12faf4bd51d25"
+      sha256 = "394024eda0a5955217ceda9cd1201e65dc8fa3aa29c2951135a49521d57c3cc3"
     } | Source,
     # base
     bash-bootstrap,


### PR DESCRIPTION
Bundles two base-soup toolchain updates so the cascading rebuild lands as one unit:
- **binutils** 2.46.0 → 2.46.1
- **coreutils** 9.10 → 9.11

**glibc** has an update too but is **deferred** to a separate change (per request).

Both mirrored + **sha-verified against upstream ftp.gnu.org** (.tar.xz):
| pkg | sha256 | matches upstream |
|---|---|---|
| binutils-2.46.1.tar.xz | `e127a709…` | ✅ |
| coreutils-9.11.tar.xz | `394024ed…` | ✅ |

⚠️ Heads-up for the reviewer: coreutils' tarball was **manually verified/corrected** — pkgmgr's GNU-FTP parser grabbed the `.tar.gz` when `.tar.xz` was also available, so I re-mirrored + sha-checked the `.xz` by hand. A parser-preference fix (prefer `.tar.xz`) is a separate pkgmgr follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binutils to version 2.46.1
  * Updated coreutils to version 9.11

<!-- end of auto-generated comment: release notes by coderabbit.ai -->