### PR TITLE
mono: make reproducible (build date + AOT id + AOT temp-name)

### DIFF
--- a/packages/mono/build.sh
+++ b/packages/mono/build.sh
@@ -40,6 +40,24 @@ sed -i 's/cmake_minimum_required (VERSION 2\.8\.10)/cmake_minimum_required (VERS
   mono/btls/CMakeLists.txt \
   external/boringssl/CMakeLists.txt
 
+# Reproducibility: mono stamps build_date with a bare `date` in
+# mono/mini/Makefile.am.in (the buildver-{sgen,boehm}.h recipes), which ignores
+# SOURCE_DATE_EPOCH and leaks wall-clock time into mono-sgen and every AOT
+# *.dll.so (the embedded "tarball <date>" runtime build-info string). Bake a
+# fixed, epoch-derived date into those recipes before autogen.sh expands the
+# template into Makefile.am.
+BUILD_DATE="$(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH:-0}")"
+sed -i "/build_date/s|\`date\`|$BUILD_DATE|g" mono/mini/Makefile.am.in
+
+# Reproducibility (AOT layer): mono's AOT compiler stamps a RANDOM 16-byte AOT ID
+# (aot-compiler.c generate_aotid -> mono_rand) into every installed *.dll.so/.exe.so.
+# mono's `deterministic` aot option suppresses it, but the default net_4_x build AOTs
+# via a path that doesn't thread that option through. So neutralize the randomness at
+# its source: zero the aotid. This is exactly what `deterministic` mode yields for the
+# emitted image (aot_opts.deterministic only gates this aotid plus one stdout line —
+# nothing else in the artifact).
+sed -i 's/mono_rand_try_get_bytes (&rand_handle, aotid, 16, error);/memset (aotid, 0, 16);/' mono/mini/aot-compiler.c
+
 # The GitHub-sourced tarball ships the raw tag tree (no generated
 # `configure`), so regenerate the autotools build system first. mono's
 # autogen.sh runs autoreconf and then invokes ./configure with "$@".
@@ -66,3 +84,13 @@ make DESTDIR=$OUTPUT_DIR install
 
 # Remove .la files for reproducibility
 find $OUTPUT_DIR -name '*.la' -delete
+
+# Reproducibility (AOT temp-name layer): mono's AOT compiler names its temporary
+# object file with a random suffix (g_file_open_tmp "mono_aot_XXXXXX") that leaks
+# into each *.dll.so/*.exe.so as a local STT_FILE symbol. The default net_4_x
+# build threads no temp-path to pin it, so strip the (runtime-unneeded) local
+# symbols from the AOT images — this removes the random name. mono's AOT loader
+# resolves via the global mono_aot_*_info symbol + offset tables, not locals, so
+# this is safe (distros ship stripped mono AOT). Verified: strip --strip-unneeded
+# makes the two builds' AOT images byte-identical.
+find "$OUTPUT_DIR" \( -name '*.dll.so' -o -name '*.exe.so' \) -exec strip --strip-unneeded {} +


### PR DESCRIPTION
## What

Makes the `mono` package reproducible. mono turned out to have **three independent sources** of non-determinism in its AOT-compiled output, all fixed here.

## The three layers

1. **Build date.** `mono/mini/Makefile.am.in` stamps `build_date` with a bare shell `` `date` `` (ignores `SOURCE_DATE_EPOCH`), which lands in `mono-sgen` and the `"tarball <date>"` runtime build-info string baked into every AOT `*.dll.so`. → Bake an epoch-derived date into those recipes before `autogen.sh`.

2. **Random AOT ID.** `aot-compiler.c:generate_aotid()` fills a 16-byte AOT ID from `mono_rand` and emits it into every AOT image. mono's `deterministic` AOT option suppresses it, but the default `net_4_x` build AOTs through a path that doesn't thread that option. → Neutralize at the source: zero the aotid (exactly what `deterministic` mode yields for the emitted image; `aot_opts.deterministic` only gates this aotid plus one stdout line).

3. **Random temp object name.** When no `temp-path` is passed, mono creates its assembler temp file via `g_file_open_tmp("mono_aot_XXXXXX")` — a random suffix that leaks into each AOT image as a local `STT_FILE` symbol. → Strip the runtime-unneeded local symbols from the AOT `.so` post-install (mono's AOT loader resolves via the global `mono_aot_*_info` symbol + offset tables, not locals; distros ship stripped mono AOT).

Each layer was found by build-twice-diff + binary forensics; fixing one revealed the next.

## Verification

Build-twice-and-diff on aarch64: with all three fixes, two from-scratch builds are **byte-for-byte identical** (`repro-check diff`, 3131/3131 files). The package's `mono --version` / `mcs --version` / AOT `open_check` tests exercise runtime correctness of the stripped AOT images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build reproducibility by implementing deterministic build metadata and compilation processes, ensuring consistent builds across different environments and machines.
  * Reduced compiled artifact file sizes by removing unnecessary debugging symbols and metadata while preserving full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->