### PR TITLE
ghc: deterministic link order + package.cache (reproducible Haskell)

### DIFF
--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -31,6 +31,10 @@ sed -i 's/let preload1 = nonDetKeysUniqMap (filterUniqMap (isJust . uv_explicit)
 ghc_pkg_main=utils/ghc-pkg/Main.hs
 grep -q 'confs = map (path </>) $ filter (".conf" `isSuffixOf`) fs' "$ghc_pkg_main" \
   || { echo "ERROR: ghc-pkg package.cache patch target not found in $ghc_pkg_main — GHC source changed." >&2; exit 1; }
+# The `sort $` below needs `sort` in scope; 9.10.3's Main.hs imports it (line 78),
+# but guard it so a future GHC import reorg fails here, not deep in the build.
+grep -qE 'import Data.List \(.*\bsort\b' "$ghc_pkg_main" \
+  || { echo "ERROR: 'sort' not imported in $ghc_pkg_main — patch (2) requires it (add a sort import)." >&2; exit 1; }
 sed -i 's#confs = map (path </>) $ filter (".conf" `isSuffixOf`) fs#confs = map (path </>) $ sort $ filter (".conf" `isSuffixOf`) fs#' "$ghc_pkg_main"
 
 # Create stubs for tools ./configure / bootstrap.py checks for but aren't strictly needed

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -9,6 +9,30 @@ cd "ghc-${MINIMAL_ARG_VERSION}"
 sed -i 's/extern void\* malloc();/extern void\* malloc(long unsigned int);/' utils/hp2ps/Utilities.c
 sed -i 's/extern void \*realloc();/extern void \*realloc(void \*, long unsigned int);/' utils/hp2ps/Utilities.c
 
+# Reproducibility: GHC iterates package/UnitId collections in hash-set order,
+# making the linker arg / DT_NEEDED / .dynstr order in every binary AND the
+# ghc-pkg package.cache non-deterministic. Code (.text/.rodata) is already
+# byte-identical; this is pure ORDERING. Sort the two collections.
+#
+# (1) Link order — backport of upstream GHC #26838 / MR !15453 (merged for
+#     10.0.1; NOT in 9.10.x; Debian ships this exact patch for 9.10.3). Restores
+#     the sorted-by-UnitId order GHC <= 9.6 had.
+ghc_state=compiler/GHC/Unit/State.hs
+grep -q 'import Data.List ( intersperse, partition, sortBy, isSuffixOf, sortOn )' "$ghc_state" \
+  && grep -q 'let preload1 = nonDetKeysUniqMap (filterUniqMap (isJust . uv_explicit) vis_map)' "$ghc_state" \
+  || { echo "ERROR: GHC link-order patch targets not found in $ghc_state — GHC source changed; revisit the #26838 backport." >&2; exit 1; }
+sed -i 's/import Data.List ( intersperse, partition, sortBy, isSuffixOf, sortOn )/import Data.List ( intersperse, partition, sortBy, isSuffixOf, sortOn, sort )/' "$ghc_state"
+sed -i 's/let preload1 = nonDetKeysUniqMap (filterUniqMap (isJust . uv_explicit) vis_map)/let preload1 = sort $ nonDetKeysUniqMap (filterUniqMap (isJust . uv_explicit) vis_map)/' "$ghc_state"
+
+# (2) ghc-pkg package.cache — sort the .conf list before it is read + serialized
+#     so the post-build `ghc-pkg recache` emits a byte-identical cache regardless
+#     of filesystem readdir order. (No upstream fix exists; `sort` already
+#     imported in Main.hs.)
+ghc_pkg_main=utils/ghc-pkg/Main.hs
+grep -q 'confs = map (path </>) $ filter (".conf" `isSuffixOf`) fs' "$ghc_pkg_main" \
+  || { echo "ERROR: ghc-pkg package.cache patch target not found in $ghc_pkg_main — GHC source changed." >&2; exit 1; }
+sed -i 's#confs = map (path </>) $ filter (".conf" `isSuffixOf`) fs#confs = map (path </>) $ sort $ filter (".conf" `isSuffixOf`) fs#' "$ghc_pkg_main"
+
 # Create stubs for tools ./configure / bootstrap.py checks for but aren't strictly needed
 STUB_DIR="$PWD/../stub-bin"
 mkdir -p "$STUB_DIR"


### PR DESCRIPTION
## What

Makes `ghc` (GHC 9.10.3) reproducible — and, because the fix is in the compiler/linker, it makes **every downstream Haskell package** (stack, haskell-language-server, …) reproducible too.

## Diagnosis

GHC's *functional* output is already reproducible — `.text`/`.rodata`/`.data` are byte-identical across builds (even the 71 MB `libHSghc.so`). The entire residual is **metadata ordering**, from GHC iterating package/UnitId collections in hash-set order (`nonDetEltsUFM`), in two places:

1. **Link-arg / `DT_NEEDED` / `.dynstr` ordering** in every linked binary (also what makes `stack`'s identically-sized functions land at different addresses).
2. **`ghc-pkg recache`** → `package.cache` serialized in unsorted `readdir` order.

`-fobject-determinism` is *not* the lever here (codegen is already deterministic).

## Fix (two source patches, applied before the Hadrian build)

1. **Link order** — exact backport of upstream **GHC #26838 / MR !15453** (a single `sort $` on `preload1` in `compiler/GHC/Unit/State.hs`). Merged upstream for 10.0.1; **not** in 9.10.x; **Debian ships this exact patch for 9.10.3** (Debian #1125305). It restores the sorted-by-UnitId order GHC ≤ 9.6 had — behavior-restoring, low-risk.
2. **`package.cache`** — sort the `.conf` list before it's read/serialized in `utils/ghc-pkg/Main.hs` (`sort` already imported). No upstream fix exists; trivial and additive. The build's existing post-install `ghc-pkg recache` then emits a byte-identical cache.

Each patch is **guarded by a `grep`** that fails the build loudly (in seconds) if a future GHC moves the target, rather than silently regressing.

## Status — DRAFT pending verification

The patches are high-confidence (Debian-proven for this exact version, applied behind fail-fast guards) but **not yet locally build-twice-verified** — a from-scratch GHC build is multi-hour (`build_cost_multiple=6`), ×2 for a repro check. Marking draft until that verify (or CI / a beefy builder) confirms byte-identical output + `ghc --version`.

When minimal moves to GHC ≥ 10.0.1, drop patch (1) (it lands upstream); keep (2) (still unfixed upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reproducibility by applying patches that ensure deterministic generation of GHC build outputs, with enhanced error checking to validate patch application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->