### PR TITLE
acl 2.4.0 (CVE-2026-54369) + tar acl-wrapper rename (base-soup)

### DIFF
--- a/packages/acl/build.ncl
+++ b/packages/acl/build.ncl
@@ -12,14 +12,14 @@ let make = import "../make/build.ncl" in
 let linux_headers = import "../linux_headers/build.ncl" in
 let sed = import "../sed/build.ncl" in
 
-let version = "2.3.2" in
+let version = "2.4.0" in
 {
   name = "acl",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/acl-%{version}.tar.xz",
-      sha256 = "97203a72cae99ab89a067fe2210c1cbf052bc492b479eca7d226d9830883b0bd",
+      sha256 = "e661131456d2708a01c614a0f400e11d7d1bfaeb6f3e74b75bb980b72f0161a3",
       extract = true,
       strip_prefix = "acl-%{version}",
     } | Source,

--- a/packages/acl/build.sh
+++ b/packages/acl/build.sh
@@ -12,7 +12,7 @@ export CXXFLAGS="${CFLAGS}"
 
 ./configure  --prefix=/usr    \
             --disable-static \
-            --docdir=/usr/share/doc/acl-2.3.2
+            --docdir=/usr/share/doc/acl-2.4.0
 
 make -j$(nproc)
 # make check # TODO "opening /etc/group: No such file or directory"

--- a/packages/tar/build.sh
+++ b/packages/tar/build.sh
@@ -4,6 +4,17 @@ set -e
 tar -xof tar-1.35.tar.xz
 cd tar-1.35
 
+# tar 1.35 rolls its own static acl_*_file_at() wrappers in src/xattrs.c
+# ("acl-at wrappers, TODO: move to gnulib in future?"). libacl 2.4.0 added
+# those exact names as public functions (the CVE-2026-54369 symlink-traversal
+# fix), so tar's declarations now collide: "conflicting types for
+# 'acl_get_file_at'". No upstream tar release fixes this yet (1.35 is latest),
+# and tar's 3-arg call sites can't use libacl's 4-arg version — so rename tar's
+# internal wrappers out of the way. Drop this once tar >1.35 (or a gnulib
+# re-import) handles the collision.
+sed -i -E 's/\b(acl_get_file_at|acl_set_file_at|acl_delete_def_file_at)\b/tar_\1/g' src/xattrs.c
+grep -q 'tar_acl_get_file_at' src/xattrs.c || { echo "tar acl-wrapper rename failed" >&2; exit 1; }
+
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;
   aarch64) MARCH="-march=armv8-a" ;;


### PR DESCRIPTION
## What

Bumps **acl 2.3.2 → 2.4.0** (a **security** release — fixes **CVE-2026-54369**, a symlink-traversal local privilege-escalation in libacl's pathname functions), bundled with a **tar** build fix that the acl bump requires.

## Why bundled (base-soup)

acl 2.4.0's CVE fix adds new public `acl_get_file_at()` / `acl_set_file_at()` / `acl_delete_def_file_at()` functions (dirfd + `AT_SYMLINK_NOFOLLOW`). **tar 1.35 rolls its OWN static wrappers of those exact names** in `src/xattrs.c` (comment: *"acl-at wrappers, TODO: move to gnulib in future?"*), so rebuilding tar against libacl 2.4.0 fails:

```
xattrs.c:142: error: conflicting types for 'acl_get_file_at';
  have    ...(int, const char *, acl_type_t)                 ← tar's wrapper (3-arg)
  /usr/include/sys/acl.h:120: extern acl_t acl_get_file_at(int dirfd, const char*, int at_flags, acl_type_t)  ← libacl 2.4.0
```

tar 1.35 is the latest release (no upstream fix), and tar's 3-arg call sites can't consume libacl's 4-arg version — so the fix **renames tar's internal wrappers** (`acl_get_file_at` → `tar_acl_get_file_at`, etc.). Verified: the sed renames the decl + `at-func.c` template + all call sites consistently, and leaves libacl's base `acl_get_file` + tar-only `file_has_acl_at` untouched. A `grep` guard fails the build if the rename ever silently no-ops.

## Scope

- **coreutils 9.11** — unaffected. Its newer (2026) gnulib doesn't declare `acl_*_file_at`, so it builds cleanly against libacl 2.4.0. No change needed.
- No other fleet package rolls its own acl-at wrappers.

## Reviewer notes (please sanity-check)

- The tar patch is a `sed` rename in `build.sh`. When tar >1.35 (or a gnulib re-import) handles the collision, drop the patch — noted in a comment.
- acl `make check` stays disabled (pre-existing).

## Related

⚠️ **pkgmgr#363** (a stacked auto-bundle) also bumps acl 2.4.0 but **without** the tar fix — as-is it would FTBFS on the tar rebuild. **acl should be dropped from #363** and land here instead; the other 9 packages in #363 are independent. (Commenting there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated ACL to version 2.4.0, including refreshed download and checksum data.
* **Bug Fixes**
  * Adjusted documentation install paths for the new ACL version.
  * Improved tar build compatibility by preventing symbol conflicts with newer ACL support and adding a build-time check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->