### PR TITLE
feat(just): package just at version 1.55.1

### DIFF
--- a/packages/just/build.ncl
+++ b/packages/just/build.ncl
@@ -1,0 +1,47 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.55.1" in
+{
+  name = "just",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/casey/just/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "40a2d3725480523ffebb762669cafe2b0135a00383946eec3d47adf5e9be6345",
+      extract = true,
+      strip_prefix = "just-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    just = { glob = "usr/bin/just" } | OutputBin,
+
+    completions = { glob = "usr/share/bash-completion/completions/*" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "CC0-1.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "casey",
+        repo = "just",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/just/build.sh
+++ b/packages/just/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ex
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+cargo build --release
+
+mkdir -p $OUTPUT_DIR/usr/bin
+install -m 755 target/release/just $OUTPUT_DIR/usr/bin/just
+
+mkdir -p $OUTPUT_DIR/usr/share/bash-completion/completions
+target/release/just --completions bash > $OUTPUT_DIR/usr/share/bash-completion/completions/just


### PR DESCRIPTION
Packages `just` as in justfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and packaging `just` version 1.55.1.
  * Includes the `just` command-line binary and Bash completion files in the installed output.
  * Uses a pinned source download with checksum verification for consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->