### PR TITLE
perl: complete reproducibility — pin all host/time-derived Config fields

### DIFF
--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -20,7 +20,7 @@ export CXXFLAGS="${CFLAGS}"
 # which feeds $config_tag1 (perlbug/perlthanks) and the "Configuration time" line
 # in Config_heavy.pl. config.over is sourced AFTER all of Configure's computation
 # (perl's documented override hook), so pin cf_time/cf_by there instead.
-# The sandbox already exports SOURCE_DATE_EPOCH=0 — read it (with a fallback), don't re-set it.
+# The sandbox already exports SOURCE_DATE_EPOCH — read it (with a fallback), don't re-set it.
 CF_TIME="$(LC_ALL=C TZ=UTC date -u -d "@${SOURCE_DATE_EPOCH:-0}" 2>/dev/null || echo 'Thu Jan  1 00:00:00 UTC 1970')"
 # Configure also bakes the build host's nodename (in the sandbox a per-build
 # `minimal-<pid>` hostname) into several Config fields: myuname (the "Target

--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -20,14 +20,14 @@ export CXXFLAGS="${CFLAGS}"
 # which feeds $config_tag1 (perlbug/perlthanks) and the "Configuration time" line
 # in Config_heavy.pl. config.over is sourced AFTER all of Configure's computation
 # (perl's documented override hook), so pin cf_time/cf_by there instead.
-export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
-CF_TIME="$(LC_ALL=C TZ=UTC date -u -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || echo 'Thu Jan  1 00:00:00 UTC 1970')"
+# The sandbox already exports SOURCE_DATE_EPOCH=0 — read it (with a fallback), don't re-set it.
+CF_TIME="$(LC_ALL=C TZ=UTC date -u -d "@${SOURCE_DATE_EPOCH:-0}" 2>/dev/null || echo 'Thu Jan  1 00:00:00 UTC 1970')"
 # Configure also bakes the build host's nodename (in the sandbox a per-build
 # `minimal-<pid>` hostname) into several Config fields: myuname (the "Target
 # system" line, via `uname -a`), myhostname, and the derived cf_email/perladmin.
 # config.over is sourced after all computation, so pin every host-derived field
 # here. myuname keeps the real kernel info with just the nodename sanitized.
-MYUNAME="$(uname -a | sed "s/$(uname -n)/builder/g" | tr '[:upper:]' '[:lower:]' | sed 's#/##g')"
+MYUNAME="$(uname -a | awk '{$2="builder"; print}' | tr '[:upper:]' '[:lower:]' | tr -d '/')"
 cat > config.over <<EOF
 cf_time='$CF_TIME'
 cf_by='builder'

--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -15,10 +15,27 @@ export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
 
-# Perl's Configure bakes the wall-clock build time into Config (cf_time/cf_by),
-# which makes the build non-reproducible. Pin both deterministically.
+# Perl's Configure recomputes cf_time from `date` UNCONDITIONALLY, so a
+# `-D cf_time=` override does NOT stick — the wall-clock still leaks into cf_time,
+# which feeds $config_tag1 (perlbug/perlthanks) and the "Configuration time" line
+# in Config_heavy.pl. config.over is sourced AFTER all of Configure's computation
+# (perl's documented override hook), so pin cf_time/cf_by there instead.
 export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
 CF_TIME="$(LC_ALL=C TZ=UTC date -u -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || echo 'Thu Jan  1 00:00:00 UTC 1970')"
+# Configure also bakes the build host's nodename (in the sandbox a per-build
+# `minimal-<pid>` hostname) into several Config fields: myuname (the "Target
+# system" line, via `uname -a`), myhostname, and the derived cf_email/perladmin.
+# config.over is sourced after all computation, so pin every host-derived field
+# here. myuname keeps the real kernel info with just the nodename sanitized.
+MYUNAME="$(uname -a | sed "s/$(uname -n)/builder/g" | tr '[:upper:]' '[:lower:]' | sed 's#/##g')"
+cat > config.over <<EOF
+cf_time='$CF_TIME'
+cf_by='builder'
+myuname='$MYUNAME'
+myhostname='builder'
+cf_email='build@builder'
+perladmin='build@builder'
+EOF
 
 sh Configure  -des                                          \
              -D cc=gcc                                     \
@@ -34,9 +51,7 @@ sh Configure  -des                                          \
              -D man3dir=/usr/share/man/man3                \
              -D pager="/usr/bin/less -isR"                 \
              -D useshrplib                                 \
-             -D usethreads                                  \
-             -D cf_time="$CF_TIME"                          \
-             -D cf_by=builder
+             -D usethreads
 
 make -j$(nproc)
 # TEST_JOBS=$(nproc) make test_harness # TODO there are failures


### PR DESCRIPTION
## Problem

The merged #249 pinned perl's build time via `-D cf_time`, but the **rebuild-world audit caught that fix was incomplete** — a forced double-build still `DIFFERS`. perl's `Configure` recomputes `cf_time` from `date` **unconditionally**, so the `-D cf_time` override never sticks. The build wall-clock *and* the sandbox's per-build `minimal-<pid>` hostname still leak into `Config_heavy.pl`, `perlbug`, and `perlthanks` via five fields:

```
cf_time     = build wall-clock     (the original target, not actually pinned)
myuname     = `uname -a`           ("Target system" line — embeds nodename)
myhostname  = minimal-<pid>
cf_email    = build@minimal-<pid>.nonet
perladmin   = build@minimal-<pid>.nonet
```

## Fix

Pin them all via `config.over`, which `Configure` sources **after** it computes everything — perl's documented override hook (unlike `-D`, which gets overwritten):

- `cf_time` / `cf_by` derived from `SOURCE_DATE_EPOCH`
- `myuname` with only the nodename sanitized (keeps real kernel info)
- `myhostname` / `cf_email` / `perladmin` → fixed tokens

## Verification

Two from-scratch forced rebuilds (`--rebuild --no-fetch`, aarch64) → **byte-identical**: `repro-check diff` reports **2736/2736 files identical, REPRODUCIBLE**. Before: `DIFFERS` on the 3 Config files. (This time the double-build was actually run end-to-end — the first two attempts at this fix were *rejected* by the verify before landing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reproducibility of Perl builds by ensuring generated configuration metadata is deterministic, including time-based fields and host-derived identity values. This reduces build-to-build variability caused by system environment differences during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->