### PR TITLE
fix(haskell): retry hackage fetches in cabal + stack bootstraps

### DIFF
--- a/packages/cabal/build.sh
+++ b/packages/cabal/build.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -euo pipefail
 
+# cabal's bootstrap fetches ~20 tarballs from hackage.haskell.org live during
+# the build, and those downloads flake intermittently (truncated reads ->
+# http.client.IncompleteRead). cabal verifies each tarball's sha256, so a
+# partial download is re-fetched cleanly, which makes a retry safe. The
+# hermetic fix is to vendor the bootstrap sources offline (see packages/ghc,
+# which passes --bootstrap-sources) -- this retry is the cheap stopgap.
+retry() {
+    local -i attempt=1 max=4
+    until "$@"; do
+        if (( attempt >= max )); then
+            echo "retry: '$*' failed after $max attempts" >&2
+            return 1
+        fi
+        echo "retry: '$*' failed (attempt $attempt/$max) -- likely a transient hackage fetch; retrying in $(( attempt * 15 ))s" >&2
+        sleep $(( attempt * 15 ))
+        attempt+=1
+    done
+}
+
 # Patch monorepo .cabal files to accept GHC 9.10.1's built-in Cabal-syntax-3.12.0.0
 # (cabal-install-3.12.1.0 expects ^>=3.12.1.0 but GHC 9.10.1 ships 3.12.0.0)
 for cabal_file in \
@@ -18,7 +37,7 @@ done
 python3 update_bootstrap_json.py bootstrap/linux-9.8.2.json > bootstrap/linux-actual.json
 
 # Run the bootstrap script with the generated JSON
-python3 bootstrap/bootstrap.py -w "$(command -v ghc)" -d bootstrap/linux-actual.json
+retry python3 bootstrap/bootstrap.py -w "$(command -v ghc)" -d bootstrap/linux-actual.json
 
 # The bootstrap script compiles cabal-install and installs to _build/bin
 mkdir -p "$OUTPUT_DIR"/usr/bin

--- a/packages/stack/build.sh
+++ b/packages/stack/build.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -euo pipefail
 
+# `cabal update` (the hackage index) and `cabal build` (stack's full dependency
+# tree) both fetch from hackage.haskell.org live during the build, and those
+# downloads flake intermittently (truncated reads). cabal verifies sha256s and
+# caches deps under ~/.cabal, so a retry re-fetches only what failed and
+# resumes. The hermetic fix is a cabal.project.freeze + a vendored local
+# package repo (a bigger job) -- this retry is the cheap stopgap.
+retry() {
+    local -i attempt=1 max=4
+    until "$@"; do
+        if (( attempt >= max )); then
+            echo "retry: '$*' failed after $max attempts" >&2
+            return 1
+        fi
+        echo "retry: '$*' failed (attempt $attempt/$max) -- likely a transient hackage fetch; retrying in $(( attempt * 15 ))s" >&2
+        sleep $(( attempt * 15 ))
+        attempt+=1
+    done
+}
+
 if [ -f Setup.hs ]; then
   echo '{-# LANGUAGE CPP #-}' > Setup.hs.tmp
   while IFS= read -r line; do
@@ -32,8 +51,8 @@ if [ -f cabal.config ]; then
   sed -i '/Cabal-syntax ==/d' cabal.config
 fi
 
-cabal update
-cabal build
+retry cabal update
+retry cabal build
 
 # Install stack binary
 mkdir -p "$OUTPUT_DIR"/usr/bin


### PR DESCRIPTION
## Why
GHC/cabal/stack builds fetch tarballs **live from `hackage.haskell.org` during the build**, and those downloads flake intermittently (truncated reads → `http.client.IncompleteRead`), failing the whole package build. Seen on a prod build:
```
http.client.IncompleteRead: IncompleteRead(1529 bytes read)
  … Fetching http://hackage.haskell.org/package/…
```

## Audit of the Haskell toolchain
| package | build | network during build? |
|---|---|---|
| `ghc` | `bootstrap.py --bootstrap-sources <vendored tarball>` | ✅ offline |
| `ghc-bootstrap` | extracts a prebuilt GHC tarball (input) | ✅ offline |
| `happy` | `ghc --make Setup.hs` → `./Setup build` | ✅ offline |
| `alex` | `ghc --make Setup.hs` → `./Setup build` | ✅ offline |
| **`cabal`** | `bootstrap.py -d plan.json` | ❌ ~20 tarballs from hackage |
| **`stack`** | `cabal update` + `cabal build` | ❌ full index + 100+ deps from hackage |

Only **cabal** and **stack** touch the network.

## This PR (the cheap, robust stopgap)
Wraps the fetching commands in a bounded `retry` (4 attempts, 15/30/45s backoff). Safe because cabal verifies each tarball's sha256 and caches deps under `~/.cabal`, so a partial download is re-fetched cleanly and a retry resumes rather than restarts. No behavior change on the happy path.

## The proper fix (follow-up, not here)
Vendor the bootstrap sources offline so builds never touch hackage — closes the hermeticity/SLSA hole *and* kills the flake for good:
- **cabal → moderate:** mirror `packages/ghc` — cabal's `bootstrap.py` supports offline sources; vendor the ~20 pinned tarballs as an input.
- **stack → hard:** needs a `cabal.project.freeze` + a vendored local package repo for its full dep tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
