### PR TITLE
feat(capy): add capy 0.7.0

### DIFF
--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -1,0 +1,75 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let ca-certificates = import "../ca-certificates/build.ncl" in
+let git = import "../git/build.ncl" in
+let node-lts = import "../node-lts/build.ncl" in
+
+let version = "0.7.0" in
+{
+  name = "capy",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    # @capysc/cli source, hash-pinned and built from source (not the prebuilt
+    # npm artifact). Referenced by url+sha256 — the source is never vendored
+    # into this registry.
+    {
+      url = "https://github.com/capysc/capy-cli/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "d2efcb436c58061662e9546d61e6b8cc1e650ae235236a89c7fe6a00265392ca",
+      extract = true,
+      strip_prefix = "capy-cli-%{version}",
+    } | Source,
+    node-lts, # node + npm to build (tsc) and stage the CLI
+  ],
+  runtime_deps = [
+    base,
+    glibc,
+    coreutils, # `capy` shebang resolves node via /usr/bin/env
+    ca-certificates, # HTTPS to the Capy API (sync, decryption)
+    git, # capy shells out to git for repo/branch detection
+    node-lts, # capy is a Node CLI (#!/usr/bin/env node)
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  # build.sh compiles the pinned source tarball above (tsc), then `npm install`
+  # pulls the CLI's runtime deps from the registry — dns+internet cover that
+  # dependency fetch. Follow-up: vendor the transitive npm deps as hash-pinned
+  # Sources for a fully hermetic / SLSA build.
+  needs = { dns = {}, internet = {} },
+
+  outputs = {
+    capy = { glob = "usr/bin/capy" } | OutputBin,
+    node_modules = { glob = "usr/lib/node_modules/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "capysc",
+        repo = "capy-cli",
+      },
+      # Maps the developer's ~/.capy into the box so in-box capy reuses the
+      # existing login instead of transporting keys. Mounted read-write so capy
+      # can refresh its session and update its local cache. For trusted
+      # developer shells.
+      env_dir_mappings = [{ read_only = false, path = "~/.capy", class = 'Credential }],
+    } | Attrs,
+
+  tests = {
+    runs =
+      {
+        class = 'Standalone,
+        test_deps = [base, node-lts],
+        cmds = [
+          # capy must run and report its version with no auth/network/config.
+          ["/bin/bash", "-c", "capy --version | grep -q '%{version}'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/capy/build.sh
+++ b/packages/capy/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -ex
+
+# The @capysc/cli source tarball is declared as a Source in build.ncl
+# (extract = true, strip_prefix), so its contents are already unpacked into the
+# working directory. Build it from source rather than installing the prebuilt
+# npm artifact.
+
+npm install                  # no committed lockfile upstream -> install, not ci
+npm run build                # tsc -> dist/
+npm pkg delete bin.capy-dev  # match the published artifact (upstream prepublishOnly)
+
+# Pack the built package, then install the tarball into the output prefix.
+# Packing first copies real files in; a bare `npm install -g .` would instead
+# symlink back to the source dir, which escapes $OUTPUT_DIR.
+npm pack
+npm install -g --prefix="$OUTPUT_DIR/usr" ./*.tgz


### PR DESCRIPTION
## Summary
Adds a `capy` package — the Capy CLI for managing end-to-end encrypted environment variables across a team. 

- Pinned to **v0.7.0**, built **from source** (`github.com/capysc/capy-cli`) with the packaged `node-lts` toolchain (`tsc`), not a prebuilt npm artifact.
- Runtime deps: `node-lts`, `glibc`, `coreutils`, `ca-certificates`,
`git`.
- Declares `dns`/`internet` for npm dependency fetching during the build.
- `source_provenance` points at the canonical upstream.

## Testing

- `min check --packages capy` — passes (0 failures; standalone `capy
--version` test passes) 
- `min patched-build capy` — clean-room build from source succeeds

## Changes

- Add new package **capy** at **v0.7.0**.
- Source:
`https://github.com/capysc/capy-cli/archive/refs/tags/v0.7.0.tar.gz`
(extracted via `strip_prefix`; built from source with
`node-lts`/`tsc`).
- Packs the built package and installs the tarball into the output
prefix
(avoids a source-dir symlink escaping `$OUTPUT_DIR`).
- Runtime deps: `node-lts`, `glibc`, `coreutils`, `ca-certificates`,
`git`.
- `sha256` verified against the upstream archive.

## Checklist

- [x] I've read CONTRIBUTING.md.
- [x] I've accepted the ICLA/CCLA. CLA Assistant will confirm on this PR.
- [x] `min check` passes for the affected packages.
- [x] `min patched-build capy` succeeds.
- [x] New package: `source_provenance` points to the canonical upstream
and it builds from source.
- [x] `sha256` verified against the upstream archive.

## Notes for reviewers

The CLI's runtime npm dependencies are fetched at build (via `dns`/`internet`) rather than vendored as hash-pinned sources — happy to vendor/pin them as a follow-up if that's preferred.