### PR TITLE
attrs: backfill source_provenance / binary_from (batch 1, 18 packages)

### DIFF
--- a/packages/alex/build.ncl
+++ b/packages/alex/build.ncl
@@ -38,6 +38,11 @@ let version = "3.5.1.0" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'GithubRepo,
+      owner = "haskell",
+      repo = "alex",
+    },
     license_spdx = "BSD-3-Clause",
   },
 } | BuildSpec

--- a/packages/android-sdk/build.ncl
+++ b/packages/android-sdk/build.ncl
@@ -34,6 +34,7 @@ let version = "11076708" in
   attrs =
     {
       upstream_version = version,
+      binary_from = "https://dl.google.com/android/repository/",
     } | Attrs,
 
   tests = {

--- a/packages/bash-bootstrap/build.ncl
+++ b/packages/bash-bootstrap/build.ncl
@@ -49,6 +49,10 @@ let version = "5.3" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'GnuProject,
+      name = "bash",
+    },
     license_spdx = "GPL-3.0-only",
   },
 

--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -63,6 +63,7 @@ in
   attrs =
     {
       upstream_version = version,
+      binary_from = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
       closed_source = true,
 
       # Claude code needs two things to function properly:

--- a/packages/dfu-util/build.ncl
+++ b/packages/dfu-util/build.ncl
@@ -44,6 +44,10 @@ let version = "0.11" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'Sourceforge,
+      name = "dfu-util",
+    },
     license_spdx = "GPL-2.0-only",
   },
 } | BuildSpec

--- a/packages/edgedelta/build.ncl
+++ b/packages/edgedelta/build.ncl
@@ -73,5 +73,6 @@ in
   attrs =
     {
       upstream_version = version,
+      binary_from = "https://release.edgedelta.com/",
     } | Attrs,
 } | BuildSpec

--- a/packages/expect/build.ncl
+++ b/packages/expect/build.ncl
@@ -40,6 +40,10 @@ let version = "5.45.4" in
   },
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'Sourceforge,
+      name = "expect",
+    },
     license_spdx = "NIST-PD",
   },
 } | BuildSpec

--- a/packages/findutils/build.ncl
+++ b/packages/findutils/build.ncl
@@ -62,6 +62,10 @@ let version = "4.10.0" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'GnuProject,
+        name = "findutils",
+      },
       license_spdx = "GPL-3.0-only",
       repology_project = "findutils",
     } | Attrs,

--- a/packages/gawk-bootstrap/build.ncl
+++ b/packages/gawk-bootstrap/build.ncl
@@ -42,6 +42,10 @@ let version = "5.3.2" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'GnuProject,
+      name = "gawk",
+    },
     license_spdx = "GPL-3.0-only",
   },
 

--- a/packages/gcloud/build.ncl
+++ b/packages/gcloud/build.ncl
@@ -74,6 +74,7 @@ in
   attrs =
     {
       upstream_version = version,
+      binary_from = "https://storage.googleapis.com/cloud-sdk-release",
       # `Pixar` + `Python-2.0.1` from auto-scan were false positives:
       # `Pixar` matched a docstring in pygments' USD lexer (the file
       # itself is BSD-licensed; "Pixar" is the format it parses), and

--- a/packages/ghc-bootstrap/build.ncl
+++ b/packages/ghc-bootstrap/build.ncl
@@ -60,6 +60,7 @@ let version = "9.8.1" in
 
   attrs = {
     upstream_version = version,
+    binary_from = "https://downloads.haskell.org/~ghc/",
     license_spdx = "BSD-3-Clause",
   },
 } | BuildSpec

--- a/packages/happy/build.ncl
+++ b/packages/happy/build.ncl
@@ -38,6 +38,11 @@ let version = "1.20.1.1" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'GithubRepo,
+      owner = "haskell",
+      repo = "happy",
+    },
     license_spdx = "BSD-2-Clause",
   },
 } | BuildSpec

--- a/packages/less/build.ncl
+++ b/packages/less/build.ncl
@@ -36,6 +36,11 @@ let version = "692" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "gwsw",
+        repo = "less",
+      },
       license_spdx = "BSD-2-Clause OR GPL-3.0-or-later",
       # Home page: https://www.greenwoodsoftware.com/less/
     } | Attrs,

--- a/packages/libfdk-aac/build.ncl
+++ b/packages/libfdk-aac/build.ncl
@@ -36,6 +36,10 @@ let version = "2.0.3" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'Sourceforge,
+        name = "opencore-amr",
+      },
       license_spdx = "FDK-AAC",
     } | Attrs,
 } | BuildSpec

--- a/packages/llvm-bootstrap/build.ncl
+++ b/packages/llvm-bootstrap/build.ncl
@@ -60,6 +60,11 @@ let version = "21.1.8" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'GithubRepo,
+      owner = "llvm",
+      repo = "llvm-project",
+    },
     license_spdx = "Apache-2.0",
     build_cost_multiple = 6,
   },

--- a/packages/maven/build.ncl
+++ b/packages/maven/build.ncl
@@ -32,6 +32,7 @@ let version = "3.9.12" in
   attrs =
     {
       upstream_version = version,
+      binary_from = "https://archive.apache.org/dist/maven/",
       license_spdx = "Apache-2.0",
     } | Attrs,
 

--- a/packages/stm32flash/build.ncl
+++ b/packages/stm32flash/build.ncl
@@ -40,6 +40,10 @@ let version = "0.7" in
 
   attrs = {
     upstream_version = version,
+    source_provenance = {
+      category = 'Sourceforge,
+      name = "stm32flash",
+    },
     license_spdx = "GPL-2.0-or-later",
   },
 } | BuildSpec

--- a/packages/zig/build.ncl
+++ b/packages/zig/build.ncl
@@ -41,6 +41,11 @@ let version = "0.16.0" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ziglang",
+        repo = "zig",
+      },
       license_spdx = "MIT",
       env_state_wiring = [
         {


### PR DESCRIPTION
Backfills provenance for 18 packages whose upstream is unambiguous. Values come from the package manager's resolver config — `suggest-provenance` returns **0 auto-candidates** (every missing package fetches from a `gs://` mirror that hides the real host, so inference can't fire). Metadata-only; no build changes; all 18 nickel-eval cleanly.

**Added**
| category | packages |
|---|---|
| `GithubRepo` (repo verified live) | zig (ziglang/zig) · llvm-bootstrap (llvm/llvm-project) · alex (haskell/alex) · happy (haskell/happy) · less (gwsw/less) |
| `Sourceforge` | stm32flash · dfu-util · expect · libfdk-aac (opencore-amr) |
| `GnuProject` | findutils · gawk-bootstrap (gawk) · bash-bootstrap (bash) |
| `binary_from` (prebuilt, not source) | gcloud · android-sdk · edgedelta · ghc-bootstrap · maven · claude-code |

**PURL:** already supported — the schema has `upstream_purl` / `peer_purl` attrs (with a PURL validator), but no package declares either; the PURL is derived from `source_provenance` at scan time. No action needed for PURL.

**Left (not in this batch)**
- **X.Org / freedesktop / GNOME (~25):** the resolver knows the exact GitLab path (gitlab.freedesktop.org/xorg, gitlab.gnome.org, mesa, cairo, pixman, dbus, fontconfig, glib, pango, atk, at-spi2-core, …), but the schema has **no GitLab category** — they only fit `Website`, which yields no PURL/CPE (so it wouldn't turn on vuln matching without a paired `cpe_remap`). These want either a new GitLab `source_provenance` category or a provenance+cpe_remap pass.
- **Non-GitHub hosts / mirror-vs-canonical unconfirmed (~25):** nss, nspr, freetype, elfutils, nasm, zsh, socat, dav1d, libx264, libaom, libx265, ghc, iproute2, procps-ng, graphviz, diffoscope, dnsutils, e2fsprogs, pasta, unzip, alsa-lib, man-db, acl, attr, libpipeline, emacs-config-dev1 — each needs the canonical origin confirmed before a category is assigned.
- **Internal / assembled (correctly no provenance):** base, base-bootstrap, toolchain, ca-certificates, microvm-rootfs, resolver-quad8, minimal-sshd, virtio-kernel-raw.
- **Kernel:** virtio-linux, virtio-linux-detonation (cdn.kernel.org).

Ref: https://minimal-dev.slack.com/archives/C091HGA43NC/p1783109351331609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source provenance metadata for several packages, improving upstream source identification and traceability.
  * Added explicit binary download source metadata for multiple packages to better document where prebuilt artifacts are obtained.
  * Expanded package metadata coverage across build specifications without changing build behavior or dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->