### PR TITLE
virtio-linux + virtio-kernel-raw: 6.12.43 -> 6.12.94 (latest 6.12 LTS)

### DIFF
--- a/packages/virtio-kernel-raw/build.ncl
+++ b/packages/virtio-kernel-raw/build.ncl
@@ -3,7 +3,7 @@ let base = import "../base/build.ncl" in
 let virtio-linux = import "../virtio-linux/build.ncl" in
 
 # Tracks the virtio-linux kernel version; this package only decompresses it.
-let version = "6.12.43" in
+let version = "6.12.94" in
 {
   name = "virtio-kernel-raw",
 

--- a/packages/virtio-linux/build.ncl
+++ b/packages/virtio-linux/build.ncl
@@ -11,7 +11,7 @@ let perl = import "../perl/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "6.12.43" in
+let version = "6.12.94" in
 {
   name = "virtio-linux",
 
@@ -19,7 +19,7 @@ let version = "6.12.43" in
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/linux-%{version}.tar.xz",
-      sha256 = "0fcbbbbcd456e87bbbfc8bf37af541fda62ccfcce76903503424fd101ef7bdee",
+      sha256 = "e998a232b9418db3301cb58468e291a4f41d6ab8306029b30d991f56251dc8d2",
       extract = true,
       strip_prefix = "linux-%{version}",
     } | Source,


### PR DESCRIPTION
## Security freshness: virtio guest kernel 6.12.43 → 6.12.94 (latest 6.12 LTS)

The virtio microVM guest kernel was **~50 LTS patch releases behind** the latest 6.12 longterm. We deliberately keep the kernel **CVE-dark** (adding `linux:linux_kernel` provenance would flood the digest with ~1,430 mostly-inapplicable driver/subsystem CVEs a virtio guest never compiles — see #400 for the long-term strategy), so **riding the latest 6.12 LTS backport stream is the kernel's security posture.** This bump is that move.

## Changes
- **virtio-linux** `6.12.43 → 6.12.94` (version + sha256).
  - Tarball staged at `gs://minimal-staging-archives/linux-6.12.94.tar.xz`.
  - `sha256 = e998a232b9418db3301cb58468e291a4f41d6ab8306029b30d991f56251dc8d2` — **verified against kernel.org's signed `sha256sums.asc`** (not just self-computed).
- **virtio-kernel-raw** version `6.12.43 → 6.12.94` — it only decompresses virtio-linux's kernel, so its `version` tracks in lockstep.
- **virtio-linux-detonation** (6.18.36, a separate mainline detonation kernel) — unchanged.

## Reviewer notes
- This is a real kernel rebuild — **the buildbot needs to confirm both packages build** (a 6.12.43→6.12.94 LTS step within the same series; no config-affecting changes expected, but worth a green build before merge).
- Related: #400 tracks the long-term kernel-vuln strategy (config-scoping / VEX / LTS-freshness-as-signal). This PR is the interim "stay on latest LTS" action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
