### PR TITLE
socat: add repology_project (un-blind the auto-update, #441)

### DIFF
--- a/packages/socat/build.ncl
+++ b/packages/socat/build.ncl
@@ -47,6 +47,12 @@ let version = "1.8.1.1" in
   attrs =
     {
       upstream_version = version,
+      # socat's upstream (dest-unreach.org) is HTTP-only and fits no
+      # source_provenance category, so version discovery resolves via repology
+      # (newest = 1.8.1.3). The gs:// mirror re-fetch on a bump pulls the real
+      # tarball from dest-unreach.org via pkgmgr's NAME_KEYED_UPSTREAMS. See
+      # gominimal/pkgmgr-rs#441.
+      repology_project = "socat",
       license_spdx = "GPL-2.0-only WITH openvpn-openssl-exception",
     } | Attrs,
 

--- a/packages/socat/build.ncl
+++ b/packages/socat/build.ncl
@@ -50,8 +50,8 @@ let version = "1.8.1.1" in
       # socat's upstream (dest-unreach.org) is HTTP-only and fits no
       # source_provenance category, so version discovery resolves via repology
       # (newest = 1.8.1.3). The gs:// mirror re-fetch on a bump pulls the real
-      # tarball from dest-unreach.org via pkgmgr's NAME_KEYED_UPSTREAMS. See
-      # gominimal/pkgmgr-rs#441.
+      # tarball from dest-unreach.org via pkgmgr's NAME_KEYED_UPSTREAMS
+      # (gominimal/pkgmgr-rs#449; tracking issue #441).
       repology_project = "socat",
       license_spdx = "GPL-2.0-only WITH openvpn-openssl-exception",
     } | Attrs,


### PR DESCRIPTION
## What
Adds `repology_project = "socat"` so pkgmgr's version-checker can discover socat's upstream releases.

## Why
The hidden-update audit found **socat is the lone confirmed hidden security update**: pinned at `1.8.1.1`, but stable upstream is `1.8.1.3` and `1.8.1.2` already fixes **CVE-2026-56123** (HIGH — SOCKS5 `DOMAINNAME` heap overflow).

socat's origin (`dest-unreach.org`) is HTTP-only and fits **no `source_provenance` category** (not GitHub/GNU/SF/GitLab), so the version-checker had no tier to resolve and silently reported it up-to-date. Repology tracks socat and reports newest = `1.8.1.3`, so `repology_project` is the right resolver.

This is the **auto-update-blind flavor of the #441 provenance gap** — socat isn't vuln-scan-dark (it matches CVE-2026-56123), but the missing provenance cost us the *fix*.

## Two-change fix (this is the pkgs half)
- **This PR** — `repology_project` for version discovery.
- **gominimal/pkgmgr-rs#449** — `NAME_KEYED_UPSTREAMS` entry so the gs:// mirror re-fetches the real tarball from dest-unreach.org on bump.

Once both land + deploy, the auto-update system cuts the `socat → 1.8.1.3` PR itself (clears CVE-2026-56123).

## Note
This PR only adds the resolver attr; it does **not** bump the version (socat stays 1.8.1.1). The bump comes from the auto-update system after this + #449 deploy. No source rebuild change.

Refs gominimal/pkgmgr-rs#441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the package’s build metadata to improve automated version tracking.
  * Version discovery now leverages Repology for this package, ensuring newer releases are detected more reliably.
  * Added explanatory notes about how version changes interact with the mirror and HTTPS integrity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->