### PR TITLE
ghostscript: honor SOURCE_DATE_EPOCH=0 for reproducible build

### DIFF
--- a/packages/ghostscript/build.sh
+++ b/packages/ghostscript/build.sh
@@ -13,6 +13,13 @@ export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
 
+# Reproducibility: mkromfs/pack_ps read SOURCE_DATE_EPOCH but then do
+# `if (!buildtime) buildtime = time(NULL)`, which treats the sandbox's
+# SOURCE_DATE_EPOCH=0 (epoch 0 is falsy) as "unset" and falls back to wall-clock
+# time -> non-deterministic gs_romfs_buildtime baked into the gs binary. Only
+# fall back to time() when SOURCE_DATE_EPOCH is genuinely unset.
+sed -i 's/if (!buildtime)/if (!env_source_date_epoch)/' base/mkromfs.c base/pack_ps.c
+
 ./configure --prefix=/usr \
             --disable-static \
             --with-system-libtiff \

--- a/packages/ghostscript/build.sh
+++ b/packages/ghostscript/build.sh
@@ -18,6 +18,15 @@ export CXXFLAGS="${CFLAGS}"
 # SOURCE_DATE_EPOCH=0 (epoch 0 is falsy) as "unset" and falls back to wall-clock
 # time -> non-deterministic gs_romfs_buildtime baked into the gs binary. Only
 # fall back to time() when SOURCE_DATE_EPOCH is genuinely unset.
+#
+# Guard: if a future ghostscript renames the variable or changes this logic,
+# fail loudly rather than silently shipping a non-reproducible binary.
+for src in base/mkromfs.c base/pack_ps.c; do
+  grep -q 'if (!buildtime)' "$src" || {
+    echo "ERROR: 'if (!buildtime)' not found in $src — ghostscript changed its SOURCE_DATE_EPOCH handling; update this patch." >&2
+    exit 1
+  }
+done
 sed -i 's/if (!buildtime)/if (!env_source_date_epoch)/' base/mkromfs.c base/pack_ps.c
 
 ./configure --prefix=/usr \


### PR DESCRIPTION
## What

Makes the `ghostscript` package reproducible by fixing a `SOURCE_DATE_EPOCH=0` handling bug in ghostscript's own build tools.

## Why

Two from-scratch builds of `ghostscript` differed in exactly one place: an 8-byte value in `usr/bin/gs` — the `gs_romfs_buildtime` global (confirmed via the symbol table), a Unix build timestamp baked into the embedded ROM filesystem.

ghostscript's `mkromfs` and `pack_ps` tools *try* to honor `SOURCE_DATE_EPOCH`, but the logic is buggy:

```c
if ((env_source_date_epoch = getenv("SOURCE_DATE_EPOCH"))) {
    buildtime = strtoul(env_source_date_epoch, NULL, 10);   // SDE="0" -> buildtime = 0
}
if (!buildtime)                 // 0 is falsy -> treats epoch 0 as "unset"
    buildtime = time(NULL);     // ...and falls back to wall-clock time
```

The build sandbox sets `SOURCE_DATE_EPOCH=0` — which is the canonical reproducible-builds value, and exactly the value ghostscript mishandles: it reads `0`, then `if (!buildtime)` treats it as unset and stamps wall-clock `time()` into the binary. (`base/mkromfs.c:2614`, `base/pack_ps.c:344`.)

## Fix

Fall back to `time()` only when `SOURCE_DATE_EPOCH` is genuinely *unset* (`!env_source_date_epoch`), not when it parses to `0`:

```sh
sed -i 's/if (!buildtime)/if (!env_source_date_epoch)/' base/mkromfs.c base/pack_ps.c
```

This is upstream-worthy — the bug bites any builder that sets `SOURCE_DATE_EPOCH=0`.

## Verification

Build-twice-and-diff on aarch64 (`--rebuild --no-fetch`): with the fix, two from-scratch builds are **byte-for-byte identical** (`repro-check diff`, 196/196 files). Before the fix, `usr/bin/gs` diverged on the embedded `gs_romfs_buildtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build reproducibility by refining how build timestamps are handled when using the `SOURCE_DATE_EPOCH` environment variable.
  * Added safeguards to ensure the expected reproducibility-related logic is present, failing the build if it changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->