### PR TITLE
patchelf: add upstream_version to un-dark version-check

### DIFF
--- a/packages/patchelf/build.ncl
+++ b/packages/patchelf/build.ncl
@@ -33,6 +33,11 @@ let glibc = import "../glibc/build.ncl" in
   },
   attrs =
     {
+      # patchelf pins a master snapshot ahead of the 0.18.0 tag, but had no
+      # upstream_version, so `pkgmgr check` couldn't compare against the
+      # GithubRepo provenance (update-dark). Stamp the release it's based on;
+      # check flags it once NixOS cuts the next release.
+      upstream_version = "0.18.0",
       license_spdx = "GPL-3.0-or-later",
       source_provenance = {
         category = 'GithubRepo,


### PR DESCRIPTION
patchelf has `source_provenance = GithubRepo NixOS/patchelf` but no `upstream_version`, so `pkgmgr check` couldn't compare against it — silently update-dark (never gets bump PRs). The pin is a master snapshot based on the 0.18.0 release; stamping `upstream_version = "0.18.0"` lets check resolve via GitHub.

Verified: `check --package patchelf` → 0.18.0 up-to-date. Once NixOS cuts 0.19.0, check correctly flags it.

(socat was investigated in the same batch but left update-dark: its only upstream, dest-unreach.org, is HTTP-only / self-signed HTTPS, and repology has no clean `newest` entry — no trusted version source exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated patchelf to version 0.18.0 in the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->