### PR TITLE
e2fsprogs: defer libblkid/libuuid to util-linux (drop bundled forks)

### DIFF
--- a/packages/e2fsprogs/build.ncl
+++ b/packages/e2fsprogs/build.ncl
@@ -1,4 +1,4 @@
-let { Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
 let base-bootstrap = import "../base-bootstrap/build.ncl" in
 let make = import "../make/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
@@ -20,17 +20,23 @@ let version = "1.47.4" in
     make,
     pkgconf,
     toolchain,
+    # Build against util-linux's libblkid/libuuid (build.sh configures
+    # --disable-libblkid --disable-libuuid). Configure detects them via
+    # pkg-config, needing the headers and .pc files (OutputData) as well as the
+    # libs, so pull the whole package here — build_deps don't propagate to
+    # consumers' runtime closures.
+    util-linux,
   ],
-  # util-linux provides libblkid/libuuid: build.sh configures --disable-libblkid
-  # --disable-libuuid so e2fsprogs's tools link util-linux's maintained,
-  # symbol-versioned libs instead of bundling its own older forks (same soname,
-  # which otherwise collide in a shared image). Needed both to link at build and
-  # to load at runtime. Cycle-safe: nothing in util-linux's closure uses
-  # e2fsprogs.
+  # e2fsprogs bundles its own older forks of libblkid/libuuid with the same
+  # soname as util-linux's maintained, symbol-versioned libs; shipping both in
+  # one image collides. build.sh disables the forks, so mke2fs/e2fsck DT_NEED
+  # util-linux's libblkid.so.1/libuuid.so.1 at runtime — pull only those two
+  # outputs, not the whole ~18 MB toolset. Cycle-safe: nothing in util-linux's
+  # closure uses e2fsprogs.
   runtime_deps = [
     glibc,
     bash,
-    util-linux,
+    subsetOf util-linux ["libblkid", "libuuid"],
   ],
 
   cmd = "./build.sh",

--- a/packages/e2fsprogs/build.ncl
+++ b/packages/e2fsprogs/build.ncl
@@ -1,9 +1,11 @@
 let { Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
 let base-bootstrap = import "../base-bootstrap/build.ncl" in
 let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let bash = import "../bash/build.ncl" in
+let util-linux = import "../util-linux/build.ncl" in
 
 let version = "1.47.4" in
 {
@@ -16,11 +18,19 @@ let version = "1.47.4" in
     } | Source,
     base-bootstrap,
     make,
+    pkgconf,
     toolchain,
   ],
+  # util-linux provides libblkid/libuuid: build.sh configures --disable-libblkid
+  # --disable-libuuid so e2fsprogs's tools link util-linux's maintained,
+  # symbol-versioned libs instead of bundling its own older forks (same soname,
+  # which otherwise collide in a shared image). Needed both to link at build and
+  # to load at runtime. Cycle-safe: nothing in util-linux's closure uses
+  # e2fsprogs.
   runtime_deps = [
     glibc,
     bash,
+    util-linux,
   ],
 
   cmd = "./build.sh",
@@ -31,17 +41,16 @@ let version = "1.47.4" in
   outputs = {
     chattr = { glob = "usr/bin/chattr" } | OutputBin,
     lsattr = { glob = "usr/bin/lsattr" } | OutputBin,
-    uuidgen = { glob = "usr/bin/uuidgen" } | OutputBin,
     compile_et = { glob = "usr/bin/compile_et" } | OutputBin,
     mk_cmds = { glob = "usr/bin/mk_cmds" } | OutputBin,
     sbins = { glob = "usr/sbin/*" } | OutputBin,
 
+    # libblkid/libuuid are intentionally not built here (--disable-libblkid
+    # --disable-libuuid); util-linux is the sole provider. See build.sh.
     libext2fs = { glob = "usr/lib/libext2fs*.so*" } | OutputLib,
     libcom_err = { glob = "usr/lib/libcom_err*.so*" } | OutputLib,
     libe2p = { glob = "usr/lib/libe2p*.so*" } | OutputLib,
     libss = { glob = "usr/lib/libss*.so*" } | OutputLib,
-    libuuid = { glob = "usr/lib/libuuid*.so*" } | OutputLib,
-    libblkid = { glob = "usr/lib/libblkid*.so*" } | OutputLib,
     libs = { glob = "usr/lib/lib*.so*" } | OutputLib,
 
     includes = { glob = "usr/include/**/*" } | OutputData,

--- a/packages/e2fsprogs/build.sh
+++ b/packages/e2fsprogs/build.sh
@@ -13,11 +13,25 @@ export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
 
+# Defer libblkid/libuuid (and uuidd) to util-linux, which is injected into this
+# build via runtime_deps. e2fsprogs bundles its own older forks of libblkid and
+# libuuid with the same soname (libblkid.so.1, libuuid.so.1) as util-linux's
+# maintained, symbol-versioned ones; shipping both in a single image makes the
+# dynamic loader resolve util-linux's libmount against the wrong libblkid and
+# warn "no version information available". Building --disable-libblkid
+# --disable-libuuid links e2fsprogs's own tools against util-linux's libs (an
+# ABI superset), so the image carries exactly one libblkid/libuuid. Point
+# pkg-config at util-linux's .pc files so configure finds them.
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+
 ./configure --bindir=/usr/bin       \
             --sbindir=/usr/sbin     \
             --libdir=/usr/lib       \
             --enable-elf-shlibs     \
             --disable-defrag        \
+            --disable-libblkid      \
+            --disable-libuuid       \
+            --disable-uuidd         \
             --without-libintl-prefix
 
 make -j"$(nproc)"

--- a/packages/microvm-rootfs/build.ncl
+++ b/packages/microvm-rootfs/build.ncl
@@ -2,24 +2,29 @@ let { BuildSpec, Local, OutputData, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let e2fsprogs = import "../e2fsprogs/build.ncl" in
 let git = import "../git/build.ncl" in
+let util-linux = import "../util-linux/build.ncl" in
 {
   name = "microvm-rootfs",
 
   # A read-only ext4 guest userland for a libkrun microVM. build.sh snapshots
-  # the runtime closure (base + git), prunes build-only bulk, and packs an ext4
-  # image loaded as a virtio-blk block device (/dev/vda). The guest minimald
-  # ships as the initramfs pid-1, mounts this image, and chroots into it — there
-  # is no standalone init in the image itself. e2fsprogs is build-only (mke2fs to
-  # pack the image) and its files are removed before packing, so the image ships
-  # only the runtime closure. git is in the closure because the in-guest minimald
-  # session bring-up inits a minimal context that shells out to git.
+  # the runtime closure, prunes build-only bulk, and packs an ext4 image loaded
+  # as a virtio-blk block device (/dev/vda). The guest minimald ships as the
+  # initramfs pid-1, mounts this image, and chroots into it — there is no
+  # standalone init in the image itself. git is in the closure because the
+  # in-guest minimald session bring-up inits a minimal context that shells out
+  # to git. e2fsprogs ships mkfs.ext4 (and mke2fs, which also packs the image
+  # below) so the guest minimald can format the per-VM writable volume
+  # (/dev/vdb) on first boot; util-linux ships fstrim to reclaim space from that
+  # volume. The mountpoint /var/lib/minimal is staged as an empty dir since the
+  # read-only root cannot be mkdir'd at runtime.
   runtime_deps = [
     base,
+    e2fsprogs,
     git,
+    util-linux,
   ],
   build_deps = [
     { file = "build.sh" } | Local,
-    e2fsprogs,
   ],
 
   cmd = "./build.sh",

--- a/packages/microvm-rootfs/build.sh
+++ b/packages/microvm-rootfs/build.sh
@@ -47,26 +47,6 @@ if [ ! -e "$STAGE/bin/sh" ]; then
   fi
 fi
 
-# libblkid / libuuid canonicalization. e2fsprogs and util-linux both ship a
-# libblkid.so.1 and libuuid.so.1 with the same soname; the staging composition
-# resolves them to e2fsprogs's older, unversioned forks. util-linux's libmount
-# then loads those and warns "libblkid.so.1: no version information available"
-# on every fstrim/mount/blkid. Repoint the sonames at util-linux's versioned
-# libs (an ABI superset — e2fsprogs's own mke2fs/e2fsck link them fine) and drop
-# the e2fsprogs forks. The util-linux targets are version-specific filenames;
-# fail loudly if a package bump renames them so this can't silently regress.
-ul_blkid=libblkid.so.1.1.0
-ul_uuid=libuuid.so.1.3.0
-for f in "$ul_blkid" "$ul_uuid"; do
-  [ -e "$STAGE/usr/lib/$f" ] || {
-    echo "ERROR: util-linux lib usr/lib/$f missing — did util-linux change soname?" >&2
-    exit 1
-  }
-done
-rm -f "$STAGE"/usr/lib/libblkid.so.1.0 "$STAGE"/usr/lib/libuuid.so.1.2
-ln -sf "$ul_blkid" "$STAGE/usr/lib/libblkid.so.1"
-ln -sf "$ul_uuid" "$STAGE/usr/lib/libuuid.so.1"
-
 # Prune build-time-only bulk the guest never needs: headers, static libs,
 # docs/man, and especially glibc's locale archive (the bulk of the closure).
 # The C locale fallback is sufficient for the guest workload.

--- a/packages/microvm-rootfs/build.sh
+++ b/packages/microvm-rootfs/build.sh
@@ -47,6 +47,26 @@ if [ ! -e "$STAGE/bin/sh" ]; then
   fi
 fi
 
+# libblkid / libuuid canonicalization. e2fsprogs and util-linux both ship a
+# libblkid.so.1 and libuuid.so.1 with the same soname; the staging composition
+# resolves them to e2fsprogs's older, unversioned forks. util-linux's libmount
+# then loads those and warns "libblkid.so.1: no version information available"
+# on every fstrim/mount/blkid. Repoint the sonames at util-linux's versioned
+# libs (an ABI superset — e2fsprogs's own mke2fs/e2fsck link them fine) and drop
+# the e2fsprogs forks. The util-linux targets are version-specific filenames;
+# fail loudly if a package bump renames them so this can't silently regress.
+ul_blkid=libblkid.so.1.1.0
+ul_uuid=libuuid.so.1.3.0
+for f in "$ul_blkid" "$ul_uuid"; do
+  [ -e "$STAGE/usr/lib/$f" ] || {
+    echo "ERROR: util-linux lib usr/lib/$f missing — did util-linux change soname?" >&2
+    exit 1
+  }
+done
+rm -f "$STAGE"/usr/lib/libblkid.so.1.0 "$STAGE"/usr/lib/libuuid.so.1.2
+ln -sf "$ul_blkid" "$STAGE/usr/lib/libblkid.so.1"
+ln -sf "$ul_uuid" "$STAGE/usr/lib/libuuid.so.1"
+
 # Prune build-time-only bulk the guest never needs: headers, static libs,
 # docs/man, and especially glibc's locale archive (the bulk of the closure).
 # The C locale fallback is sufficient for the guest workload.

--- a/packages/microvm-rootfs/build.sh
+++ b/packages/microvm-rootfs/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 # Assemble a libkrun microVM guest userland as a read-only ext4 image.
 #
-# The build sandbox hardlinks this package's runtime closure (base + git + their
-# libs) and its build-only deps (e2fsprogs, for mke2fs) into the sandbox root at
-# standard paths. We snapshot the userland into a staging tree, drop the
-# build-only e2fsprogs files, prune bulk, and pack an ext4 image with mke2fs. The
+# The build sandbox hardlinks this package's runtime closure (base + git +
+# e2fsprogs + util-linux + their libs) into the sandbox root at standard paths.
+# We snapshot the userland into a staging tree, prune build-only bulk, and pack
+# an ext4 image with mke2fs (from the e2fsprogs runtime closure, on PATH). The
 # image is loaded as a virtio-blk block device (/dev/vda); the guest minimald
 # ships as the initramfs pid-1, mounts this image, and chroots into it, so the
-# image itself carries no standalone init.
+# image itself carries no standalone init. e2fsprogs (mkfs.ext4) and util-linux
+# (fstrim) ship in the image so the guest can format and reclaim the per-VM
+# writable volume (/dev/vdb) mounted at /var/lib/minimal.
 set -euo pipefail
 
 STAGE="$(pwd)/stage"
@@ -21,20 +23,13 @@ for d in usr bin sbin lib lib64 etc; do
   fi
 done
 
-# e2fsprogs is a build-only dependency: it provides mke2fs to pack the image
-# below (invoked from the build sandbox PATH, not from $STAGE), but the guest
-# never needs it at runtime. Drop its staged files so the runtime image carries
-# only the runtime closure. The symlink guard skips a usr-merged /usr/sbin.
-if [ -d "$STAGE/usr/sbin" ] && [ ! -L "$STAGE/usr/sbin" ]; then
-  rm -rf "$STAGE/usr/sbin"
-fi
-rm -f "$STAGE"/usr/bin/chattr "$STAGE"/usr/bin/lsattr "$STAGE"/usr/bin/uuidgen \
-      "$STAGE"/usr/bin/compile_et "$STAGE"/usr/bin/mk_cmds
-# Note: `libss.so*` (not `libss*.so*`) — the latter also matches openssl's
-# libssl.so, which the git runtime closure (curl, openssl) needs at runtime.
-rm -f "$STAGE"/usr/lib/libext2fs.so* "$STAGE"/usr/lib/libe2p.so* "$STAGE"/usr/lib/libss.so*
-
 mkdir -p "$STAGE/bin" "$STAGE/sbin"
+
+# Per-VM writable volume mountpoint. The guest minimald mounts /dev/vdb here on
+# first boot (after formatting it with mkfs.ext4). The root image is mounted
+# read-only, so this directory cannot be created at runtime — it must ship in
+# the image or the mount fails with ENOENT/EROFS.
+mkdir -p "$STAGE/var/lib/minimal"
 
 # Kernel mountpoints. devtmpfs auto-mounts on /dev at boot (CONFIG_DEVTMPFS_MOUNT)
 # — without the directory it fails with "devtmpfs: error mounting -2" and the
@@ -66,7 +61,7 @@ fi
 
 # Fail loudly (not silently with an empty output) if the image tool is absent.
 command -v mke2fs >/dev/null || {
-  echo "ERROR: mke2fs not found on PATH ($PATH) — is e2fsprogs in build_deps?" >&2
+  echo "ERROR: mke2fs not found on PATH ($PATH) — is e2fsprogs in runtime_deps?" >&2
   exit 1
 }
 


### PR DESCRIPTION
Follow-up to #365 (per Bryan's suggestion to do it now). **Stacked on #365** — base this on `main` once #365 merges.

## Why

e2fsprogs bundles its own older forks of `libblkid` and `libuuid` with the **same soname** (`libblkid.so.1`, `libuuid.so.1`) as util-linux's maintained, symbol-versioned libraries. Any image shipping both — like `microvm-rootfs` after #365 — has the dynamic loader resolve util-linux's `libmount` against e2fsprogs's unversioned `libblkid`, warning `libblkid.so.1: no version information available` on every `fstrim`/`mount`/`blkid`.

#365 worked around this *in the image* by repointing symlinks in `microvm-rootfs/build.sh`. This fixes it *at the source*: e2fsprogs stops building its forks and links util-linux's libs instead — the standard distro configuration (Debian/Fedora/Arch all build e2fsprogs `--disable-libblkid --disable-libuuid`).

## What

- **`e2fsprogs/build.sh`**: configure `--disable-libblkid --disable-libuuid --disable-uuidd`; set `PKG_CONFIG_PATH` so configure locates util-linux's libs.
- **`e2fsprogs/build.ncl`**: add `pkgconf` + full `util-linux` to build deps (configure needs util-linux's headers and `.pc` files — `OutputData` outputs, which `subsetOf` can't express — and build deps don't propagate to consumers' runtime closures). Add `subsetOf util-linux ["libblkid", "libuuid"]` to runtime deps — only those `.so`s load at runtime. Drop the `libblkid`/`libuuid`/`uuidgen` outputs — no longer built.
- **`microvm-rootfs/build.sh`**: remove the now-redundant libblkid/libuuid symlink-canonicalization block introduced in #365.

e2fsprogs now builds **no** `libblkid`/`libuuid`/`blkid`/`findfs`/`uuidgen`; util-linux is the sole provider.

**Cycle-safe:** `microvm-rootfs` is the *only* package in the repo that imports `e2fsprogs` (grep-confirmed), so nothing in util-linux's closure can reach it. Blast radius is exactly these two packages.

## Verification

`minimal package e2fsprogs` + `minimal patched-build microvm-rootfs`, then loopback-mounted the guest image:

**e2fsprogs artifact:**
- Ships none of `libblkid*`/`libuuid*`/`blkid`/`findfs`/`uuidgen`; keeps its own `libext2fs`/`libe2p`/`libss`/`libcom_err`.
- `readelf -d mke2fs` → `NEEDED libblkid.so.1`, `NEEDED libuuid.so.1` (resolved to util-linux's at runtime).
- `min check --packages e2fsprogs` all Pass — including `missing runtime_deps`, which confirms every DT_NEEDED lib is satisfied by the declared closure.

**Guest image:**
- Exactly one `libblkid.so.1 → libblkid.so.1.1.0` and one `libuuid.so.1 → libuuid.so.1.3.0` (util-linux); e2fsprogs forks gone.
- `blkid --version` → `blkid from util-linux 2.42.1` (modern binary, not e2fsprogs's 2003-era one).
- `fstrim --help` → exit 0, **zero stderr**.
- Real `mkfs.ext4 -qF` on a scratch image → exit 0, zero stderr, produces valid ext4 (`TYPE="ext4"`), `fsck.ext4 -fn` reports it **clean**.
- `/var/lib/minimal` empty; `ip` + `nsenter` intact; `TYPE="ext4"`.

## Downstream

Same handoff as #365 — after this and #365 merge and the artifact publishes, `gominimal/minimal` re-pins `microvm-rootfs` in `.minimal/minimal.toml` `[outputs.minvmd-rootfs]`. No separate re-pin needed for e2fsprogs (it has no other consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for file-system tools by using the system-provided versions of shared libraries.
  * Reduced the risk of library loading conflicts during package use and system startup.
  * Adjusted the root filesystem packaging to keep existing library links intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
