### PR TITLE
gnutls: add GnuProject source_provenance (un-dark the vuln scan, surfaces CVE-2025-32988)

### DIFF
--- a/packages/gnutls/build.ncl
+++ b/packages/gnutls/build.ncl
@@ -55,5 +55,12 @@ let version = "3.8.9" in
     {
       upstream_version = version,
       license_spdx = "(GPL-3.0-only AND LGPL-2.1-only)",
+      # Vuln-scan identity. GnuProject → pkg:generic/gnu/gnutls, which the
+      # cpe_remap maps to NVD's gnu:gnutls — without this, gnutls is "dark"
+      # (no provenance → never queried → reported 0/0/0 despite real CVEs).
+      source_provenance = {
+        category = 'GnuProject,
+        name = "gnutls",
+      },
     } | Attrs,
 } | BuildSpec


### PR DESCRIPTION
## What

Adds `source_provenance = GnuProject "gnutls"` to gnutls's `build.ncl`.

## Why

gnutls was one of the **66 "dark" packages** — no `source_provenance`, so the vuln scanner never queried it and reported **0/0/0**. It's actually sitting on a **HIGH**: `CVE-2025-32988` affects the pinned 3.8.9.

`GnuProject "gnutls"` → `pkg:generic/gnu/gnutls`, which resolves via the **existing** `cpe_remap` (`gnu:gnutls`) — so no supply-chain change is needed, the scan path (pm#193) lights up immediately.

## Verified locally
- `pkgmgr vulns --package gnutls` → now reports **CVE-2025-32988 (HIGH)** (was 0/0/0).
- `pkgmgr check --package gnutls` → still resolves cleanly (up-to-date at 3.8.9). Note: the fix is in the **unreleased 3.8.10**, so there's no bump available yet — this is a *track-until-fix-ships* HIGH, surfaced now instead of hidden.

First of the dark-package provenance backfill from the 66-package audit (wf w4kghqujr). mesa + dnsutils follow (those also need a `cpe_remap` row in supply-chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
