### PR TITLE
cf: mark closed-source and record the binary origin

### DIFF
--- a/packages/cf/build.ncl
+++ b/packages/cf/build.ncl
@@ -46,6 +46,8 @@ let version = "0.1.0" in
     {
       upstream_version = version,
       license_spdx = "MIT",
+      closed_source = true,
+      binary_from = "https://registry.npmjs.org/cf/-/cf-%{version}.tgz",
     } | Attrs,
 
   tests = {


### PR DESCRIPTION
Follow-up to @twitchyliquid64's review comment on #362 (merged before it was actioned): `packages/cf/build.ncl` now sets

- `closed_source = true`
- `binary_from = "https://registry.npmjs.org/cf/-/cf-%{version}.tgz"`

matching the requested values exactly and the `claude-code` package's precedent for closed-source, registry-distributed binaries. Two-line attrs addition; no build/spec behavior changes. `min check` couldn't run in this sandbox (missing socat) — relying on CI for schema validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to better align with Cloudflare distribution, including a pinned binary source for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->