### PR TITLE
microvm-rootfs: ship e2fsprogs + util-linux and /var/lib/minimal mountpoint

### DIFF
--- a/packages/microvm-rootfs/build.ncl
+++ b/packages/microvm-rootfs/build.ncl
@@ -2,24 +2,29 @@ let { BuildSpec, Local, OutputData, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let e2fsprogs = import "../e2fsprogs/build.ncl" in
 let git = import "../git/build.ncl" in
+let util-linux = import "../util-linux/build.ncl" in
 {
   name = "microvm-rootfs",
 
   # A read-only ext4 guest userland for a libkrun microVM. build.sh snapshots
-  # the runtime closure (base + git), prunes build-only bulk, and packs an ext4
-  # image loaded as a virtio-blk block device (/dev/vda). The guest minimald
-  # ships as the initramfs pid-1, mounts this image, and chroots into it — there
-  # is no standalone init in the image itself. e2fsprogs is build-only (mke2fs to
-  # pack the image) and its files are removed before packing, so the image ships
-  # only the runtime closure. git is in the closure because the in-guest minimald
-  # session bring-up inits a minimal context that shells out to git.
+  # the runtime closure, prunes build-only bulk, and packs an ext4 image loaded
+  # as a virtio-blk block device (/dev/vda). The guest minimald ships as the
+  # initramfs pid-1, mounts this image, and chroots into it — there is no
+  # standalone init in the image itself. git is in the closure because the
+  # in-guest minimald session bring-up inits a minimal context that shells out
+  # to git. e2fsprogs ships mkfs.ext4 (and mke2fs, which also packs the image
+  # below) so the guest minimald can format the per-VM writable volume
+  # (/dev/vdb) on first boot; util-linux ships fstrim to reclaim space from that
+  # volume. The mountpoint /var/lib/minimal is staged as an empty dir since the
+  # read-only root cannot be mkdir'd at runtime.
   runtime_deps = [
     base,
+    e2fsprogs,
     git,
+    util-linux,
   ],
   build_deps = [
     { file = "build.sh" } | Local,
-    e2fsprogs,
   ],
 
   cmd = "./build.sh",

--- a/packages/microvm-rootfs/build.sh
+++ b/packages/microvm-rootfs/build.sh
@@ -47,6 +47,26 @@ if [ ! -e "$STAGE/bin/sh" ]; then
   fi
 fi
 
+# libblkid / libuuid canonicalization. e2fsprogs and util-linux both ship a
+# libblkid.so.1 and libuuid.so.1 with the same soname; the staging composition
+# resolves them to e2fsprogs's older, unversioned forks. util-linux's libmount
+# then loads those and warns "libblkid.so.1: no version information available"
+# on every fstrim/mount/blkid. Repoint the sonames at util-linux's versioned
+# libs (an ABI superset — e2fsprogs's own mke2fs/e2fsck link them fine) and drop
+# the e2fsprogs forks. The util-linux targets are version-specific filenames;
+# fail loudly if a package bump renames them so this can't silently regress.
+ul_blkid=libblkid.so.1.1.0
+ul_uuid=libuuid.so.1.3.0
+for f in "$ul_blkid" "$ul_uuid"; do
+  [ -e "$STAGE/usr/lib/$f" ] || {
+    echo "ERROR: util-linux lib usr/lib/$f missing — did util-linux change soname?" >&2
+    exit 1
+  }
+done
+rm -f "$STAGE"/usr/lib/libblkid.so.1.0 "$STAGE"/usr/lib/libuuid.so.1.2
+ln -sf "$ul_blkid" "$STAGE/usr/lib/libblkid.so.1"
+ln -sf "$ul_uuid" "$STAGE/usr/lib/libuuid.so.1"
+
 # Prune build-time-only bulk the guest never needs: headers, static libs,
 # docs/man, and especially glibc's locale archive (the bulk of the closure).
 # The C locale fallback is sufficient for the guest workload.

--- a/packages/microvm-rootfs/build.sh
+++ b/packages/microvm-rootfs/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 # Assemble a libkrun microVM guest userland as a read-only ext4 image.
 #
-# The build sandbox hardlinks this package's runtime closure (base + git + their
-# libs) and its build-only deps (e2fsprogs, for mke2fs) into the sandbox root at
-# standard paths. We snapshot the userland into a staging tree, drop the
-# build-only e2fsprogs files, prune bulk, and pack an ext4 image with mke2fs. The
+# The build sandbox hardlinks this package's runtime closure (base + git +
+# e2fsprogs + util-linux + their libs) into the sandbox root at standard paths.
+# We snapshot the userland into a staging tree, prune build-only bulk, and pack
+# an ext4 image with mke2fs (from the e2fsprogs runtime closure, on PATH). The
 # image is loaded as a virtio-blk block device (/dev/vda); the guest minimald
 # ships as the initramfs pid-1, mounts this image, and chroots into it, so the
-# image itself carries no standalone init.
+# image itself carries no standalone init. e2fsprogs (mkfs.ext4) and util-linux
+# (fstrim) ship in the image so the guest can format and reclaim the per-VM
+# writable volume (/dev/vdb) mounted at /var/lib/minimal.
 set -euo pipefail
 
 STAGE="$(pwd)/stage"
@@ -21,20 +23,13 @@ for d in usr bin sbin lib lib64 etc; do
   fi
 done
 
-# e2fsprogs is a build-only dependency: it provides mke2fs to pack the image
-# below (invoked from the build sandbox PATH, not from $STAGE), but the guest
-# never needs it at runtime. Drop its staged files so the runtime image carries
-# only the runtime closure. The symlink guard skips a usr-merged /usr/sbin.
-if [ -d "$STAGE/usr/sbin" ] && [ ! -L "$STAGE/usr/sbin" ]; then
-  rm -rf "$STAGE/usr/sbin"
-fi
-rm -f "$STAGE"/usr/bin/chattr "$STAGE"/usr/bin/lsattr "$STAGE"/usr/bin/uuidgen \
-      "$STAGE"/usr/bin/compile_et "$STAGE"/usr/bin/mk_cmds
-# Note: `libss.so*` (not `libss*.so*`) — the latter also matches openssl's
-# libssl.so, which the git runtime closure (curl, openssl) needs at runtime.
-rm -f "$STAGE"/usr/lib/libext2fs.so* "$STAGE"/usr/lib/libe2p.so* "$STAGE"/usr/lib/libss.so*
-
 mkdir -p "$STAGE/bin" "$STAGE/sbin"
+
+# Per-VM writable volume mountpoint. The guest minimald mounts /dev/vdb here on
+# first boot (after formatting it with mkfs.ext4). The root image is mounted
+# read-only, so this directory cannot be created at runtime — it must ship in
+# the image or the mount fails with ENOENT/EROFS.
+mkdir -p "$STAGE/var/lib/minimal"
 
 # Kernel mountpoints. devtmpfs auto-mounts on /dev at boot (CONFIG_DEVTMPFS_MOUNT)
 # — without the directory it fails with "devtmpfs: error mounting -2" and the
@@ -66,7 +61,7 @@ fi
 
 # Fail loudly (not silently with an empty output) if the image tool is absent.
 command -v mke2fs >/dev/null || {
-  echo "ERROR: mke2fs not found on PATH ($PATH) — is e2fsprogs in build_deps?" >&2
+  echo "ERROR: mke2fs not found on PATH ($PATH) — is e2fsprogs in runtime_deps?" >&2
   exit 1
 }
 


### PR DESCRIPTION
## What

Adds the three pieces the guest rootfs needs to support a per-VM writable ext4 volume, unblocking **Unit 1** of the per-VM writable volume spec ([gominimal/minimal#583](https://github.com/gominimal/minimal/issues/583), [PR #658](https://github.com/gominimal/minimal/pull/658) R1.7).

The in-guest `minimald` mounts a per-VM writable volume (`/dev/vdb`) at `/var/lib/minimal`, formats it with `mkfs.ext4` on first boot, and reclaims space via discard / `fstrim`. The current rootfs (`base` + `git`) ships none of these. This change:

1. **Promotes `e2fsprogs` from build-only to the runtime closure.** It was previously a `build_deps` entry whose files (`usr/sbin`, `mke2fs`, e2fsprogs libs) were *deliberately stripped* from the image by `build.sh`. Now its files ship, providing `mkfs.ext4`/`mke2fs` in the guest. `mke2fs` remains on the build PATH via the injected runtime closure, so it still packs the image — the redundant `build_deps` entry and the strip block are removed.
2. **Adds `util-linux` to the runtime closure** for `fstrim` (space reclaim). `mount -o discard` (online discard) also works with plain ext4, so this is secondary to `e2fsprogs`.
3. **Stages `/var/lib/minimal` as an empty directory.** The root image is mounted read-only in the guest, so `minimald` cannot `mkdir` the mountpoint at runtime — it must ship in the image or the mount fails with `ENOENT`/`EROFS`.
4. **Canonicalizes `libblkid`/`libuuid` to util-linux's versioned libs.** e2fsprogs and util-linux both ship a `libblkid.so.1`/`libuuid.so.1` with the same soname; staging resolved them to e2fsprogs's older, unversioned forks, so util-linux's `libmount` warned `no version information available` on every `fstrim`/`mount`/`blkid`. `build.sh` now repoints both sonames at util-linux's versioned libs (an ABI superset — e2fsprogs's own `mke2fs`/`e2fsck` link them fine) and drops the e2fsprogs forks. A guard fails the build if a package bump renames the util-linux targets, so it can't silently regress.

No packaging/format change: the output stays a raw ext4 `rootfs.img`.

## Verification

Built with `minimal patched-build microvm-rootfs`, then mounted the resulting ext4 image (loopback, in a Linux container) and chrooted:

- `/var/lib/minimal` — present, **empty** (0 entries).
- `mkfs.ext4 -V` / `mke2fs -V` → `mke2fs 1.47.4`. `mkfs.ext4` is the `mke2fs` symlink in `/usr/sbin`; a real `mkfs.ext4 -F` format of a scratch image succeeds against util-linux's `libblkid`.
- `fstrim --help` / `fstrim --version` → `fstrim from util-linux 2.42.1`, **zero stderr** (no libblkid warning).
- `mount -V` → `mount from util-linux 2.42.1`, **zero stderr**.
- `libblkid.so.1 -> libblkid.so.1.1.0` and `libuuid.so.1 -> libuuid.so.1.3.0` (util-linux); e2fsprogs forks removed.
- `blkid` on the image → `TYPE="ext4"` (raw ext4, boot layout unchanged).
- `min check --packages microvm-rootfs` — all checks Pass (including post-build `enumerate bins`, `output types valid`, `missing runtime_deps`).

**Image size:** `444,070,912` → `471,600,128` bytes (**+~27.5 MiB**), bounded and expected for both packages' binaries + libs. (The bulk of the image — a ~192 MiB GCC in the closure — is pre-existing in both baseline and this build; not introduced here.)

### Follow-up (not in this PR)

The scoped `libblkid`/`libuuid` repoint above fixes the warning for this image. The upstream-correct fix is to build `e2fsprogs` with `--disable-libblkid --disable-libuuid --disable-uuidd` so util-linux is the sole provider ecosystem-wide (and the guest gets util-linux's modern `blkid` binary too, rather than e2fsprogs's 2003-era one). That touches a foundational package and forces a rebuild + re-pin of every `e2fsprogs` consumer, so it's deliberately out of scope here. Worth filing separately.

## ⚠️ Downstream re-pin required (cross-repo handoff)

Once this merges and the `microvm-rootfs` artifact is published, **gominimal/minimal must re-pin it** in `.minimal/minimal.toml` under `[outputs.minvmd-rootfs]` (`locked_commit`) to the new build, so the updated rootfs (with `/var/lib/minimal`, `mkfs.ext4`, `fstrim`) is materialized. The guest mount code (`minimald mount_state_volume`) and host attach already exist in gominimal/minimal and are waiting on this rootfs.

Refs: [gominimal/minimal#583](https://github.com/gominimal/minimal/issues/583), [gominimal/minimal#658](https://github.com/gominimal/minimal/pull/658)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented per-VM writable volume mount failures by ensuring the `/var/lib/minimal` directory exists during staging under a read-only root.
  * Improved runtime disk-space reclamation support by aligning the expected `libblkid`/`libuuid` libraries to the provided `util-linux` versions, with build-time validation.
  * Updated the “missing tool” guidance to point to the correct runtime dependency for filesystem creation.
* **Documentation**
  * Refreshed microvm-rootfs build notes to reflect the updated runtime contents (including `util-linux`) and support for reclaiming space via `fstrim`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->