### PR TITLE
setuptools: build with PEP 517 isolation (pip 26 in python 3.14.6 broke --no-build-isolation)

### DIFF
--- a/packages/setuptools/build.sh
+++ b/packages/setuptools/build.sh
@@ -4,5 +4,10 @@ set -e
 tar -xof "setuptools-$MINIMAL_ARG_VERSION.tar.gz"
 cd "setuptools-$MINIMAL_ARG_VERSION"
 
-pip3 wheel -w dist --no-cache-dir --no-build-isolation --no-deps $PWD
-pip3 install --root $OUTPUT_DIR --no-index --find-links dist setuptools
+# Build with PEP 517 build isolation. python 3.14.6 ships pip 26, which dropped
+# the fallback that let `--no-build-isolation` self-build setuptools without an
+# already-installed setuptools backend — so the old recipe fails with
+# `invalid command 'dist_info'` on ANY setuptools rebuild. minimal's clean room
+# pre-stages the backend, so isolation resolves offline.
+pip3 wheel -w dist --no-cache-dir --no-deps "$PWD"
+pip3 install --root "$OUTPUT_DIR" --no-index --find-links dist setuptools


### PR DESCRIPTION
The `python` bump to 3.14.6 ships **pip 26**, which dropped the fallback that let `pip wheel --no-build-isolation` self-build setuptools without an already-installed setuptools backend (3.14 ensurepip = pip only, no setuptools). So the old recipe fails on **any** setuptools rebuild:

```
error: invalid command 'dist_info'
metadata-generation-failed
```

Not version-specific — surfaced first by the auto-update PR #355 (setuptools → 83.0.0), whose buildbot caught it. Root-caused by reproducing locally via `minimal package setuptools` (diag showed python 3.14.6, pip 26.1.2, **no ambient setuptools**).

**Fix:** drop `--no-build-isolation`; pip uses PEP 517 build isolation, and minimal's clean room pre-stages the backend so it resolves **offline**. Verified: `minimal package --rebuild --no-cache --offline setuptools` exits 0 for **both 82.0.1 and 83.0.0**. The wheel install stays `--no-index --find-links dist`.

Unblocks #355.