### PR TITLE
difftastic: deterministic parser link order for reproducible builds

### DIFF
--- a/packages/difftastic/build.sh
+++ b/packages/difftastic/build.sh
@@ -6,6 +6,16 @@ export LD=gcc
 export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo -C codegen-units=1"
 export CONST_RANDOM_SEED=0   # pin ahash/const-random compile-time seed
 
+# Reproducibility: build.rs compiles the 11 vendored tree-sitter parsers with
+# rayon `parsers.par_iter()`, so each cc::Build::compile() emits its
+# cargo:rustc-link-lib directive in non-deterministic completion order. That
+# randomizes the LINK ORDER of the parser static libs, so the (huge) parser
+# tables land at different addresses each build — distributed .rodata/.text/.data
+# differences that codegen-units=1 cannot fix. Serialize parser compilation so
+# the link directives are emitted in deterministic source order.
+sed -i 's/parsers\.par_iter()\.for_each/parsers.iter().for_each/' build.rs
+grep -q 'parsers.iter().for_each' build.rs || { echo "ERROR: difftastic par_iter->iter patch did not apply — build.rs changed" >&2; exit 1; }
+
 cargo build --release --locked
 
 mkdir -p $OUTPUT_DIR/usr/bin


### PR DESCRIPTION
## What

Makes the `difftastic` package build byte-reproducibly with a one-word `build.rs` change.

## Root cause

`difftastic`'s `build.rs` compiles its 11 vendored tree-sitter parsers in parallel:

```rust
parsers.par_iter().for_each(|p| p.build());   // rayon
```

Each `cc::Build::compile()` prints its `cargo:rustc-link-lib` directive when it finishes, so under parallel compilation the parser static libs link in **non-deterministic completion order**. Those parser tables are large (~99 MB of `.rodata`), so reshuffling their link order relocates everything — yielding distributed, same-size differences across `.text` / `.rodata` / `.data` / `.rela.dyn` between builds (measured ~16% of `.text`, ~8% of `.rodata`).

This sits *above* the codegen layer, so the existing `-C codegen-units=1` + `CONST_RANDOM_SEED` (from #254) couldn't fix it — it's **link order**, not codegen or compile-time RNG.

## Fix

Serialize parser compilation (`par_iter()` → `iter()`) so the `cargo:rustc-link-lib` directives are emitted in deterministic source order. Applied as a grep-guarded `sed` in `build.sh`.

## Verification

`repro-verify difftastic` (two from-scratch builds + `repro-check diff`): **byte-identical** ✅ (was: ~9.5% of bytes differing before the fix). `minimal check` green.

> Generalizable gotcha: any crate whose `build.rs` builds multiple native libs via `par_iter` emits link directives in nondeterministic order — worth keeping in mind for other Rust packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to improve determinism and reliability for difftastic compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->