### PR TITLE
nushell: make reproducible (mangling v0 + deterministic build-time entropy)

### DIFF
--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -42,10 +42,9 @@ int getentropy(void *buf, size_t len) {
 }
 CEOF
 gcc -shared -fPIC -O2 -o /tmp/libdetrand.so /tmp/detrand.c
-export LD_PRELOAD=/tmp/libdetrand.so
 
-cargo build --release
-unset LD_PRELOAD
+# Scope the shim to the cargo build only — no global export/unset window.
+LD_PRELOAD=/tmp/libdetrand.so cargo build --release
 
 mkdir -p $OUTPUT_DIR/usr/bin
 install -m 755 target/release/nu $OUTPUT_DIR/usr/bin/nu

--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -2,10 +2,50 @@
 set -ex
 export CC=gcc
 export LD=gcc
-export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo -C codegen-units=1"
+# symbol-mangling-version=v0: the default (legacy) mangling appends a hash to
+# each monomorphized generic; for a few instances (Vec::extend_desugared, Vec as
+# Debug/Drop, ...) that hash came out non-deterministic build-to-build. Since
+# rustc places codegen items in symbol-name order, those differing names shuffled
+# addresses and cascaded into a ~10% size-preserving .text/.rela.dyn reordering.
+# v0 mangling is structural (no hash) -> deterministic by construction.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo -C codegen-units=1 -C symbol-mangling-version=v0"
 export CONST_RANDOM_SEED=0   # pin ahash/const-random compile-time seed
 
+# nushell's Cargo.toml [profile.release] sets lto="thin". ThinLTO's parallel
+# backend is non-deterministic — it produces the `.llvm.<hash>` codegen-unit
+# locals and section reordering that left `nu` non-reproducible even WITH
+# `-C codegen-units=1` (LTO runs on top of codegen units, so that flag can't fix
+# it). Override the profile via cargo env (which beats Cargo.toml) to disable LTO;
+# codegen-units=1 then yields deterministic codegen. Modest size/perf cost — the
+# same reproducibility-over-optimization trade as dropping PGO for python.
+export CARGO_PROFILE_RELEASE_LTO=off
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+
+# Determinism shim (fixes a CLASS of Rust non-repro): build-time code — here the
+# pest/pest_consume proc-macros generating the parser — seeds std::HashMap from
+# getrandom(), whose per-process-random seed makes their CODE-GENERATION order vary
+# build-to-build (different Rule discriminants/match-arm order -> different .text).
+# std exposes no knob to pin its hasher, so pin the build's entropy itself: an
+# LD_PRELOAD that makes getrandom/getentropy deterministic, so every build-time
+# HashMap iterates stably. Applies to rustc + all proc-macros for this build only.
+cat > /tmp/detrand.c <<'CEOF'
+#include <stddef.h>
+#include <sys/types.h>
+ssize_t getrandom(void *buf, size_t len, unsigned int flags) {
+    (void)flags;
+    for (size_t i = 0; i < len; i++) ((unsigned char *)buf)[i] = 0;
+    return (ssize_t)len;
+}
+int getentropy(void *buf, size_t len) {
+    for (size_t i = 0; i < len; i++) ((unsigned char *)buf)[i] = 0;
+    return 0;
+}
+CEOF
+gcc -shared -fPIC -O2 -o /tmp/libdetrand.so /tmp/detrand.c
+export LD_PRELOAD=/tmp/libdetrand.so
+
 cargo build --release
+unset LD_PRELOAD
 
 mkdir -p $OUTPUT_DIR/usr/bin
 install -m 755 target/release/nu $OUTPUT_DIR/usr/bin/nu


### PR DESCRIPTION
## Problem

The rebuild-world audit caught that #254's Rust recipe (`-C codegen-units=1` + `CONST_RANDOM_SEED=0`) left `nu` **non-reproducible** — ~11.7% of bytes differing across two builds. (`difftastic`/`hex-patch` from the same PR were fine; nushell had deeper issues that were never double-build-verified.)

## Root cause — three layers

| Layer | Symptom | Fix |
|---|---|---|
| **ThinLTO** (`Cargo.toml` `lto = "thin"`) | parallel LTO backend non-deterministic | `CARGO_PROFILE_RELEASE_LTO=off` (env beats Cargo.toml) |
| **Legacy mangling hash** | a few `core`/`alloc` generics got unstable `…17h<hash>E` names; rustc emits codegen items in symbol-name order → ~10% size-preserving `.text`/`.rela.dyn` reorder | `-C symbol-mangling-version=v0` (structural, no hash) |
| **Proc-macro `HashMap`** (last 0.02%) | `pest`/`pest_consume` generate the parser by iterating `std::HashMap`; its per-process-random seed varies the `Rule` discriminants / match-arm order build-to-build, and std has no knob to pin its hasher | `LD_PRELOAD` shim pinning `getrandom`/`getentropy` so build-time `HashMap`s iterate deterministically |

## Why this matters beyond nushell

Layers 2 and 3 are **general** Rust-reproducibility mechanisms, not nushell hacks:

- `-C symbol-mangling-version=v0` deterministically fixes rustc mangling for any crate.
- The entropy shim fixes **the whole class** of proc-macro / `build.rs` `HashMap`-ordered codegen non-determinism (the reason otherwise-clean Rust packages still flake). It's the entropy analogue of what `SOURCE_DATE_EPOCH` does for time.

(Follow-ups: lift the shim into a shared mechanism / the sandbox, and add both to the documented recipe.)

## Verification

Two from-scratch forced rebuilds (`--rebuild --no-fetch`, aarch64) → **byte-identical**: `repro-check diff` reports **REPRODUCIBLE**. Diagnosed end-to-end with repro-check's new symbol-divergence analysis (gominimal/minimal-repro#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved reproducibility and deterministic outputs in the Nushell package build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->