### PR TITLE
packages: wolfi import batch 2 — go+rust (lazygit, act, mkcert, ruff, zola, xh)

### DIFF
--- a/packages/act/build.ncl
+++ b/packages/act/build.ncl
@@ -1,0 +1,51 @@
+# Imported from Wolfi `act` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.2.89" in
+{
+  name = "act",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/nektos/act/v%{version}.tar.gz",
+      sha256 = "649cd5b91cad870871d2283fb3ad95c8fa1d5ced7a1db8d7b346d1a7dcd3ec71",
+      extract = true,
+      strip_prefix = "act-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    act = { glob = "usr/bin/act" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "nektos", repo = "act" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "act --version"],
+          ["/bin/bash", "-c", "act --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/act/build.ncl
+++ b/packages/act/build.ncl
@@ -26,6 +26,9 @@ let version = "0.2.89" in
       internet = {},
     } | Needs,
   cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
   outputs = {
     act = { glob = "usr/bin/act" } | OutputBin,
   },

--- a/packages/act/build.sh
+++ b/packages/act/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Imported from Wolfi `act` (0.2.89, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+go build -trimpath -ldflags "-buildid= -w -s" -o act .
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 act "$OUTPUT_DIR/usr/bin/act"

--- a/packages/act/build.sh
+++ b/packages/act/build.sh
@@ -2,6 +2,8 @@
 # Imported from Wolfi `act` (0.2.89, go) by pkgmgr import-wolfi.
 set -eu
 export GOROOT=/usr/go
-go build -trimpath -ldflags "-buildid= -w -s" -o act .
+# Stamp the version so `act --version` reports it (act reads `main.version`);
+# $MINIMAL_ARG_VERSION is forwarded from build.ncl's `version` via build_args.
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION}" -o act .
 mkdir -p "$OUTPUT_DIR/usr/bin"
 install -m 755 act "$OUTPUT_DIR/usr/bin/act"

--- a/packages/lazygit/build.ncl
+++ b/packages/lazygit/build.ncl
@@ -1,0 +1,55 @@
+# Imported from Wolfi `lazygit` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.63.0" in
+{
+  name = "lazygit",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/jesseduffield/lazygit/v%{version}.tar.gz",
+      sha256 = "56f028ad7700cbe4474e5fb09a617649a82d0963820d38757f61a93b31832610",
+      extract = true,
+      strip_prefix = "lazygit-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    lazygit = { glob = "usr/bin/lazygit" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "jesseduffield", repo = "lazygit" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "lazygit --help"],
+          ["/bin/bash", "-c", "lazygit --version"],
+          ["/bin/bash", "-c", "set -euo pipefail\n# Verify buildSource was embedded via ldflags\nlazygit --version 2>&1 | grep -F \"wolfiRelease\""],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lazygit/build.sh
+++ b/packages/lazygit/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Imported from Wolfi `lazygit` (0.63.0, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION} -X main.buildSource=wolfiRelease" -o lazygit .
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 lazygit "$OUTPUT_DIR/usr/bin/lazygit"

--- a/packages/mkcert/build.ncl
+++ b/packages/mkcert/build.ncl
@@ -1,0 +1,54 @@
+# Imported from Wolfi `mkcert` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "1.4.4" in
+{
+  name = "mkcert",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/FiloSottile/mkcert/v%{version}.tar.gz",
+      sha256 = "32bd5519581bf0b03f53e5b22721692b99f39ab5b161dc27532c51eafa512ca9",
+      extract = true,
+      strip_prefix = "mkcert-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    mkcert = { glob = "usr/bin/mkcert" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "FiloSottile", repo = "mkcert" },
+      license_spdx = "BSD-3-Clause",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "mkcert --version"],
+          ["/bin/bash", "-c", "mkcert --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/mkcert/build.sh
+++ b/packages/mkcert/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Imported from Wolfi `mkcert` (1.4.4, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+go build -trimpath -ldflags "-buildid= -w -s -X main.Version=${MINIMAL_ARG_VERSION}" -o mkcert .
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 mkcert "$OUTPUT_DIR/usr/bin/mkcert"

--- a/packages/ruff/build.ncl
+++ b/packages/ruff/build.ncl
@@ -1,0 +1,56 @@
+# Imported from Wolfi `ruff` by `pkgmgr import-wolfi` (rust build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "0.15.20" in
+{
+  name = "ruff",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/astral-sh/ruff/%{version}.tar.gz",
+      sha256 = "3d2d9283f8221d04f1debf1ac32ec900bba08aec5609266ac93b8b8464073d16",
+      extract = true,
+      strip_prefix = "ruff-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    ruff = { glob = "usr/bin/ruff" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "astral-sh", repo = "ruff" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "ruff --version"],
+          ["/bin/bash", "-c", "ruff --help"],
+          ["/bin/bash", "-c", "echo 'print(\"Hello, world!\")' > test.py\nruff check test.py || exit 1"],
+          ["/bin/bash", "-c", "echo 'print(\"Hello, world!\")' > test.py\nruff check --select F401 test.py || exit 1"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ruff/build.sh
+++ b/packages/ruff/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Imported from Wolfi `ruff` (0.15.20, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/ruff" "$OUTPUT_DIR/usr/bin/"

--- a/packages/xh/build.ncl
+++ b/packages/xh/build.ncl
@@ -1,0 +1,57 @@
+# Imported from Wolfi `xh` by `pkgmgr import-wolfi` (rust build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "0.26.1" in
+{
+  name = "xh",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/ducaale/xh/v%{version}.tar.gz",
+      sha256 = "6c4822374d3b9bacfc50719ffb5653a32fd84344e50fd88b499ed8fc9e52198b",
+      extract = true,
+      strip_prefix = "xh-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    xh = { glob = "usr/bin/xh" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ducaale", repo = "xh" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "xh --version"],
+          ["/bin/bash", "-c", "xh --help"],
+          ["/bin/bash", "-c", "set -euo pipefail\noutput=$(xh --offline GET https://example.com)\necho \"$output\" | grep -F \"GET / HTTP\""],
+          ["/bin/bash", "-c", "set -euo pipefail\noutput=$(echo '{\"key\":\"value\"}' | xh --offline POST https://example.com Content-Type:application/json)\necho \"$output\" | grep -F \"key\""],
+          ["/bin/bash", "-c", "set -euo pipefail\noutput=$(xh --offline GET https://example.com X-Custom:test)\necho \"$output\" | grep -F \"X-Custom: test\""],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/xh/build.sh
+++ b/packages/xh/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Imported from Wolfi `xh` (0.26.1, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/xh" "$OUTPUT_DIR/usr/bin/"

--- a/packages/zola/build.ncl
+++ b/packages/zola/build.ncl
@@ -37,7 +37,9 @@ let version = "0.22.1" in
     {
       upstream_version = version,
       source_provenance = { category = 'GithubRepo, owner = "getzola", repo = "zola" },
-      license_spdx = "MIT",
+      # zola relicensed to EUPL-1.2 at v0.22 (commit 3c9131d); v0.22.1 declares
+      # `license = "EUPL-1.2"` in Cargo.toml and ships only the EUPL LICENSE file.
+      license_spdx = "EUPL-1.2",
     } | Attrs,
   tests = {
     smoke =

--- a/packages/zola/build.ncl
+++ b/packages/zola/build.ncl
@@ -1,0 +1,54 @@
+# Imported from Wolfi `zola` by `pkgmgr import-wolfi` (rust build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "0.22.1" in
+{
+  name = "zola",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/getzola/zola/v%{version}.tar.gz",
+      sha256 = "0f59479e05bce79e8d5860dc7e807ea818986094469ed8bf0bb46588ade95982",
+      extract = true,
+      strip_prefix = "zola-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    zola = { glob = "usr/bin/zola" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "getzola", repo = "zola" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "zola --version"],
+          ["/bin/bash", "-c", "zola --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/zola/build.sh
+++ b/packages/zola/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Imported from Wolfi `zola` (0.22.1, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/zola" "$OUTPUT_DIR/usr/bin/"


### PR DESCRIPTION
Second batch from **`pkgmgr import-wolfi`** — this one exercises the new **compiled-language templates** (go + rust), where the first batch was all C-family (autotools/cmake/meson). Chosen as the highest-star clean single-binary tools in Wolfi that Minimal doesn't already ship (the giants — ollama/zed/influxdb/teleport — are CGO/GPU/GUI builds deliberately deferred).

| package | upstream | build | runtime_deps (from ELF `DT_NEEDED`) |
|---|---|---|---|
| lazygit 0.63.0 | jesseduffield/lazygit | go | glibc |
| act 0.2.89 | nektos/act | go | glibc |
| mkcert 1.4.4 | FiloSottile/mkcert | go | glibc |
| ruff 0.15.20 | astral-sh/ruff | rust | glibc, gcc[libgcc] |
| zola 0.22.1 | getzola/zola | rust | glibc, gcc[libgcc] |
| xh 0.26.1 | ducaale/xh | rust | glibc, gcc[libgcc] |

### How they were produced
- **go** builds follow the crane convention: `base`/`go`/`toolchain` build_deps, `glibc` runtime, a `needs = { dns, internet }` block for module downloads, and the version stamped through `build_args { include version }` → `MINIMAL_ARG_VERSION` in the ldflags.
- **rust** builds follow the ripgrep convention: `cargo build --release` with reproducible `RUSTFLAGS` + `CARGO_INCREMENTAL=0`, `glibc` + the `gcc[libgcc]` runtime subset.
- **Sources mirrored** to `gs://minimal-staging-archives/<owner>/<repo>/<tag>.tar.gz` (reproducible, sha256-pinned), referenced via `gs://` URLs.
- **outputs** derived from the real install manifest; **runtime_deps** from every installed object's ELF `DT_NEEDED`.
- Each **builds clean** and passes **every `minimal check` checker** at **0 TODOs**.

### Reviewer notes (surfaced, not hidden)
- **ruff** pulls `tikv-jemalloc-sys`, whose `build.rs` compiles a bundled jemalloc via `./configure && make` — so the rust template includes `make` in build_deps (Wolfi's rust recipes declare `build-base`, which supplies it; it's inert for pure-rust crates). ruff is also a large build — it needs ~16 GiB to link; fine on the buildbot.
- **lazygit** stamps `-X main.commit=$(git rev-parse HEAD)` / `-X main.date=$(date …)` in its ldflags. There's no `.git` in an archive tarball, so those `$(…)` stamps are dropped (the `main.version` stamp is preserved); its ported test asserting the `wolfiRelease` buildSource stamp still passes.
- **rust completions**: several rust CLIs install shell completions in their Wolfi `runs:` block. The from-source build.sh ships only the binary for now (surfaced as a note during import); a `--from-build` refine would capture them once build.sh installs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package builds for several new command-line tools: `act`, `lazygit`, `mkcert`, `ruff`, `xh`, and `zola`.
  * These packages now install their binaries into standard locations and include version metadata.

* **Tests**
  * Added smoke tests to verify each tool starts correctly and responds to basic help/version commands.
  * Added functional checks for selected tools to confirm expected command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->