### PR TITLE
docs(AGENTS): add concise reproducibility recipes for build.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,6 +567,10 @@ let bash = import "../bash/build.ncl" in
 
 The build script must install everything to `$OUTPUT_DIR`.
 
+**Every package must be reproducible** — layer the determinism flags from
+[Reproducibility (required)](#reproducibility-required) below onto whichever pattern you
+use. The patterns below show the minimal shape; they are not complete without those flags.
+
 #### Autotools pattern
 
 ```bash
@@ -629,6 +633,32 @@ cargo build --release
 mkdir -p $OUTPUT_DIR/usr/bin
 cp target/release/my-tool $OUTPUT_DIR/usr/bin/
 ```
+
+
+### Reproducibility (required)
+
+Two builds of the same source must produce **byte-identical** output — the build cache is
+content-addressed and can't trust non-reproducible artifacts. The sandbox does **not** pin
+the clock or inject flags for you; determinism is `build.sh`'s responsibility. Apply the
+recipe for your build system on top of the pattern above. Background and the full taxonomy
+of non-determinism: <https://reproducible-builds.org/>.
+
+- **C / C++:** `CFLAGS="… -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"`,
+  `CXXFLAGS="$CFLAGS"`, `LDFLAGS="-Wl,--build-id=none"`, `export ARFLAGS=Drc`
+  (autotools: also pass `--enable-deterministic-archives` to `./configure`).
+- **Go:** every `go build`/`go install`: `-trimpath -ldflags "-buildid="`
+  (add `-buildvcs=false` if the source tree contains a `.git` directory).
+- **Rust:** `RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"`;
+  if the binary still differs in `.text`/`.rodata`, also add `-C codegen-units=1` and
+  `export CONST_RANDOM_SEED=0`.
+- **Linux kernel:** `export KBUILD_BUILD_TIMESTAMP=@0 KBUILD_BUILD_USER=builder KBUILD_BUILD_HOST=minimal`.
+- **Embedded timestamps** (configure scripts, generated docs, `__DATE__`/`__TIME__`):
+  `export SOURCE_DATE_EPOCH=0` (and `PYTHONHASHSEED=0` for Python-based build steps).
+- **Post-install:** drop libtool archives — `find "$OUTPUT_DIR" -name '*.la' -delete`.
+
+**Verify:** build the package twice and compare the two `$OUTPUT_DIR` trees — they must be
+byte-for-byte identical. When they differ, the diff points at the cause (a timestamp, a
+build path, a random build-id) and the recipe above has the fix.
 
 
 ### Step 4: Validate


### PR DESCRIPTION
## What

Adds a concise **Reproducibility (required)** subsection to the "Creating packages workflow → Step 3: Write build.sh" section of `AGENTS.md` (which `CLAUDE.md` symlinks to).

## Why

Step 3's existing `build.sh` patterns (Autotools / CMake / Go / Rust) include **no determinism flags** — so a package authored by copying them defaults to non-reproducible. Reproducibility was mentioned only abstractly elsewhere in the doc (no actionable recipes). The build cache is content-addressed, so non-reproducible outputs undermine cache trust and cross-machine verification.

## What's in it

A self-contained, tool-agnostic recipe per build system:

- **C/C++** — `-ffile-prefix-map`, `-gno-record-gcc-switches`, `-Wl,--build-id=none`, `ARFLAGS=Drc` (+ `--enable-deterministic-archives`)
- **Go** — `-trimpath -ldflags "-buildid="` (+ `-buildvcs=false` when a `.git` dir is present)
- **Rust** — `--remap-path-prefix` (build dir + cargo registry); `-C codegen-units=1` + `CONST_RANDOM_SEED=0` for the deeper codegen/compile-time-RNG cases
- **Linux kernel** — `KBUILD_BUILD_TIMESTAMP/_USER/_HOST`
- **Embedded timestamps** — `SOURCE_DATE_EPOCH=0` (+ `PYTHONHASHSEED=0`)
- **Post-install** — drop libtool `.la` archives
- **Verify** — build twice, compare `$OUTPUT_DIR` byte-for-byte

Plus a pointer at the top of Step 3 so the patterns aren't taken as complete on their own. Links to <https://reproducible-builds.org/> for background. No references to private/internal tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Build documentation now includes explicit reproducibility requirements for all package builds
  * Provides determinism guidance across multiple build systems including C/C++, Go, Rust, Linux kernel, and embedded timestamps
  * Includes verification instructions for confirming reproducible builds through rebuild comparison

<!-- end of auto-generated comment: release notes by coderabbit.ai -->