### PR TITLE
git: 2.55.0 + Rust toolchain (libgitcore.a)

### DIFF
--- a/packages/git/build.ncl
+++ b/packages/git/build.ncl
@@ -7,18 +7,19 @@ let openssl = import "../openssl/build.ncl" in
 let pcre2 = import "../pcre2/build.ncl" in
 let python = import "../python/build.ncl" in
 let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "2.54.0" in
+let version = "2.55.0" in
 {
   name = "git",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.xz
+      # https://www.kernel.org/pub/software/scm/git/git-2.55.0.tar.xz
       url = "gs://minimal-staging-archives/git-%{version}.tar.xz",
-      sha256 = "f689162364c10de79ef89aa8dbf48731eb057e34edbbd20aca510ce0154681a3",
+      sha256 = "457fdb04dc8728e007d4688695e6912e6f680727920f2a40bf11eacc17505357",
       extract = true,
       strip_prefix = "git-%{version}",
     } | Source,
@@ -26,6 +27,8 @@ let version = "2.54.0" in
     gettext,
     make,
     python,
+    # git 2.55 builds a Rust component (libgitcore.a) via cargo; supplies the toolchain.
+    rust,
     toolchain,
   ],
   runtime_deps = [

--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -9,6 +9,9 @@ esac
 export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
 export LDFLAGS="-Wl,--build-id=none"
 export CXXFLAGS="${CFLAGS}"
+# git 2.55+ builds a Rust component (libgitcore.a) via cargo; remap paths so the
+# static lib is reproducible (matches the C -ffile-prefix-map above).
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
 
 ./configure --prefix=/usr                   \
             --with-gitconfig=/etc/gitconfig \


### PR DESCRIPTION
## What
Bumps `git` 2.54.0 → **2.55.0** and adds the **Rust toolchain** as a build dep.

git 2.55.0's Makefile now compiles a Rust component (`target/release/libgitcore.a` via `cargo`) as part of the default build — 2.54.0 didn't. Without a cargo on PATH the build FTBFS with `cargo: command not found` (this is why git was dropped from the #375 auto-bundle → tracked as #376).

## Change
- `build.ncl`: add `rust` to `build_deps` (same toolchain ~dozens of pure-Rust packages already use).
- `build.sh`: `export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"` so the Rust static lib is reproducible, mirroring the existing C `-ffile-prefix-map`.

## Build-proven (clean-main worktree, `minimal package --rebuild git`)
- ✅ **EXIT 0** — was `cargo: command not found` / `make: *** [libgitcore.a] Error 127`.
- ✅ **Rust component linked in** — `strings usr/bin/git` contains `rustc version 1.95.0 (…) (built from a source tarball)`; libgitcore compiled with our rust toolchain.
- ✅ **Reproducible** — two independent `--rebuild` passes produced a **byte-identical** `git` (sha256 `509eb189…`).
- ✅ **No host-path leak** — no `/Users/bryan` in the binary; the RUSTFLAGS remap works.

## Note for reviewers
This makes git **build-depend on the whole Rust toolchain** — a real supply-chain expansion, which is why it's a deliberate standalone PR rather than an auto-bundle bump. That's the intended trade (git upstream is migrating to Rust).

Closes #376.