### PR TITLE
dnsutils: bump BIND 9.20.20 -> 9.20.24 (stable line)

### DIFF
--- a/packages/dnsutils/build.ncl
+++ b/packages/dnsutils/build.ncl
@@ -11,14 +11,14 @@ let libcap = import "../libcap/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "9.20.20" in
+let version = "9.20.24" in
 {
   name = "dnsutils",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://downloads.isc.org/isc/bind9/%{version}/bind-%{version}.tar.xz",
-      sha256 = "19b8335d25305231d5eb8f7d924240d1ac97c4da7c93eaa6273503133aa6106a",
+      sha256 = "989fef1fc88ea59d04cd86f854dca5a4616a20a9968bcdde3c1a3668ab36be08",
     } | Source,
     base,
     toolchain,


### PR DESCRIPTION
Bumps **dnsutils (BIND)** `9.20.20 → 9.20.24` along the stable line.

### Why this instead of #269
The auto-generated #269 proposed `9.20.20 → 9.21.23`, which **broke the build** (exit 127):

```
+ cd bind-9.21.23
+ ./configure --prefix=/usr ...
./build.sh: line 16: ./configure: No such file or directory
```

BIND uses **odd-numbered minors as development branches** (9.21, 9.23, …) and **even minors as stable** (9.18, 9.20). The 9.21 dev branch has dropped the autotools build, so its tarball ships no `./configure`. We pin the stable line on purpose; **9.20.24** is the current stable release and keeps the existing configure-based `build.sh` unchanged.

### Verification
- `pkgmgr check --package dnsutils` → `up_to_date=1` (was proposing 9.21.23).
- Build path unchanged (autotools); only `version` + source `sha256` move.

### Root-cause fix
The version-check override that suggested the dev branch is fixed in **minimal-supply-chain#261** — it now constrains `dnsutils` to its `major.minor` stable line (same pattern as the LTS kernel), so it tracks `9.20.x` and never jumps to `9.21`.

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated BIND DNS utility from version 9.20.20 to 9.20.24 with latest upstream improvements and security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->