### PR TITLE
claude-code: bump to 2.1.174 (ahead of stable channel)

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -11,9 +11,9 @@ let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
-  version = "2.1.153",
-  amd64_sha256 = "214f603f31942162dac9a65f18d43b3ac646ae215240fad481c4aad6c60f2e38",
-  arm64_sha256 = "6277fbbea72228a069e4719fc3e5fa36f16749247a2321c520dae93e83e92d9c",
+  version = "2.1.174",
+  amd64_sha256 = "08a7c90925cc622003a94b813ae0fc544c08776f6d890532f6212e15962899a8",
+  arm64_sha256 = "397896495a6cb90376e00797f1520af959b4ac1b9dddf7af9127b8cec1010071",
 }
 in
 


### PR DESCRIPTION
## Summary

Pin claude-code to `2.1.174` (current `latest` channel) rather than tracking the GCS `stable` channel, which is currently at `2.1.153`.

Motivation: two model versions are unreachable on the pinned binary's `/model` picker until we move past 2.1.169:
- **Opus 4.8** — added in [2.1.154](https://github.com/anthropics/claude-code/blob/v2.1.174/CHANGELOG.md#21154)
- **Claude Fable 5** (Mythos-class) — added in [2.1.170](https://github.com/anthropics/claude-code/blob/v2.1.174/CHANGELOG.md#21170)

This is a one-time hop ahead of `stable`. Future bumps can resume tracking the auto-PR cadence from `app/gominimal-pkgmgr-mgr` (which opened #235 for the 2.1.153 promotion).

## Verification

Both linux SHAs verified against actual GCS downloads:

```
$ curl -sL .../2.1.174/linux-x64/claude   | sha256sum
08a7c90925cc622003a94b813ae0fc544c08776f6d890532f6212e15962899a8  -

$ curl -sL .../2.1.174/linux-arm64/claude | sha256sum
397896495a6cb90376e00797f1520af959b4ac1b9dddf7af9127b8cec1010071  -
```

Matches the new pins in `build.ncl` and the published [2.1.174 manifest](https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.174/manifest.json).

Full changelog: https://github.com/anthropics/claude-code/blob/v2.1.174/CHANGELOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code to version 2.1.174 with updated platform-specific artifacts for amd64 and arm64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->