### PR TITLE
Add edgedelta package

### DIFF
--- a/packages/edgedelta/build.ncl
+++ b/packages/edgedelta/build.ncl
@@ -1,0 +1,63 @@
+let { Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let ca-certificates = import "../ca-certificates/build.ncl" in
+
+let version = "2.19.0" in
+
+let { amd64_sha256, arm64_sha256 } = {
+  amd64_sha256 = "e660e312df0faa8fe319a98bc19244f3b741c9e65576a1be20bd95ec03857dbc",
+  arm64_sha256 = "48f523fefcf5f1b40954a6524ce70b6b540241d88a7043c40ec01e2832dd0a49",
+}
+in
+
+{
+  name = "edgedelta",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://release.edgedelta.com/v%{version}/edgedelta-linux-amd64.sh",
+          sha256 = amd64_sha256,
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://release.edgedelta.com/v%{version}/edgedelta-linux-arm64.sh",
+          sha256 = arm64_sha256,
+        } | Source,
+    } target,
+    base,
+  ],
+
+  # The agent is a statically linked Go binary; ca-certificates is needed at
+  # runtime so it can establish TLS connections to the Edge Delta cloud.
+  runtime_deps = [ca-certificates],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/edgedelta" } | OutputBin,
+  },
+
+  tests = {
+    smoketest =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "test -x /usr/bin/edgedelta"],
+          ["/bin/bash", "-c", "/usr/bin/edgedelta -v || /usr/bin/edgedelta -version || /usr/bin/edgedelta --help || true"],
+        ],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+    } | Attrs,
+} | BuildSpec

--- a/packages/edgedelta/build.ncl
+++ b/packages/edgedelta/build.ncl
@@ -5,6 +5,15 @@ let ca-certificates = import "../ca-certificates/build.ncl" in
 
 let version = "2.19.0" in
 
+# Resolve the *target* arch (not the build host's `uname -m`) so build.sh
+# references the same installer that build_deps stages. Passed via MINIMAL_ARG_ARCH.
+let target_arch =
+  match {
+    { arch = 'Amd64, .. } => "amd64",
+    { arch = 'Arm64, .. } => "arm64",
+  } target
+in
+
 let { amd64_sha256, arm64_sha256 } = {
   amd64_sha256 = "e660e312df0faa8fe319a98bc19244f3b741c9e65576a1be20bd95ec03857dbc",
   arm64_sha256 = "48f523fefcf5f1b40954a6524ce70b6b540241d88a7043c40ec01e2832dd0a49",
@@ -38,6 +47,7 @@ in
   cmd = "./build.sh",
   build_args = {
     include version,
+    arch = target_arch,
   },
 
   outputs = {
@@ -51,7 +61,11 @@ in
         test_deps = [base],
         cmds = [
           ["/bin/bash", "-c", "test -x /usr/bin/edgedelta"],
-          ["/bin/bash", "-c", "/usr/bin/edgedelta -v || /usr/bin/edgedelta -version || /usr/bin/edgedelta --help || true"],
+          # Usability: the binary must actually execute. The exit code of
+          # --version is irrelevant; we fail only if the kernel can't run it
+          # (126/127) or it dies on a signal (>=128) -- i.e. a wrong-arch,
+          # corrupt, or mis-extracted binary.
+          ["/bin/bash", "-c", "/usr/bin/edgedelta --version >/dev/null 2>&1; rc=$?; [ $rc -lt 126 ]"],
         ],
       } | Test,
   },

--- a/packages/edgedelta/build.sh
+++ b/packages/edgedelta/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+case "$(uname -m)" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+installer="edgedelta-linux-${ARCH}.sh"
+
+# The installer is a Makeself self-extracting archive that, when run, would
+# create a system user, install a service and start the agent. We don't want
+# any of that — we only want the bundled binary. So extract the embedded
+# gzip-compressed tar payload directly instead of executing the installer.
+#
+# Makeself appends the payload after a fixed number of header lines; the line
+# count is embedded in the script itself (`offset=`head -n N "$0"`...`). Parse
+# it out rather than hardcoding, so this keeps working across versions.
+header_lines=$(grep -aoE 'head -n [0-9]+ "\$0"' "$installer" | head -1 | grep -oE 'head -n [0-9]+' | grep -oE '[0-9]+')
+if [ -z "$header_lines" ]; then
+  echo "could not determine Makeself payload offset in $installer" >&2
+  exit 1
+fi
+
+byte_offset=$(head -n "$header_lines" "$installer" | wc -c | tr -d ' ')
+
+mkdir -p payload
+tail -c "+$((byte_offset + 1))" "$installer" | gzip -dc | tar -xof - -C payload
+
+if [ ! -f payload/edgedelta ]; then
+  echo "edgedelta binary not found in extracted payload" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 0755 payload/edgedelta "$OUTPUT_DIR/usr/bin/edgedelta"

--- a/packages/edgedelta/build.sh
+++ b/packages/edgedelta/build.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-case "$(uname -m)" in
-  x86_64)  ARCH="amd64" ;;
-  aarch64) ARCH="arm64" ;;
-  *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-esac
-
-installer="edgedelta-linux-${ARCH}.sh"
+# Use the resolved target arch from build.ncl (MINIMAL_ARG_ARCH) rather than the
+# build host's `uname -m`, so the correct installer is referenced on cross-builds.
+installer="edgedelta-linux-${MINIMAL_ARG_ARCH}.sh"
 
 # The installer is a Makeself self-extracting archive that, when run, would
 # create a system user, install a service and start the agent. We don't want


### PR DESCRIPTION
Packages the Edge Delta observability agent (v2.19.0) by extracting the binary from upstream's Makeself self-extracting installer, skipping the installer's host-mutating steps (user creation, service install, agent start). amd64 and arm64 supported; ca-certificates as a runtime dep for TLS.

<!--
Thanks for the contribution! A few quick notes:

- For anything non-trivial, please open an issue first so we can align on approach.
- Before we can merge, you'll need to accept our Contributor License Agreement.
  CLA Assistant will prompt you automatically on this PR — see CONTRIBUTING.md
  for details.
- Small, focused PRs are easier to review and faster to merge.
-->

## Summary

<!-- What does this PR do, and why? "Why" is more useful than "what". -->

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

## Changes

<!-- High-level list of what changed. For a new package, mention upstream version and source URL. For an update, the old → new version. -->

-

## Checklist

- [ ] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [ ] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [ ] `min check` passes for the affected packages/harnesses.
- [ ] `min patched-build <name>` succeeds for any package I added or modified.
- [ ] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [ ] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to, known limitations, follow-up work, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for packaging and installing the EdgeDelta agent.
  * The agent now includes architecture-specific downloads and works on supported Linux architectures.
  * Added a standalone smoke test to confirm the installed binary is present and responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->