### PR TITLE
ngspice: provenance GithubRepo -> Sourceforge (version-check fix)

### DIFF
--- a/packages/ngspice/build.ncl
+++ b/packages/ngspice/build.ncl
@@ -47,10 +47,14 @@ let version = "46" in
   attrs = {
     upstream_version = version,
     license_spdx = "BSD-3-Clause",
+    # github.com/ngspice/ngspice is a frozen CVS-import mirror (newest tag
+    # ngspice-26, ~2014); real releases (up to 46) ship only on SourceForge
+    # (ng-spice-rework). Track SourceForge for version resolution. No CPE
+    # impact: ngspice has no NVD CVEs, and both provenances map to
+    # vendor/product = ngspice/ngspice.
     source_provenance = {
-      category = 'GithubRepo,
-      owner = "ngspice",
-      repo = "ngspice",
+      category = 'Sourceforge,
+      name = "ngspice",
     },
   },
 


### PR DESCRIPTION
## The bug
`github.com/ngspice/ngspice` is a **frozen CVS-import mirror** — its newest version tag is `ngspice-26` (~2014). Real ngspice releases (up to **46**) ship only on SourceForge (`ng-spice-rework`). So the GitHub version-check tier resolved the frozen `26`, and the no-downgrade clamp pinned it back to the shipped `46` → "at latest." Currently **latent** (46 == shipped), but the next ngspice release would be silently missed — the same masking class we just fixed for gnutls/cabal/etc.

## The fix
Flip `source_provenance` from `GithubRepo{ngspice/ngspice}` → `Sourceforge{ngspice}`, so version-check routes to the SourceForge tier (`best_release.json` → 46, and tracks 47+).

## Verified safe (this is the first `Sourceforge`-provenance package)
- **Parses cleanly:** `minimal dump` accepts it with no contract error (Sourceforge is a valid `Attrs` category — confirmed it resolves to `Sourceforge{ngspice}` in the dump). This was the key first-user check.
- **No vuln-coverage impact:** the provenance change *does* switch the scan query path (github cpe-synth → sourceforge purl), but **NVD has 0 CVEs for ngspice**, so there's no coverage to lose; and both provenances map to vendor/product = `ngspice/ngspice` either way.
- The source tarball is a GCS mirror keyed on `version`, unaffected by the provenance change.

## Note
Detection only, latent — 46 == current, so no bump needed. This ensures ngspice-47 (whenever it ships) won't be masked. The version-check itself will be prod-validated on the next runner that carries this (`check --package ngspice` → 46 via sourceforge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
