### PR TITLE
Add libkrun, libkrunfw, and build deps cpio + pyelftools

### DIFF
--- a/packages/cpio/build.ncl
+++ b/packages/cpio/build.ncl
@@ -1,0 +1,47 @@
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "2.15" in
+{
+  name = "cpio",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://mirrors.kernel.org/gnu/cpio/cpio-%{version}.tar.gz",
+      sha256 = "efa50ef983137eefc0a02fdb51509d624b5e3295c980aa127ceee4183455499e",
+      extract = true,
+      strip_prefix = "cpio-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+  ],
+
+  runtime_deps = [glibc],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    cpio = { glob = "usr/bin/cpio" } | OutputBin,
+    mans = { glob = "usr/share/man/**" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GnuProject,
+        name = "cpio",
+      },
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/cpio --version",
+  },
+} | BuildSpec

--- a/packages/cpio/build.sh
+++ b/packages/cpio/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -ex
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+# cpio 2.15 uses K&R `int xstat()` declarations; GCC's C23 default reads `()`
+# as zero-args and rejects the calls. -std=gnu17 restores the older semantics.
+export CFLAGS="$MARCH -O2 -pipe -std=gnu17 -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr
+make -j"$(nproc)"
+make DESTDIR="$OUTPUT_DIR" install

--- a/packages/libkrun/build.ncl
+++ b/packages/libkrun/build.ncl
@@ -1,0 +1,62 @@
+let { subsetOf, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let libkrunfw = import "../libkrunfw/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "1.19.0" in
+{
+  name = "libkrun",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/containers/libkrun/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "832e76e93f1ea7a41e5c763a9710acf42d3d54f628015c1255f115a4b7ef2a06",
+      extract = true,
+      strip_prefix = "libkrun-%{version}",
+    } | Source,
+    base,
+    toolchain,
+    make,
+    rust,
+    pkgconf,
+  ],
+
+  # libkrunfw is dlopen()ed at runtime (libkrunfw.so.5), not linked at build.
+  runtime_deps = [
+    glibc,
+    libkrunfw,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  # cargo fetches crates from crates.io during the build.
+  needs = {
+    dns = {},
+    internet = {},
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/libkrun.so*" } | OutputLib,
+    headers = { glob = "usr/include/libkrun*.h" } | OutputData,
+    pkgconfig = { glob = "usr/lib/pkgconfig/libkrun.pc" } | OutputData,
+  },
+
+  attrs = {
+    upstream_version = version,
+    source_provenance = {
+      category = 'GithubRepo,
+      owner = "containers",
+      repo = "libkrun",
+    },
+  },
+} | BuildSpec

--- a/packages/libkrun/build.sh
+++ b/packages/libkrun/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -ex
+
+# The sandbox has no `cc` symlink, so force gcc for both cargo's cc-rs builds
+# and the init blob compiled by init_blob/build.rs.
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+# BLK=1 enables virtio-blk (exports krun_add_disk2); `blk` is not a default
+# libkrun feature, so consumers fail to link without it.
+make CC=gcc BLK=1 -j"$(nproc)"
+# Install to lib (not the Makefile's default lib64), matching the repo convention.
+make CC=gcc BLK=1 install PREFIX=/usr DESTDIR="$OUTPUT_DIR" LIBDIR_Linux=lib

--- a/packages/libkrunfw/build.ncl
+++ b/packages/libkrunfw/build.ncl
@@ -1,0 +1,71 @@
+let { BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bc = import "../bc/build.ncl" in
+let bison = import "../bison/build.ncl" in
+let cpio = import "../cpio/build.ncl" in
+let elfutils = import "../elfutils/build.ncl" in
+let flex = import "../flex/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let m4 = import "../m4/build.ncl" in
+let make = import "../make/build.ncl" in
+let openssl = import "../openssl/build.ncl" in
+let patch = import "../patch/build.ncl" in
+let perl = import "../perl/build.ncl" in
+let pyelftools = import "../pyelftools/build.ncl" in
+let python = import "../python/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "5.5.0" in
+{
+  name = "libkrunfw",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/containers/libkrunfw/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "b0cbf1450269c80aea1dccbf440011deb2762a098b338c234079a6ef06456ead",
+      extract = true,
+      strip_prefix = "libkrunfw-%{version}",
+    } | Source,
+    # Guest kernel firmware source, vendored so the build is hermetic (the
+    # Makefile otherwise curls it into tarballs/ at build time).
+    {
+      url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.91.tar.xz",
+      sha256 = "0ff2ab9e169f9f1948557471fbb450d3018f8c5b77caf288e1a3982582597969",
+    } | Source,
+    base,
+    toolchain,
+    make,
+    flex,
+    bison,
+    m4,
+    bc,
+    cpio,
+    elfutils,
+    openssl,
+    perl,
+    patch,
+    python,
+    pyelftools,
+  ],
+
+  runtime_deps = [glibc],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/libkrunfw.so*" } | OutputLib,
+  },
+
+  attrs = {
+    upstream_version = version,
+    source_provenance = {
+      category = 'GithubRepo,
+      owner = "containers",
+      repo = "libkrunfw",
+    },
+  },
+} | BuildSpec

--- a/packages/libkrunfw/build.sh
+++ b/packages/libkrunfw/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -ex
+
+# The guest kernel source is vendored as a Source; the Makefile expects it
+# under tarballs/ and skips its curl download when it is already present.
+mkdir -p tarballs
+mv linux-*.tar.xz tarballs/
+
+# Build the firmware shared object: compiles the guest kernel, then bundles the
+# image into kernel.c via bin2cbundle.py (needs python + pyelftools).
+#
+# Run a plain in-dir `make -jN` — NOT `make -C` and NOT an exported MAKEFLAGS.
+# libkrunfw forwards MAKEFLAGS verbatim into the kernel's recursive make; `-C`
+# injects a bare `w` token that the kernel make treats as a goal.
+# The sandbox has no `cc` symlink; libkrunfw's Makefile links the firmware .so
+# with $(CC) (default cc), so force gcc. The kernel sub-make already defaults to
+# gcc, and forwarding CC=gcc to it is harmless.
+make CC=gcc -j"$(nproc)"
+# Install to lib (not the Makefile's default lib64), matching the repo convention.
+make CC=gcc install PREFIX=/usr DESTDIR="$OUTPUT_DIR" LIBDIR_Linux=lib

--- a/packages/pyelftools/build.ncl
+++ b/packages/pyelftools/build.ncl
@@ -1,0 +1,42 @@
+let { Attrs, BuildSpec, Local, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+
+let python = import "../python/build.ncl" in
+let setuptools = import "../setuptools/build.ncl" in
+
+let version = "0.33" in
+{
+  name = "pyelftools",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://files.pythonhosted.org/packages/source/p/pyelftools/pyelftools-%{version}.tar.gz",
+      sha256 = "660d82dcbeb8e83d1702bd97f223f761625da06111c0cc988eac6b8ab0c1b61f",
+      extract = true,
+      strip_prefix = "pyelftools-%{version}",
+    } | Source,
+    base,
+  ],
+
+  runtime_deps = [
+    python,
+    setuptools,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    python_site_package = { glob = "usr/lib/python*/site-packages/elftools/**" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/pyelftools-*.dist-info/**" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "eliben",
+        repo = "pyelftools",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/pyelftools/build.sh
+++ b/packages/pyelftools/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -ex
+
+pip3 wheel -w dist --no-build-isolation --no-deps --no-cache-dir $(pwd)
+pip3 install --no-index --find-links dist --no-user --root $OUTPUT_DIR pyelftools


### PR DESCRIPTION
Packages the libkrun KVM backend and its libkrunfw guest-kernel firmware (from `gominimal/minimal`'s [`scripts/build-libkrun.sh`](https://github.com/gominimal/minimal/blob/cd246b2211549034a849a5be471105c3c8edecfb/scripts/build-libkrun.sh)), plus two missing build dependencies.

## Packages

| Package | Version | Role |
|---|---|---|
| `libkrun` | 1.19.0 | KVM backend, built `--features blk` |
| `libkrunfw` | 5.5.0 | Guest kernel firmware (bundles linux-6.12.91) |
| `pyelftools` | 0.33 | Build dep — `bin2cbundle.py` imports `elftools` |
| `cpio` | 2.15 | Build dep — kernel `CONFIG_IKHEADERS` needs it |

## Design

- **Two packages, not one.** The script builds two distinct upstreams (`containers/libkrunfw`, `containers/libkrun`); `libkrunfw` is a dependency of `libkrun`.
- **libkrunfw is a runtime dep, not a link dep.** `libkrun` `dlopen()`s `libkrunfw.so.5` via `libloading` (`src/libkrun/src/lib.rs`), so it is in `runtime_deps`, not `build_deps`.
- **clang/libclang dropped.** `bindgen` only feeds the `input`/`display` crates, which `--features blk` does not pull in.
- **Kernel tarball vendored** as a second `Source` in `libkrunfw`, so the firmware build is hermetic. `libkrun` keeps `needs.internet` for cargo.

## Build notes

- cpio 2.15's K&R `int xstat()` breaks under GCC's C23 default → `-std=gnu17`.
- `ftp.gnu.org` 403s the sandbox fetcher → cpio sourced from `mirrors.kernel.org` (byte-identical).
- Both Makefiles link the final `.so` with bare `cc` (absent in sandbox) → `CC=gcc`, and install to `lib64` by default → `LIBDIR_Linux=lib` override (keeps the `.pc` libdir consistent).

## Verification

All four built via `min patched-pkg` and pass `min check` (50 checks, 0 failures) on the compiled outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for building cpio (v2.15)
  * Added support for building libkrun (v1.19.0)
  * Added support for building libkrunfw (v5.5.0)
  * Added support for building pyelftools (v0.33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->