### PR TITLE
bc: fix source_provenance GnuProject → GithubRepo gavinhoward/bc

### DIFF
--- a/packages/bc/build.ncl
+++ b/packages/bc/build.ncl
@@ -38,8 +38,9 @@ let version = "7.0.3" in
       license_spdx = "BSD-2-Clause",
       repology_project = "bc-gh",
       source_provenance = {
-        category = 'GnuProject,
-        name = "bc",
+        category = 'GithubRepo,
+        owner = "gavinhoward",
+        repo = "bc",
       },
     } | Attrs,
 


### PR DESCRIPTION
## What
Correct `bc`'s `source_provenance` from `GnuProject` (name=`bc`) to `GithubRepo gavinhoward/bc`.

## Why
`bc`'s real upstream is **gavinhoward/bc** (the modern BSD/GPL `bc`, currently 7.0.3), **not** GNU bc (which tops out at 1.07.1). The `GnuProject` label is a mislabel — flagged in the provenance audit, and confirmed live by a perf workflow this morning.

Two concrete problems it causes:
1. **Vuln-scan namespace is wrong.** `bc` is scanned against GNU bc's CVE namespace instead of gavinhoward/bc — a latent false-negative.
2. **Upstream-version resolution is fragile.** Today it only resolves correctly because of the `repology_project = "bc-gh"` workaround. An upcoming pkgmgr change reorders the upstream-check cascade to try provenance-specific resolvers (GNU FTP) **before** the generic repology tier — under which `bc` would hit GNU FTP first, get 1.07.x, stop the cascade, and the no-downgrade guard would clamp it → **`bc` silently frozen, never seeing a real 7.x update again.** This PR removes `bc` from the `GnuProject ∩ repology` set so that reorder is safe.

## Safety
- `source_provenance` is **metadata only** (vuln-scan + upstream-version check). The build source is unchanged — `bc` still builds from `gs://minimal-staging-archives/bc-%{version}.tar.xz`. No rebuild impact.
- `repology_project = "bc-gh"` is kept as a fallback; with correct GithubRepo provenance, the GitHub-releases tier is now primary.

## Reviewer note
Worth a sanity-check that gavinhoward/bc is the intended upstream (it is — v7.x matches the pinned 7.0.3). On merge this propagates to the vulndb (provenance → scan namespace) on the next ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
