### PR TITLE
opencv: link system openjpeg 2.5.4 instead of the bundled copy

### DIFF
--- a/packages/opencv/build.ncl
+++ b/packages/opencv/build.ncl
@@ -7,6 +7,7 @@ let make = import "../make/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
+let openjpeg = import "../openjpeg/build.ncl" in
 
 # TODO: This doesn't install the opencv_contrib, which has a LOT of the useful stuff. Implement that.
 # See:
@@ -18,7 +19,7 @@ let version = "4.13.0" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://github.com/opencv/opencv/archive/refs/tags/4.12.0.tar.gz
+      # https://github.com/opencv/opencv/archive/refs/tags/4.13.0.tar.gz
       url = "gs://minimal-staging-archives/opencv-%{version}.tar.gz",
       sha256 = "1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d",
       extract = true,
@@ -27,11 +28,16 @@ let version = "4.13.0" in
     toolchain,
     cmake,
     make,
+    # System openjpeg for JPEG2000 (find_package(OpenJPEG) at configure
+    # time); replaces opencv's bundled 3rdparty/openjpeg. See build.sh.
+    openjpeg,
   ],
   runtime_deps = [
     glibc,
     subsetOf gcc ["libgcc", "libstdcpp"],
     zlib,
+    # opencv's imgcodecs dynamically links libopenjp2.so at runtime.
+    openjpeg,
   ],
 
   cmd = "./build.sh",

--- a/packages/opencv/build.sh
+++ b/packages/opencv/build.sh
@@ -13,11 +13,20 @@ export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
 
-# Configure
+# Configure.
+#
+# WITH_OPENJPEG=ON + BUILD_OPENJPEG=OFF links the system openjpeg (our
+# 2.5.4 package) instead of compiling the bundled 3rdparty/openjpeg copy.
+# The bundled copy is what OSS-Fuzz flagged as OSV-2023-444 (heap-overflow
+# in opj_jp2_apply_pclr); the system lib carries the upstream fix
+# (OpenJPEG PR #1441, shipped in 2.5.1+), so this removes the vulnerable
+# code rather than asserting the vendored copy is patched.
 cmake \
         -DCMAKE_INSTALL_PREFIX=/usr         \
         -DOPENCV_GENERATE_PKGCONFIG=ON      \
         -DOPENCV_LIB_INSTALL_PATH=/usr/lib  \
+        -DWITH_OPENJPEG=ON                  \
+        -DBUILD_OPENJPEG=OFF                \
         ../opencv-$MINIMAL_ARG_VERSION
 
 # Build


### PR DESCRIPTION
## What

Switch opencv (4.13.0) from its bundled `3rdparty/openjpeg` to our **system openjpeg 2.5.4**:

- `build.sh`: add `-DWITH_OPENJPEG=ON -DBUILD_OPENJPEG=OFF` so cmake's `find_package(OpenJPEG)` detects and links the system `libopenjp2` instead of compiling the vendored copy.
- `build.ncl`: add `openjpeg` to `build_deps` (configure-time headers + `OpenJPEGConfig.cmake`/`libopenjp2.pc`, which our openjpeg pkg exports) and to `runtime_deps` (imgcodecs dynamically links `libopenjp2.so`).

## Why

OpenCV's bundled openjpeg is what OSS-Fuzz flagged as **OSV-2023-444** (heap-buffer-overflow in `opj_jp2_apply_pclr`, found while fuzzing opencv). The fix landed upstream in **OpenJPEG PR #1441** (commit `c8fef1d`, Aug 2022) and shipped in **2.5.1+**. We already ship **openjpeg 2.5.4**, which carries the fix.

Linking the system lib **removes the vulnerable code** from our opencv binary rather than asserting the vendored copy is patched (today that's an `advisory_overrides.toml` entry, `< 4.13.0`, which re-asserts trust on every bump). It also means future openjpeg CVEs surface on the **openjpeg package**, where we patch once, instead of riding silently inside opencv's vendored copy.

## Reviewer notes / to verify on buildbot

- Confirm the cmake **"Media I/O"** config summary resolves a real system openjpeg path (e.g. `/usr/lib/libopenjp2.so`), **not** `build` — that's the proof it picked up our 2.5.4 rather than the bundle.
- opencv requires openjpeg ≥ 2.0 (recommended ≥ 2.3.1); 2.5.4 clears it.
- Follow-up (separate, after this is green): drop the `OSV-2023-444` override in `minimal-supply-chain/data/advisory_overrides.toml` — the finding no longer applies once the bundle is gone.
- Unrelated to this PR: opencv's other finding **OSV-2022-394** (cv::split) is pure-opencv code fixed in 4.10.0, already covered by its own override; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenCV now uses the system OpenJPEG library during build and at runtime, improving compatibility and avoiding the bundled copy.
  * Updated the referenced OpenCV source version information to align with the latest release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->