### PR TITLE
emacs: pin clock_gettime in fixrand shim for reproducible .pdmp

### DIFF
--- a/packages/emacs/fixrand.c
+++ b/packages/emacs/fixrand.c
@@ -81,5 +81,9 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
         tp->tv_nsec = 0;
         return 0;
     }
+    if (!real_clock_gettime) {
+        errno = ENOSYS;
+        return -1;
+    }
     return real_clock_gettime(clk_id, tp);
 }

--- a/packages/emacs/fixrand.c
+++ b/packages/emacs/fixrand.c
@@ -5,6 +5,11 @@
  * output from a fixed-seed LCG. This makes Emacs's internal hash table
  * seeding reproducible, fixing .elc and .pdmp non-determinism.
  *
+ * Also freezes clock_gettime(CLOCK_REALTIME) to SOURCE_DATE_EPOCH: the dumped
+ * .pdmp otherwise embeds two wall-clock reads that getrandom interception does
+ * not cover — the *scratch* buffer's buffer-display-time (Fcurrent_time during
+ * make_initial_frame) and Vgc_elapsed GC timing (src/alloc.c).
+ *
  * Inspired by libfate (Nicolas Graves / Guix).
  *
  * Build:  gcc -shared -fPIC -O2 -ldl -o fixrand.so fixrand.c
@@ -15,8 +20,10 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/random.h>
+#include <time.h>
 #include <unistd.h>
 
 static uint32_t seed = 0x12345678;
@@ -57,4 +64,22 @@ ssize_t read(int fd, void *buf, size_t count) {
         }
     }
     return real_read(fd, buf, count);
+}
+
+/* Freeze wall-clock reads so Emacs's current-time (e.g. the *scratch* buffer's
+   buffer-display-time, set in make_initial_frame) and GC timing (Vgc_elapsed)
+   are deterministic in the dumped .pdmp. Only CLOCK_REALTIME is pinned (to the
+   sandbox-exported SOURCE_DATE_EPOCH); CLOCK_MONOTONIC and others pass through
+   so timeouts / progress loops are unaffected. */
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+    static int (*real_clock_gettime)(clockid_t, struct timespec *) = NULL;
+    if (!real_clock_gettime)
+        real_clock_gettime = dlsym(RTLD_NEXT, "clock_gettime");
+    if (clk_id == CLOCK_REALTIME && tp) {
+        const char *e = getenv("SOURCE_DATE_EPOCH");
+        tp->tv_sec = e ? (time_t)strtoll(e, NULL, 10) : 0;
+        tp->tv_nsec = 0;
+        return 0;
+    }
+    return real_clock_gettime(clk_id, tp);
 }


### PR DESCRIPTION
## What

Makes the `emacs` package reproducible by extending the existing `fixrand.so` LD_PRELOAD shim to also pin `clock_gettime(CLOCK_REALTIME)`.

## Why

After the current shim (which makes `getrandom()`/`/dev/urandom` deterministic for hash-table seeding), the dumped `emacs-*.pdmp` still differed across builds — in exactly **11 bytes**, in two clusters, both decoding to wall-clock timestamps captured at dump time via `clock_gettime(CLOCK_REALTIME)` (which the shim didn't intercept):

1. **`*scratch*` buffer's `buffer-display-time`** — an Emacs `(TICKS . HZ)` timestamp cons set by `Fcurrent_time()` during `make_initial_frame` (`src/window.c` / `src/emacs.c`). The two builds decoded to `2026-06-16 04:01:42` vs `04:02:43` — exactly the ~61s gap between them.
2. **`Vgc_elapsed`** — accumulated GC time (a float) in `src/alloc.c`, measured with `current_timespec()`.

`SOURCE_DATE_EPOCH` doesn't help here because Emacs reads the live clock directly.

## Fix

Add a `clock_gettime` interceptor to `fixrand.c` that returns `SOURCE_DATE_EPOCH` for `CLOCK_REALTIME` (and passes all other clocks, e.g. `CLOCK_MONOTONIC`, through untouched so timeouts/progress loops are unaffected). The build.sh compile line is unchanged — it already builds `fixrand.c` with `-ldl`.

This pins the display-time and makes GC `start == end` (elapsed `0.0`), both deterministic. No literal `SOURCE_DATE_EPOCH=0` (uses `getenv` + fallback), so it passes `minimal-check`.

## Verification

Build-twice-and-diff on aarch64: two from-scratch builds are now **byte-for-byte identical** (`repro-check diff`, 4282/4282 files). Before, the `.pdmp` differed in 11 timestamp bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reproducibility of Emacs builds by freezing system time readings during snapshot generation, ensuring consistent and deterministic output across different build environments and execution times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->