### PR TITLE
virtio-linux: pin KBUILD_BUILD_* for reproducible kernel image

### DIFF
--- a/packages/virtio-linux/build.sh
+++ b/packages/virtio-linux/build.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 
 JOBS=$(nproc)
 
+# Reproducibility: the kernel bakes build time/user/host into the image
+# (scripts/mkcompile_h). Pin them so vmlinuz is byte-identical across builds.
+export KBUILD_BUILD_TIMESTAMP="@${SOURCE_DATE_EPOCH:-0}"
+export KBUILD_BUILD_USER=builder
+export KBUILD_BUILD_HOST=minimal
+
 # Pick the right kernel image target + path per host arch. arm64's analogue
 # of bzImage is just `Image`; there's no `kvm_guest.config` fragment for
 # arm64 either, so we only merge that on x86.


### PR DESCRIPTION
## What

Pins the kernel's embedded build metadata so the `virtio-linux` image is reproducible.

## Why

The Linux kernel bakes build time, user, and host into the image (via `scripts/mkcompile_h`, surfaced in `/proc/version`), so `vmlinuz` differed byte-for-byte across otherwise-identical rebuilds. Setting the standard `KBUILD_BUILD_*` variables makes those fields deterministic (timestamp derived from `SOURCE_DATE_EPOCH`, defaulting to epoch 0).

```sh
export KBUILD_BUILD_TIMESTAMP="@${SOURCE_DATE_EPOCH:-0}"
export KBUILD_BUILD_USER=builder
export KBUILD_BUILD_HOST=minimal
```

## Verification

Verified with a build-twice-and-diff on aarch64: two from-scratch forced rebuilds (`--rebuild --no-fetch`) produced **byte-identical** output (3/3 files identical). Before this change the image diverged on the embedded timestamp/user/host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved kernel build reproducibility to ensure builds are deterministic and consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->