### PR TITLE
agent-browser: make Rust CLI + pnpm tree reproducible

### DIFF
--- a/packages/agent-browser/build.sh
+++ b/packages/agent-browser/build.sh
@@ -3,7 +3,8 @@ set -e
 
 export CC=gcc
 export LD=gcc
-export RUSTFLAGS="-C linker=gcc"
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo -C codegen-units=1"
+export CONST_RANDOM_SEED=0   # pin ahash/const-random compile-time seed
 
 # Install JS deps (skip postinstall which downloads pre-built binary).
 # Use the hoisted node-linker so node_modules is a flat, self-contained
@@ -34,6 +35,10 @@ cp cli/target/release/agent-browser bin/agent-browser-${PLATFORM}
 install -d $OUTPUT_DIR/usr/bin
 install -d $OUTPUT_DIR/usr/libexec/agent-browser
 
+# pnpm bakes wall-clock timestamps into its node_modules state files
+# (.modules.yaml `prunedAt`, .pnpm-workspace-state-v1.json `lastValidatedTimestamp`)
+# — non-deterministic and not needed at runtime. Drop them before packaging.
+rm -f node_modules/.modules.yaml node_modules/.pnpm-workspace-state-v1.json
 cp -R dist bin node_modules package.json $OUTPUT_DIR/usr/libexec/agent-browser/
 
 cat > $OUTPUT_DIR/usr/bin/agent-browser << EOF


### PR DESCRIPTION
## What

Makes the `agent-browser` package reproducible — its Rust CLI and its pnpm `node_modules` tree both diverged across rebuilds.

## Why / fixes

Two independent causes, both addressed:

1. **Rust CLI codegen non-determinism.** The release build split each crate into parallel codegen units (non-deterministic `.llvm.<hash>` symbols + function partitioning) and `ahash`/`const-random` baked a compile-time random seed. Fixed by extending `RUSTFLAGS`:
   ```sh
   export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo -C codegen-units=1"
   export CONST_RANDOM_SEED=0
   ```

2. **pnpm state-file timestamps.** pnpm writes wall-clock timestamps into two `node_modules` state files that aren't needed at runtime — `.modules.yaml` (`prunedAt`) and `.pnpm-workspace-state-v1.json` (`lastValidatedTimestamp`). Drop both before packaging.

## Verification

Two from-scratch forced rebuilds (`--rebuild --no-fetch`, aarch64) produced output identical in **12,737 / 12,738** files — with the codegen fixes in place, the *only* remaining difference was the `.pnpm-workspace-state-v1.json` timestamp. After removing that file the two builds are **byte-for-byte identical** (`repro-check diff`, 0 differences). The Rust binary and all other artifacts were already byte-identical, confirming the codegen flags resolve the CLI non-determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build script reproducibility and determinism by adding compiler flags and removing non-deterministic artifacts during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->