### PR TITLE
nspr: pin build timestamp for reproducible library

### DIFF
--- a/packages/nspr/build.sh
+++ b/packages/nspr/build.sh
@@ -10,7 +10,15 @@ export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
 
+# Reproducibility: NSPR stamps a wall-clock build time into the library version
+# string (config/now.c -> _BUILD_TIME, and `date` -> _BUILD_STRING) and ignores
+# SOURCE_DATE_EPOCH. Override the two make vars the version header is built from:
+# SH_NOW="" omits _BUILD_TIME (defaults to 0 in prvrsion.c); SH_DATE is pinned
+# from SOURCE_DATE_EPOCH.
+export SOURCE_DATE_EPOCH=0
+BUILD_DATE="$(date -u -d "@${SOURCE_DATE_EPOCH}" '+%Y-%m-%d %T')"
+
 cd nspr
 ./configure --prefix=/usr --disable-static --enable-64bit
-make -j$(nproc)
+make -j$(nproc) SH_DATE="$BUILD_DATE" SH_NOW=
 make DESTDIR=$OUTPUT_DIR install

--- a/packages/nspr/build.sh
+++ b/packages/nspr/build.sh
@@ -14,9 +14,8 @@ export CXXFLAGS="${CFLAGS}"
 # string (config/now.c -> _BUILD_TIME, and `date` -> _BUILD_STRING) and ignores
 # SOURCE_DATE_EPOCH. Override the two make vars the version header is built from:
 # SH_NOW="" omits _BUILD_TIME (defaults to 0 in prvrsion.c); SH_DATE is pinned
-# from SOURCE_DATE_EPOCH.
-export SOURCE_DATE_EPOCH=0
-BUILD_DATE="$(date -u -d "@${SOURCE_DATE_EPOCH}" '+%Y-%m-%d %T')"
+# from SOURCE_DATE_EPOCH (set by the build sandbox).
+BUILD_DATE="$(LC_ALL=C TZ=UTC date -u -d "@${SOURCE_DATE_EPOCH:-0}" '+%Y-%m-%d %T' 2>/dev/null || echo '1970-01-01 00:00:00')"
 
 cd nspr
 ./configure --prefix=/usr --disable-static --enable-64bit


### PR DESCRIPTION
## What

Makes the `nspr` library reproducible by pinning the build timestamp it bakes into its version string.

## Why

NSPR stamps a wall-clock build time into the library's embedded version info (the `"<date> libnspr4.so Portable runtime"` string), and it **ignores `SOURCE_DATE_EPOCH`**, so `libnspr4.so` differed across rebuilds. There are two sources, both in the generated version header (`_pr_bld.h`), built in `pr/src/Makefile.in`:

- `_BUILD_STRING "$(SH_DATE)"` where `SH_DATE = $(shell date ...)` — a human-readable build date (written unconditionally)
- `_BUILD_TIME $(SH_NOW)` from `config/now.c` (`time(NULL) * 1e6`) — written only when `SH_NOW` is non-empty

## Fix

Both are plain make variables, so no source patch is needed — override them on the `make` line:

```sh
export SOURCE_DATE_EPOCH=0
BUILD_DATE="$(date -u -d "@${SOURCE_DATE_EPOCH}" '+%Y-%m-%d %T')"
make -j$(nproc) SH_DATE="$BUILD_DATE" SH_NOW=
```

`SH_NOW=` (empty) makes the Makefile skip the `_BUILD_TIME` define, which then defaults to `0` in `pr/src/prvrsion.c`; `SH_DATE` is pinned from `SOURCE_DATE_EPOCH`.

## Verification

Build-twice-and-diff on aarch64 (`--rebuild --no-fetch`): two from-scratch builds are **byte-for-byte identical** (`repro-check diff`, 72/72 files, 0 differences). Before this change the library diverged on the embedded build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build reproducibility to ensure consistent version metadata generation across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->