### PR TITLE
next: fix sharp FTBFS — glib dep + surface glib paths to native build (unblock #240 cascade)

### DIFF
--- a/packages/binutils/build.ncl
+++ b/packages/binutils/build.ncl
@@ -16,13 +16,13 @@ let glibc = import "../glibc/build.ncl" in
 let linux_headers = import "../linux_headers/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "2.46.0" in
+let version = "2.46.1" in
 {
   name = "binutils",
   build_deps = [
     {
       url = "gs://minimal-staging-archives/binutils-%{version}.tar.xz",
-      sha256 = "d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2",
+      sha256 = "e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4",
       extract = true,
     } | Source,
     { file = "build.sh" } | Local,

--- a/packages/coreutils/build.ncl
+++ b/packages/coreutils/build.ncl
@@ -26,14 +26,14 @@ let attr = import "../attr/build.ncl" in
 let libcap = import "../libcap/build.ncl" in
 let gmp = import "../gmp/build.ncl" in
 
-let version = "9.10" in
+let version = "9.11" in
 {
   name = "coreutils",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/coreutils-%{version}.tar.xz",
-      sha256 = "16535a9adf0b10037364e2d612aad3d9f4eca3a344949ced74d12faf4bd51d25"
+      sha256 = "394024eda0a5955217ceda9cd1201e65dc8fa3aa29c2951135a49521d57c3cc3"
     } | Source,
     # base
     bash-bootstrap,

--- a/packages/libvips/build.ncl
+++ b/packages/libvips/build.ncl
@@ -15,14 +15,14 @@ let zlib = import "../zlib/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "8.18.2" in
+let version = "8.18.3" in
 {
   name = "libvips",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/libvips/libvips/releases/download/v%{version}/vips-%{version}.tar.xz",
-      sha256 = "a30d4aede16f1c2899c1a2241870f8a7409feafa38484bcdcdac113d6d6f8ff5",
+      sha256 = "f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146",
       extract = true,
       strip_prefix = "vips-%{version}",
     } | Source,

--- a/packages/next/build.ncl
+++ b/packages/next/build.ncl
@@ -1,6 +1,7 @@
 let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
+let glib = import "../glib/build.ncl" in
 let libvips = import "../libvips/build.ncl" in
 let make = import "../make/build.ncl" in
 let node = import "../node/build.ncl" in
@@ -21,6 +22,7 @@ let version = "16.2.6" in
       strip_prefix = "next.js-%{version}",
     } | Source,
     base,
+    glib,
     make,
     node,
     pkgconf,
@@ -30,6 +32,7 @@ let version = "16.2.6" in
   ],
   runtime_deps = [
     coreutils,
+    glib,
     libvips,
     node,
   ],

--- a/packages/next/build.sh
+++ b/packages/next/build.sh
@@ -31,6 +31,26 @@ echo '{"private":true}' > package.json
 npm install --ignore-scripts sharp node-addon-api node-gyp
 export PATH="$SHARP_STAGING/node_modules/.bin:$PATH"
 cd node_modules/sharp
+
+# sharp discovers our system libvips via `pkg-config vips-cpp`, but libvips's public
+# header <vips/vips8> #includes <glib-object.h> while vips-cpp.pc lists glib only under
+# Requires.private. A non-static `pkg-config --cflags/--libs vips-cpp` (what sharp's
+# node-gyp build uses) does not expand private requires, so glib's include/link paths
+# are never passed and the addon FTBFS on "glib-object.h: No such file". Surface glib's
+# include/lib dirs explicitly. CPATH/LIBRARY_PATH are read by gcc directly (independent
+# of node-gyp's Makefile flag handling); CXXFLAGS/LDFLAGS cover the conventional path.
+glib_inc=""
+for i in $(pkg-config --cflags-only-I glib-2.0 gobject-2.0); do
+  glib_inc="${glib_inc:+$glib_inc:}${i#-I}"
+done
+export CPATH="${glib_inc}${CPATH:+:$CPATH}"
+export LIBRARY_PATH="/usr/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
+glib_cflags="$(pkg-config --cflags glib-2.0 gobject-2.0)"
+glib_libs="$(pkg-config --libs glib-2.0 gobject-2.0)"
+export CFLAGS="${CFLAGS:-} ${glib_cflags}"
+export CXXFLAGS="${CXXFLAGS:-} ${glib_cflags}"
+export LDFLAGS="${LDFLAGS:-} ${glib_libs}"
+
 node install/build.js
 
 # Clean up native build artifacts, keeping only the final .node addon


### PR DESCRIPTION
## What
Unblocks the `next` rebuild triggered by the base-soup bundle (#240). Three coupled fixes — next won't build without all three:
1. **`packages/next/build.ncl`** — add `glib` to `build_deps` + `runtime_deps` (puts glib's headers, `glib-2.0.pc`, `libglib.so` in the sandbox/runtime closure).
2. **`packages/next/build.sh`** — surface glib's include/lib paths to the sharp native compile.
3. **`packages/libvips/build.ncl`** — bump 8.18.2 → **8.18.3** (sha verified against upstream `.sha256sum`).

## Why — latent FTBFS surfaced by the cascade (NOT a binutils/coreutils defect)
The bundle (#240) forced the toolchain closure to rebuild, including `next`. **This was the first _genuine_ recompile of `next` since #161; every build since was a cache hit** — which is why it appeared fine recently. The true rebuild compiles `sharp` from source against the system libvips, and exposed two pieces of accumulated drift. Diagnosed across three buildbot rounds, each error advancing past the last:

### (a) `glib-object.h: No such file` — fixed by parts 1+2
`vips/vips8` is a **public** libvips header that `#include`s `<glib-object.h>`, but `vips-cpp.pc` lists glib under **`Requires.private`**. sharp's node-gyp build runs a *non-static* `pkg-config --cflags vips-cpp`, which doesn't expand private requires — so glib's `-I/usr/include/glib-2.0` was never on the compile line. Adding glib to the deps put the headers in the sandbox; `build.sh` now exports them via **`CPATH`** (read by gcc directly, independent of node-gyp's Makefile flag handling) + `CXXFLAGS`/`LDFLAGS`.

### (b) `"libvips version 8.18.3+ is required"` — fixed by part 3
With the headers found, the compile advanced to sharp's version assertion. `next/build.sh` installs `sharp` **unpinned** (always latest); sharp 0.35.1 hard-requires libvips ≥ 8.18.3, **released only 2026-06-09**. Our package was pinned at 8.18.2 → assertion failure. Bumped to 8.18.3 (the version sharp's `libvips-cpp-8.18.3.stamp` expects).

## Residual uncertainty (buildbot is the judge)
- I can't reproduce the sharp build locally (clean-room VM stalled on spin-up), so the buildbot verdict is the truth.
- Confirmed fixed: glib header (round 2 got past it) → libvips version (round 3 error). The remaining unknown is the **link** step; `.node` addons usually tolerate undefined glib symbols (resolved at load via libvips → libglib) and I've added `LDFLAGS` anyway. If link surfaces something, it's a one-line follow-up here.

## Follow-up worth filing (not in this PR)
`next/build.sh`'s `npm install --ignore-scripts sharp` is **unpinned** — this exact break (sharp bumps its min-libvips, we lag) will recur. Pinning sharp to a known-good version in the install line would make the build reproducible. Flagging for a separate hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bump binutils to 2.46.1.
  * Bump coreutils to 9.11.
  * Bump libvips to 8.18.3.
  * Add glib to the "next" package build/runtime to improve native image-processing builds so required native headers/libs are found during build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->