### PR TITLE
boost: drop the b2 engine self-test step (deadlocks on high-core boxes)

### DIFF
--- a/packages/boost/build.sh
+++ b/packages/boost/build.sh
@@ -16,6 +16,11 @@ export CXXFLAGS="${CFLAGS}"
 ./bootstrap.sh --prefix=/usr --with-python=python3
 ./b2 stage -j$(nproc) threading=multi link=shared
 
-pushd tools/build/test; python3 test_all.py; popd
+# Deliberately do NOT run Boost.Build's engine self-test suite
+# (tools/build/test/test_all.py) here: it validates the b2 build *tool*, not
+# boost, so it's unnecessary for packaging — and it spawns a
+# multiprocessing.Pool(cpu_count()) that deadlocks in the build sandbox (49 idle
+# workers, empty /dev/shm), which wedged the whole fleet for hours once the
+# res-servers went to 48 cores. Don't re-add it.
 
 ./b2 --prefix=$OUTPUT_DIR/usr install threading=multi link=shared


### PR DESCRIPTION
## What

Removes the `pushd tools/build/test; python3 test_all.py; popd` step from `packages/boost/build.sh`.

## Why

That line runs **Boost.Build's own engine regression suite** (`test_all.py`) after staging boost. It spawns `multiprocessing.Pool(cpu_count())` — **48 workers** on the resized `c4-standard-48` res-servers — and **deadlocks in the build sandbox**: 49 idle `spawn_main` workers at 0% CPU, empty `/dev/shm`, zero progress. It wedged a full pkgs build for **hours** (seen on #312 — both arches stuck at `Building package: boost`; res-servers idle at 2–4% CPU, ~1.3 MB/min of spin output).

It validates the **b2 build tool**, not boost — so it's unnecessary for packaging. `bootstrap.sh` + `b2 stage` + `b2 install` fully build and install boost without it. Removing it kills the deadlock on any core count.

The 32→48-core res-server resize is what surfaced this (`cpu_count()` → worker count), and it's likely the same class as the earlier bun hangs — follow-ups: cap effective parallelism in the build sandbox, and a build-bot mid-stream read-timeout so a wedged step fails fast instead of riding the 6h watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package build reliability by avoiding a test step that could cause build-time hangs in restricted environments.
  * Added a note clarifying why that check is skipped during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->