### PR TITLE
gnutls: 3.8.9 -> 3.8.13 (clears CVE-2025-32988 High + 5 more)

### DIFF
--- a/packages/gnutls/build.ncl
+++ b/packages/gnutls/build.ncl
@@ -11,14 +11,14 @@ let nettle = import "../nettle/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "3.8.9" in
+let version = "3.8.13" in
 {
   name = "gnutls",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-%{version}.tar.xz",
-      sha256 = "69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed",
+      sha256 = "ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e",
       extract = true,
       strip_prefix = "gnutls-%{version}",
     } | Source,


### PR DESCRIPTION
## Security update: gnutls 3.8.9 → 3.8.13

gnutls 3.8.9 (Feb 2025) trails **six disclosed CVEs**, all fixed upstream in 3.8.10–3.8.12. Our scan flags **CVE-2025-32988 as High** (CVSS 7.5, `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H`). gnutls self-rates it "low," but the network-reachable availability impact (`A:H`) makes it a 7.5 by the CVSS vector — which is why our scan surfaces it as High.

3.8.13 (2026-04-29) is the current gnutls release and clears the full set (per the tarball's own `NEWS`):

| CVE | gnutls NEWS | CVSS | fixed in |
|---|---|---|---|
| CVE-2025-32988 | low | **7.5 High** | 3.8.10 |
| CVE-2025-32990 | low | **7.5 High** | 3.8.10 |
| CVE-2025-32989 | medium | 5.3 Med | 3.8.10 |
| CVE-2025-6395 | medium | Med | 3.8.10 |
| CVE-2025-14831 | medium | 3.7 Low | 3.8.12 |
| CVE-2025-9820 | low | 3.3 Low | 3.8.11 |

## Why this was hidden

This update was **masked**, not missed by neglect. refresh-latest resolved gnutls's "latest" via the **frozen `ftp.gnu.org/gnu/gnutls` archive** — which tops out at `gnutls-3.1.5` (~2013; gnutls moved its releases to gnupg.org). That stale 3.1.5 short-circuited the cascade before the gnupg.org override (which has 3.8.13), and the no-downgrade clamp pinned `latest_known` back to the shipped 3.8.9 — so the page read **"at latest — no upstream update."** [pkgmgr-rs#398](https://github.com/gominimal/pkgmgr-rs/pull/398) fixes the detection so this can't recur.

## Checksum

`sha256 = ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e` — computed from the canonical gnupg.org tarball (`v3.8/gnutls-3.8.13.tar.xz`, the same URL the build fetches), xz-integrity-verified, and confirmed as 3.8.13 via the bundled NEWS.

## Reviewer note

This is a minor-version bump within the 3.8.x line (same configure surface), so no `build.sh` change is expected — but I could not run the full build locally; **the buildbot should confirm it builds and links** against the current nettle/gmp deps before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
