### PR TITLE
packages: add ddgr (DuckDuckGo terminal search) — resolves #358

### DIFF
--- a/packages/ddgr/build.ncl
+++ b/packages/ddgr/build.ncl
@@ -1,0 +1,47 @@
+# Bootstrapped from https://github.com/jarun/ddgr by `pkgmgr bootstrap`
+# (python), then finalized: outputs read from a verified `minimal package` build.
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let python = import "../python/build.ncl" in
+let setuptools = import "../setuptools/build.ncl" in
+let version = "2.2" in
+{
+  name = "ddgr",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/jarun/ddgr/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "a858e0477ea339b64ae0427743ebe798a577c4d942737d8b3460bce52ac52524",
+      extract = true,
+      strip_prefix = "ddgr-%{version}",
+    } | Source,
+    base,
+    setuptools,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    ddgr = { glob = "usr/bin/ddgr" } | OutputBin,
+    # ddgr ships a single top-level module (setup.py `py_modules=['ddgr']`).
+    python_site_package = { glob = "usr/lib/python*/site-packages/ddgr.py" } | OutputData,
+    python_dist_info = { glob = "usr/lib/python*/site-packages/ddgr-*.dist-info/**" } | OutputData,
+  },
+  runtime_deps = [
+    python,
+  ],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "jarun", repo = "ddgr" },
+      license_spdx = "GPL-3.0-or-later",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "ddgr --version"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ddgr/build.sh
+++ b/packages/ddgr/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Auto-bootstrapped by `pkgmgr bootstrap` (ddgr 2.2, python).
+set -eu
+
+# Build a wheel from the source tree with the in-environment setuptools
+# backend (no build isolation, no network), then install it into $OUTPUT_DIR.
+# `--no-deps` on both steps: Minimal provides runtime deps as its own packages,
+# so pip must NOT resolve them from the (empty) index.
+pip3 wheel -w dist --no-build-isolation --no-deps --no-cache-dir "$(pwd)"
+pip3 install --no-index --find-links dist --no-deps --no-user --root "$OUTPUT_DIR" ddgr


### PR DESCRIPTION
Adds **ddgr** (jarun/ddgr) — DuckDuckGo search from the terminal. Resolves the package request in #358.

This one exercises a different onboarding path than the recent Wolfi-import batches: ddgr **isn't in Wolfi**, so it was onboarded straight from GitHub with **`pkgmgr bootstrap https://github.com/jarun/ddgr`** (the github-onboard path), then finalized by hand.

- **Pure-python, stdlib-only** — no runtime deps beyond `python`.
- Single top-level module (`ddgr.py`) + the `ddgr` console script.
- Builds via `pip3 wheel` + `pip3 install --root`; passes **every `minimal check` checker at 0 TODOs**.

The bootstrap tooling learned a python template from this (it previously detected python but rendered an all-TODO scaffold) — so future `pkgmgr bootstrap <github-url>` runs on python repos produce a real starting point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing the `ddgr` package from source.
  * Included a version check smoke test to verify the command runs correctly after install.
  * Improved packaging so the tool and its Python components are included in the final output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->