### PR TITLE
zsh: fix dead source URL (5.9 moved to /pub/old/)

### DIFF
--- a/packages/zsh/build.ncl
+++ b/packages/zsh/build.ncl
@@ -17,7 +17,7 @@ let version = "5.9" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "https://www.zsh.org/pub/zsh-%{version}.tar.xz",
+      url = "https://www.zsh.org/pub/old/zsh-%{version}.tar.xz",
       sha256 = "9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5",
       extract = true,
       strip_prefix = "zsh-%{version}",


### PR DESCRIPTION
`https://www.zsh.org/pub/zsh-5.9.tar.xz` now returns **404** — zsh.org moved older releases under `/pub/old/`, so zsh fails to build (source can't be fetched).

Fix: point at `https://www.zsh.org/pub/old/zsh-%{version}.tar.xz`, which serves the **identical tarball** — sha256 `9b8d1ecedd...` unchanged (verified by download). Content-identical URL swap; no version/behavior change.

Found by the reproducibility audit (landed as `build_failed` with the 404 in its log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the download source for the zsh package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->