### PR TITLE
packages: wolfi import batch 5 — 10 CLI tools (dive, restic, gitleaks, sccache, …)

### DIFF
--- a/packages/croc/build.ncl
+++ b/packages/croc/build.ncl
@@ -1,0 +1,51 @@
+# Imported from Wolfi `croc` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "10.4.11" in
+{
+  name = "croc",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/schollz/croc/v%{version}.tar.gz",
+      sha256 = "4e45794c8ecb67a595a9d60958a80806bc50b9eca04796dc24d3295e0cc9be46",
+      extract = true,
+      strip_prefix = "croc-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    croc = { glob = "usr/bin/croc" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "schollz", repo = "croc" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "croc --version"],
+          ["/bin/bash", "-c", "croc --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/croc/build.sh
+++ b/packages/croc/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `croc` (10.4.11, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s" -o "$OUTPUT_DIR/usr/bin/croc" .

--- a/packages/dive/build.ncl
+++ b/packages/dive/build.ncl
@@ -1,0 +1,53 @@
+# Imported from Wolfi `dive` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.13.1" in
+{
+  name = "dive",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/wagoodman/dive/v%{version}.tar.gz",
+      sha256 = "2a9666e9c3fddd5e2e5bad81dccda520b8102e7cea34e2888f264b4eb0506852",
+      extract = true,
+      strip_prefix = "dive-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    dive = { glob = "usr/bin/dive" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "wagoodman", repo = "dive" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "dive --version\ndive --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/dive/build.sh
+++ b/packages/dive/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `dive` (0.13.1, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=v${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/dive" .

--- a/packages/dua/build.ncl
+++ b/packages/dua/build.ncl
@@ -1,0 +1,53 @@
+# Imported from Wolfi `dua` by `pkgmgr import-wolfi` (rust build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "2.37.1" in
+{
+  name = "dua",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/Byron/dua-cli/v%{version}.tar.gz",
+      sha256 = "309194f35a6cabe8a91046641680862cbe1e1379f55c88c94337b541ce987969",
+      extract = true,
+      strip_prefix = "dua-cli-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    dua = { glob = "usr/bin/dua" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "Byron", repo = "dua-cli" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "dua -V\ndua --version\ndua --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/dua/build.sh
+++ b/packages/dua/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Imported from Wolfi `dua` (2.37.1, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release --no-default-features --features tui-crossplatform
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/dua" "$OUTPUT_DIR/usr/bin/"

--- a/packages/esbuild/build.ncl
+++ b/packages/esbuild/build.ncl
@@ -1,0 +1,53 @@
+# Imported from Wolfi `esbuild` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.28.1" in
+{
+  name = "esbuild",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/evanw/esbuild/v%{version}.tar.gz",
+      sha256 = "65c756fa87d43178ac4a5242454c2bd0fde325f8ecf77997f8fa4b88f94d5cd2",
+      extract = true,
+      strip_prefix = "esbuild-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    esbuild = { glob = "usr/bin/esbuild" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "evanw", repo = "esbuild" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "esbuild --version"],
+          ["/bin/bash", "-c", "esbuild --help"],
+          ["/bin/bash", "-c", "set -euo pipefail\n\n# Create a JS file with some content that can be minified\necho 'const   x   =   1;   console.log(  x  )' > /tmp/minify-input.js\nesbuild /tmp/minify-input.js --minify --outfile=/tmp/minify-output.js\n\n# Verify the minified output is smaller than the input\ninput_size=$(wc -c < /tmp/minify-input.js)\noutput_size=$(wc -c < /tmp/minify-output.js)\nif [ \"$output_size\" -ge \"$input_size\" ]; then\n  echo \"FAIL: Minified output ($output_size bytes) should be smaller than input ($input_size bytes)\"\n  exit 1\nfi\necho \"SUCCESS: Minified from $input_size to $output_size bytes\""],
+          ["/bin/bash", "-c", "set -euo pipefail\n\n# Create a TypeScript file with type annotations\necho 'const x: number = 1; console.log(x)' > /tmp/input.ts\nesbuild /tmp/input.ts --outfile=/tmp/ts-output.js\n\n# Verify the output contains the JS code without type annotations\ngrep -F 'console.log' /tmp/ts-output.js\n\n# Verify type annotation was stripped\nif grep -F ': number' /tmp/ts-output.js; then\n  echo \"FAIL: TypeScript type annotation was not stripped\"\n  exit 1\nfi\necho \"SUCCESS: TypeScript transformed to JavaScript\""],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/esbuild/build.sh
+++ b/packages/esbuild/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `esbuild` (0.28.1, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s" -o "$OUTPUT_DIR/usr/bin/esbuild" ./cmd/esbuild

--- a/packages/gitleaks/build.ncl
+++ b/packages/gitleaks/build.ncl
@@ -1,0 +1,57 @@
+# Imported from Wolfi `gitleaks` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "8.30.1" in
+{
+  name = "gitleaks",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/gitleaks/gitleaks/v%{version}.tar.gz",
+      sha256 = "e90fb266d75837e75894c778bf594ab8e2787f12dce5a62651f21b893eaf9abb",
+      extract = true,
+      strip_prefix = "gitleaks-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    gitleaks = { glob = "usr/bin/gitleaks" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "gitleaks", repo = "gitleaks" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "gitleaks --help"],
+          ["/bin/bash", "-c", "set -euo pipefail\n# Test secret detection via stdin\necho 'api_key = \"sk_live_abcdef123456\"' | gitleaks detect --source - --no-git && EXIT_CODE=0 || EXIT_CODE=$?\nif [ \"$EXIT_CODE\" != \"1\" ]; then\n  echo \"ERROR: Expected gitleaks to detect secret in stdin and exit with code 1\"\n  exit 1\nfi\n\n# Test with multiple secrets via stdin\ncat << 'EOF' | gitleaks detect --source - --no-git && EXIT_CODE=0 || EXIT_CODE=$?\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\ngithub_token = ghp_wWPw5k4aXcaajCqbDsLRnJZZzVLgLO0M\nEOF\nif [ \"$EXIT_CODE\" != \"1\" ]; then\n  echo \"ERROR: Expected gitleaks to detect secrets in stdin\"\n  exit 1\nfi"],
+          ["/bin/bash", "-c", "# Create custom config\ncat > test-config.toml << 'EOF'\ntitle = \"test config\"\n\n[[rules]]\nid = \"test-rule\"\ndescription = \"Test rule for API keys\"\nregex = '''test_api_key\\s*=\\s*['\"]?([A-Za-z0-9]{32})['\"]?'''\nkeywords = [\"test_api_key\"]\nEOF\n\n# Create file with custom secret pattern\necho 'test_api_key = \"abcdef1234567890abcdef1234567890\"' > test_secret.txt\n\n# Test with custom config\ngitleaks detect --source test_secret.txt --config test-config.toml --no-git --exit-code 1 || EXIT_CODE=$?\nif [ \"$EXIT_CODE\" != \"1\" ]; then\n  echo \"ERROR: Custom rule should have detected the secret\"\n  exit 1\nfi\n\nrm -f test-config.toml test_secret.txt"],
+          ["/bin/bash", "-c", "# Create file with secret\necho 'api_key = \"AKIAIOSFODNN7EXAMPLE\" # gitleaks:allow' > allowed_secret.txt\n\n# This should pass because of the gitleaks:allow comment\ngitleaks detect --source allowed_secret.txt --no-git\n\n# Create .gitleaksignore file\necho 'allowed_secret2.txt' > .gitleaksignore\necho 'aws_key = \"AKIAIOSFODNN7EXAMPLE\"' > allowed_secret2.txt\n\n# This should pass because file is in .gitleaksignore\ngitleaks detect --source . --no-git\n\nrm -f allowed_secret.txt allowed_secret2.txt .gitleaksignore"],
+          ["/bin/bash", "-c", "# Create initial scan with secrets\necho 'token = \"ghp_1234567890abcdef\"' > baseline_test.txt\ngitleaks detect --source baseline_test.txt --no-git --report-path baseline.json --report-format json --exit-code 1 && EXIT_CODE=0 || EXIT_CODE=$?\nif [ \"$EXIT_CODE\" != \"1\" ]; then\n  echo \"ERROR: Expected gitleaks to exit 1 when leaks found\"\n  exit 1\nfi\n\n# Using baseline should not report the same findings\ngitleaks detect --source baseline_test.txt --no-git --baseline-path baseline.json\n\nrm -f baseline_test.txt baseline.json"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/gitleaks/build.sh
+++ b/packages/gitleaks/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `gitleaks` (8.30.1, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s -X github.com/gitleaks/gitleaks/v8/cmd.Version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/gitleaks" .

--- a/packages/gitleaks/build.sh
+++ b/packages/gitleaks/build.sh
@@ -3,4 +3,7 @@
 set -eu
 export GOROOT=/usr/go
 mkdir -p "$OUTPUT_DIR/usr/bin"
-go build -trimpath -ldflags "-buildid= -w -s -X github.com/gitleaks/gitleaks/v8/cmd.Version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/gitleaks" .
+# Version var lives in the `version` package and the module path kept the
+# original `zricethezav` org (per upstream .goreleaser.yml) despite the GitHub
+# org rename to gitleaks/gitleaks — a wrong path is silently ignored by the linker.
+go build -trimpath -ldflags "-buildid= -w -s -X github.com/zricethezav/gitleaks/v8/version.Version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/gitleaks" .

--- a/packages/lazydocker/build.ncl
+++ b/packages/lazydocker/build.ncl
@@ -1,0 +1,54 @@
+# Imported from Wolfi `lazydocker` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.25.2" in
+{
+  name = "lazydocker",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/jesseduffield/lazydocker/v%{version}.tar.gz",
+      sha256 = "405071220e5be9aa061c65d290e0347143b73ae0a3cc01df164f0105de2b53c4",
+      extract = true,
+      strip_prefix = "lazydocker-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    lazydocker = { glob = "usr/bin/lazydocker" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "jesseduffield", repo = "lazydocker" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "lazydocker --help"],
+          ["/bin/bash", "-c", "lazydocker --version"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lazydocker/build.sh
+++ b/packages/lazydocker/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `lazydocker` (0.25.2, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION} -X main.buildSource=wolfiRelease" -o "$OUTPUT_DIR/usr/bin/lazydocker" .

--- a/packages/lazydocker/build.sh
+++ b/packages/lazydocker/build.sh
@@ -3,4 +3,4 @@
 set -eu
 export GOROOT=/usr/go
 mkdir -p "$OUTPUT_DIR/usr/bin"
-go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION} -X main.buildSource=wolfiRelease" -o "$OUTPUT_DIR/usr/bin/lazydocker" .
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/lazydocker" .

--- a/packages/restic/build.ncl
+++ b/packages/restic/build.ncl
@@ -1,0 +1,54 @@
+# Imported from Wolfi `restic` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.19.1" in
+{
+  name = "restic",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/restic/restic/v%{version}.tar.gz",
+      sha256 = "bb9b1a19040744d26d8a79be029d4e6b189c45ccc9d8831d7fe367d3c33df725",
+      extract = true,
+      strip_prefix = "restic-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    restic = { glob = "usr/bin/restic" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "restic", repo = "restic" },
+      license_spdx = "BSD-2-Clause",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "restic --version"],
+          ["/bin/bash", "-c", "restic --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/restic/build.ncl
+++ b/packages/restic/build.ncl
@@ -46,8 +46,8 @@ let version = "0.19.1" in
         test_deps = [base],
         cmds = [
           # Smoke test ported from the Wolfi recipe's test block.
-          ["/bin/bash", "-c", "restic --version"],
-          ["/bin/bash", "-c", "restic --help"],
+          ["/bin/bash", "-c", "restic --version 2>/dev/null || restic version"],
+          ["/bin/bash", "-c", "restic --help 2>/dev/null || restic help"],
         ],
       } | Test,
   },

--- a/packages/restic/build.sh
+++ b/packages/restic/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `restic` (0.19.1, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/restic" ./cmd/restic

--- a/packages/sccache/build.ncl
+++ b/packages/sccache/build.ncl
@@ -1,0 +1,59 @@
+# Imported from Wolfi `sccache` by `pkgmgr import-wolfi` (rust build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let openssl = import "../openssl/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "0.16.0" in
+{
+  name = "sccache",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/mozilla/sccache/v%{version}.tar.gz",
+      sha256 = "917fd4d7e584c23dd3cf9ca2f394c2ca03c57c73e2d6079770f07d9008176afe",
+      extract = true,
+      strip_prefix = "sccache-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+    openssl,
+    pkgconf,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    sccache = { glob = "usr/bin/sccache" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"], openssl],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "mozilla", repo = "sccache" },
+      license_spdx = "Apache-2.0",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "sccache --version\nsccache --help"],
+          ["/bin/bash", "-c", "set -euo pipefail\n\n# Start the sccache server\nsccache --start-server\n\n# Verify server is running by showing stats\nsccache --show-stats\n\n# Stop the server\nsccache --stop-server"],
+          ["/bin/bash", "-c", "set -euo pipefail\n\n# Start a fresh server\nsccache --start-server\n\n# Show stats and verify output contains expected fields\nstats_output=$(sccache --show-stats)\necho \"$stats_output\" | grep -iF \"cache\"\n\n# Clean up\nsccache --stop-server"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/sccache/build.sh
+++ b/packages/sccache/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Imported from Wolfi `sccache` (0.16.0, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/sccache" "$OUTPUT_DIR/usr/bin/"

--- a/packages/sops/build.ncl
+++ b/packages/sops/build.ncl
@@ -1,0 +1,50 @@
+# Imported from Wolfi `sops` by `pkgmgr import-wolfi` (go build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "3.13.2" in
+{
+  name = "sops",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/getsops/sops/v%{version}.tar.gz",
+      sha256 = "79560b53814e20031d094a293d6c169314eaaf97efd6e95a6d765e61e881db2c",
+      extract = true,
+      strip_prefix = "sops-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    sops = { glob = "usr/bin/sops" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "getsops", repo = "sops" },
+      license_spdx = "MPL-2.0",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "sops --version\nsops --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/sops/build.sh
+++ b/packages/sops/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `sops` (3.13.2, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s" -o "$OUTPUT_DIR/usr/bin/sops" ./cmd/sops

--- a/packages/tealdeer/build.ncl
+++ b/packages/tealdeer/build.ncl
@@ -1,0 +1,54 @@
+# Imported from Wolfi `tealdeer` by `pkgmgr import-wolfi` (rust build),
+# with outputs + runtime_deps refined from a verified `minimal package` build.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "1.8.1" in
+{
+  name = "tealdeer",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/tealdeer-rs/tealdeer/v%{version}.tar.gz",
+      sha256 = "8b9ea7ef8dd594d6fb8b452733b0c883a68153cec266b23564ce185bdf22fcfa",
+      extract = true,
+      strip_prefix = "tealdeer-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    tldr = { glob = "usr/bin/tldr" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "tealdeer-rs", repo = "tealdeer" },
+      license_spdx = "Apache-2.0",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Smoke test ported from the Wolfi recipe's test block.
+          ["/bin/bash", "-c", "tldr --version"],
+          ["/bin/bash", "-c", "tldr --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/tealdeer/build.ncl
+++ b/packages/tealdeer/build.ncl
@@ -37,7 +37,9 @@ let version = "1.8.1" in
     {
       upstream_version = version,
       source_provenance = { category = 'GithubRepo, owner = "tealdeer-rs", repo = "tealdeer" },
-      license_spdx = "Apache-2.0",
+      # Dual-licensed: v1.8.1 Cargo.toml declares "MIT OR Apache-2.0" and ships
+      # both LICENSE-MIT and LICENSE-APACHE.
+      license_spdx = "MIT OR Apache-2.0",
     } | Attrs,
   tests = {
     smoke =

--- a/packages/tealdeer/build.sh
+++ b/packages/tealdeer/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Imported from Wolfi `tealdeer` (1.8.1, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/tldr" "$OUTPUT_DIR/usr/bin/"


### PR DESCRIPTION
Fifth batch from **`pkgmgr import-wolfi`** — high-star single-binary **CLI tools** (go + rust). Chosen from a stars survey; all pure-go / pure-rust (deps bundled by the module/crate tree).

### What's here (10 packages, all build + pass every `minimal check` at 0 TODOs)

| pkg | ★ | lang | what |
|---|---|---|---|
| dive | 54k | go | docker image layer explorer |
| lazydocker | 51k | go | docker TUI |
| esbuild | 39k | go | JS/TS bundler |
| croc | 35k | go | secure file transfer |
| restic | 34k | go | encrypted backups |
| gitleaks | 28k | go | secret scanner |
| sops | 22k | go | encrypted secrets |
| sccache | 7.4k | rust | shared compiler cache (links openssl) |
| tealdeer | 6.4k | rust | fast `tldr` client |
| dua | 6k | rust | disk-usage analyzer |

### How they're produced
- **go**: `go build -trimpath` (built straight into `$OUTPUT_DIR/usr/bin` — avoids a `<name>/` package-dir clash), `glibc` runtime, `needs = { dns, internet }`, version stamped via `MINIMAL_ARG_VERSION`.
- **rust**: `cargo build --release` with reproducible `RUSTFLAGS`; sccache's `openssl-sys` crate pulls `openssl` + `pkgconf` build-deps and `openssl` runtime (resolved from the ELF's `libssl` linkage).
- Sources mirrored to `gs://minimal-staging-archives/<owner>/<repo>/<tag>.tar.gz`.

### Reviewer notes
- **tealdeer** ships the `tldr` binary (crate name ≠ binary name).
- All independent of batches #367–#370 — go/rust bundle their deps, so at the Minimal level these only need glibc (+ gcc[libgcc], + openssl for sccache), all already in base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added packaging support for several developer tools, including `croc`, `dive`, `dua`, `esbuild`, `gitleaks`, `lazydocker`, `restic`, `sccache`, `sops`, and `tealdeer`.
  * Each package now includes a build recipe, binary output, runtime dependency setup, and basic smoke tests to verify the tool launches and reports its help/version information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->