### PR TITLE
Update tree-sitter to 0.25.10

### DIFF
--- a/packages/tree-sitter/build.ncl
+++ b/packages/tree-sitter/build.ncl
@@ -5,14 +5,14 @@ let glibc = import "../glibc/build.ncl" in
 let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "0.24.7" in
+let version = "0.26.7" in
 {
   name = "tree-sitter",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "7cbc13c974d6abe978cafc9da12d1e79e07e365c42af75e43ec1b5cdc03ed447",
+      sha256 = "4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84",
       extract = true,
       strip_prefix = "tree-sitter-%{version}",
     } | Source,

--- a/packages/tree-sitter/build.ncl
+++ b/packages/tree-sitter/build.ncl
@@ -5,14 +5,14 @@ let glibc = import "../glibc/build.ncl" in
 let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "0.26.7" in
+let version = "0.25.10" in
 {
   name = "tree-sitter",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84",
+      sha256 = "ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c",
       extract = true,
       strip_prefix = "tree-sitter-%{version}",
     } | Source,


### PR DESCRIPTION
## Summary

Bumps the `tree-sitter` package 0.24.7 → 0.25.10 (version + sha256 only — the Makefile-based build recipe is unchanged).

## Motivation

The neovim package stacked on this PR ([#382](https://github.com/gominimal/pkgs/pull/382)) requires it: neovim 0.12 declares `find_package(Treesitter 0.25.0 REQUIRED)` and calls `ts_parser_parse_with_options`, which was added in tree-sitter 0.25.

## Why 0.25.x and not 0.26.x

The first revision of this PR bumped to 0.26.7 and the `minimal build` check failed: tree-sitter 0.26 removed `ts_language_version` (renamed `ts_language_abi_version`), which emacs 30.2's `treesit.c` still calls, breaking the emacs dependent rebuild (`treesit.c:749: error: implicit declaration of function 'ts_language_version'`). 0.25.10 carries both the old symbol and the 0.25 API neovim needs.

## Blast radius

`emacs` and `emacs-config-dev1` depend on `tree-sitter` and rebuild against the new soname.

## Verification

- Tarball sha256 verified against upstream `tree-sitter/tree-sitter` v0.25.10.
- `minimal package tree-sitter` builds clean.
- `minimal package emacs` rebuilt clean against 0.25.10 (this is what failed with 0.26.7).
- `minimal package neovim` (from the stacked branch) builds clean against 0.25.10.
- `minimal check --packages tree-sitter emacs neovim` passes all checkers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)