### PR TITLE
docs(AGENTS): fix reproducibility guidance (sandbox sets SOURCE_DATE_EPOCH)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,23 +638,27 @@ cp target/release/my-tool $OUTPUT_DIR/usr/bin/
 ### Reproducibility (required)
 
 Two builds of the same source must produce **byte-identical** output — the build cache is
-content-addressed and can't trust non-reproducible artifacts. The sandbox does **not** pin
-the clock or inject flags for you; determinism is `build.sh`'s responsibility. Apply the
-recipe for your build system on top of the pattern above. Background and the full taxonomy
-of non-determinism: <https://reproducible-builds.org/>.
+content-addressed and can't trust non-reproducible artifacts. The build sandbox already
+exports `SOURCE_DATE_EPOCH=0` and `PYTHONHASHSEED=0` for you, so **do not set those
+yourself** — `minimal-check` rejects it. Compiler/linker determinism flags are otherwise
+`build.sh`'s responsibility. Apply **only the bullet that matches your build system** —
+these are per-stack recipes, not a checklist to run all of. Background and the full
+taxonomy of non-determinism: <https://reproducible-builds.org/>.
 
 - **C / C++:** `CFLAGS="… -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"`,
   `CXXFLAGS="$CFLAGS"`, `LDFLAGS="-Wl,--build-id=none"`, `export ARFLAGS=Drc`
-  (autotools: also pass `--enable-deterministic-archives` to `./configure`).
+  (autotools: also pass `--enable-deterministic-archives` to `./configure`; post-install,
+  drop libtool archives with `find "$OUTPUT_DIR" -name '*.la' -delete`).
 - **Go:** every `go build`/`go install`: `-trimpath -ldflags "-buildid="`
   (add `-buildvcs=false` if the source tree contains a `.git` directory).
 - **Rust:** `RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"`;
   if the binary still differs in `.text`/`.rodata`, also add `-C codegen-units=1` and
   `export CONST_RANDOM_SEED=0`.
 - **Linux kernel:** `export KBUILD_BUILD_TIMESTAMP=@0 KBUILD_BUILD_USER=builder KBUILD_BUILD_HOST=minimal`.
-- **Embedded timestamps** (configure scripts, generated docs, `__DATE__`/`__TIME__`):
-  `export SOURCE_DATE_EPOCH=0` (and `PYTHONHASHSEED=0` for Python-based build steps).
-- **Post-install:** drop libtool archives — `find "$OUTPUT_DIR" -name '*.la' -delete`.
+- **A build that bakes in its own wall-clock time** despite `SOURCE_DATE_EPOCH` (version
+  strings, generated headers): pin that specific stamp rather than re-exporting
+  `SOURCE_DATE_EPOCH`. For example `nspr` overrides the make variables its version header
+  is generated from (`SH_DATE` from `$SOURCE_DATE_EPOCH`, `SH_NOW=` to omit the build time).
 
 **Verify:** build the package twice and compare the two `$OUTPUT_DIR` trees — they must be
 byte-for-byte identical. When they differ, the diff points at the cause (a timestamp, a


### PR DESCRIPTION
## What

Corrects the **Reproducibility (required)** guidance added in #259, which had two factual errors and one framing issue that caused real fallout.

## Why

The build sandbox **already exports `SOURCE_DATE_EPOCH=0` and `PYTHONHASHSEED=0`**, and `minimal-check`'s `build script disallowed-patterns` checker actively *rejects* re-setting them in a `build.sh`. But the merged guidance said the opposite:

- It claimed "the sandbox does **not** pin the clock" — false.
- It told authors to `export SOURCE_DATE_EPOCH=0` (and `PYTHONHASHSEED=0`) — which **fails CI**.

This already bit us: the `nspr` reproducibility PR followed the guidance, added `export SOURCE_DATE_EPOCH=0`, and failed `minimal-check`. CodeRabbit also cited the guidance to (incorrectly) request the same export on an unrelated PR.

A secondary issue: the bullets read as a universal checklist, so the C/autotools items (e.g. libtool `.la` cleanup) got applied to non-C packages.

## Changes

- State that the sandbox provides `SOURCE_DATE_EPOCH=0` / `PYTHONHASHSEED=0` and must **not** be set in `build.sh`.
- Replace the "export `SOURCE_DATE_EPOCH=0`" bullet with the correct pattern for builds that ignore `SOURCE_DATE_EPOCH`: pin the *specific* stamp (with `nspr`'s `SH_DATE`/`SH_NOW` as the worked example).
- Fold the libtool `.la` cleanup into the C/C++ bullet (where it belongs) and make explicit that authors apply **only the bullet for their build system**, not all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated build determinism and reproducibility guidance with clarified environment variable configuration in the build sandbox
* Refined C/C++ build recipes with improved cleanup procedures for better reproducibility
* Expanded recommendations for projects with embedded timestamps, including practical implementation examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->