### PR TITLE
chore(openssh): bump version to 10.4

### DIFF
--- a/packages/openssh/build.ncl
+++ b/packages/openssh/build.ncl
@@ -7,14 +7,14 @@ let pkgconf = import "../pkgconf/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 
-let version = "10.3p1" in
+let version = "10.4p1" in
 {
   name = "openssh",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/openssh-%{version}.tar.gz",
-      sha256 = "56682a36bb92dcf4b4f016fd8ec8e74059b79a8de25c15d670d731e7d18e45f4",
+      sha256 = "ef6026dd2aea8d56059638d5d3262902c892ceba9f88395835e0d06d3fb63238",
       extract = true,
       strip_prefix = "openssh-%{version}",
     } | Source,


### PR DESCRIPTION
## Summary

Update OpenSSH

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

## Changes

N/A

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [ x I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [ ] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [x] For version bumps: I've verified the new `sha256` against the upstream archive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenSSH to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->