### PR TITLE
Add neovim 0.12.4 and its dependency tree (11 packages)

### DIFF
--- a/packages/lpeg/build.ncl
+++ b/packages/lpeg/build.ncl
@@ -1,0 +1,50 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let luajit = import "../luajit/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# PEG pattern-matching library for Lua, built as a Lua 5.1 C module against
+# the luajit headers. Canonical source is Roberto Ierusalimschy's PUC-Rio
+# page (not a GitHub or GNU project, so source_provenance is omitted).
+let version = "1.1.0" in
+{
+  name = "lpeg",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-%{version}.tar.gz",
+      sha256 = "4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a",
+      extract = true,
+      strip_prefix = "lpeg-%{version}",
+    } | Source,
+    base,
+    luajit,
+    make,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    module = { glob = "usr/lib/lua/5.1/*.so" } | OutputLib,
+    data = { glob = "usr/share/lua/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base, luajit],
+        cmds = [
+          ["/bin/bash", "-c", "luajit -e 'assert(require(\"lpeg\").match ~= nil)'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lpeg/build.sh
+++ b/packages/lpeg/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md). lpeg's makefile composes CFLAGS
+# itself, so the extra flags go in via COPT and the linker flags via DLLFLAGS.
+COPT="-O2 -DNDEBUG -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+make lpeg.so LUADIR=/usr/include/luajit-2.1 COPT="$COPT" \
+  DLLFLAGS="-shared -fPIC -Wl,--build-id=none"
+
+install -D -m 755 lpeg.so "$OUTPUT_DIR/usr/lib/lua/5.1/lpeg.so"
+install -D -m 644 re.lua "$OUTPUT_DIR/usr/share/lua/5.1/re.lua"

--- a/packages/luajit/build.ncl
+++ b/packages/luajit/build.ncl
@@ -1,0 +1,60 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# LuaJIT has no tagged releases (v2.1 is a rolling branch); this is the commit
+# neovim 0.12.4 pins in its cmake.deps. The upstream version is
+# 2.1.<timestamp> where the timestamp comes from the tarball's .relver file.
+let commit = "fbb36bb6bfa88716a47c58bcf9ce9f2ef752abac" in
+let version = "2.1.1774638290" in
+{
+  name = "luajit",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/LuaJIT/LuaJIT/archive/%{commit}.tar.gz",
+      sha256 = "e60cd2f3057aa39d33d1c895a20087ab54494d9a1ca45aa488ff0378af42df48",
+      extract = true,
+      strip_prefix = "LuaJIT-%{commit}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    luajit = { glob = "usr/bin/luajit" } | OutputBin,
+    luajit_versioned = { glob = "usr/bin/luajit-*" } | OutputBin,
+    libs = { glob = "usr/lib/libluajit*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfigs = { glob = "usr/lib/pkgconfig/**" } | OutputData,
+    data = { glob = "usr/share/**/*" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "LuaJIT",
+        repo = "LuaJIT",
+      },
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "luajit -e 'print(jit.version)'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/luajit/build.sh
+++ b/packages/luajit/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="-O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export LDFLAGS="-Wl,--build-id=none"
+
+# amalg is the upstream-recommended release build (single amalgamated
+# translation unit, better optimization).
+make -j"$(nproc)" amalg PREFIX=/usr \
+  TARGET_CFLAGS="$CFLAGS" TARGET_LDFLAGS="$LDFLAGS"
+make install PREFIX=/usr DESTDIR="$OUTPUT_DIR"

--- a/packages/luv/build.ncl
+++ b/packages/luv/build.ncl
@@ -1,0 +1,59 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let ninja = import "../ninja/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let libuv = import "../libuv/build.ncl" in
+let luajit = import "../luajit/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.52.1-0" in
+# Header-only Lua compatibility shims vendored by luv as a git submodule,
+# which GitHub archive tarballs don't include — fetched separately.
+let compat53_version = "0.13" in
+{
+  name = "luv",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/luvit/luv/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "e8b8774b31d24be4fcf2b021b90599ecccc8e476c61efcc59c3c10cab813a885",
+      extract = true,
+      strip_prefix = "luv-%{version}",
+    } | Source,
+    {
+      url = "https://github.com/lunarmodules/lua-compat-5.3/archive/refs/tags/v%{compat53_version}.tar.gz",
+      sha256 = "f5dc30e7b1fda856ee4d392be457642c1f0c259264a9b9bfbcb680302ce88fc2",
+      extract = true,
+    } | Source,
+    base,
+    cmake,
+    ninja,
+    pkgconf,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+    libuv,
+    luajit,
+  ],
+  cmd = "./build.sh",
+  build_args = {
+    include compat53_version,
+  },
+  outputs = {
+    libs = { glob = "usr/lib/libluv.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "luvit",
+        repo = "luv",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/luv/build.sh
+++ b/packages/luv/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+
+# Same configuration neovim's cmake.deps uses, except built as a shared
+# library against the registry's shared libuv and luajit.
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DLUA_BUILD_TYPE=System \
+  -DWITH_LUA_ENGINE=LuaJIT \
+  -DWITH_SHARED_LIBUV=ON \
+  -DBUILD_MODULE=OFF \
+  -DBUILD_SHARED_LIBS=ON \
+  -DLUA_COMPAT53_DIR="$(pwd)/lua-compat-5.3-$MINIMAL_ARG_COMPAT53_VERSION"
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build

--- a/packages/neovim/build.ncl
+++ b/packages/neovim/build.ncl
@@ -1,0 +1,89 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let gettext = import "../gettext/build.ncl" in
+let make = import "../make/build.ncl" in
+let ninja = import "../ninja/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let libuv = import "../libuv/build.ncl" in
+let lpeg = import "../lpeg/build.ncl" in
+let luajit = import "../luajit/build.ncl" in
+let luv = import "../luv/build.ncl" in
+let tree-sitter = import "../tree-sitter/build.ncl" in
+let tree-sitter-c = import "../tree-sitter-c/build.ncl" in
+let tree-sitter-lua = import "../tree-sitter-lua/build.ncl" in
+let tree-sitter-markdown = import "../tree-sitter-markdown/build.ncl" in
+let tree-sitter-query = import "../tree-sitter-query/build.ncl" in
+let tree-sitter-vim = import "../tree-sitter-vim/build.ncl" in
+let tree-sitter-vimdoc = import "../tree-sitter-vimdoc/build.ncl" in
+let unibilium = import "../unibilium/build.ncl" in
+let utf8proc = import "../utf8proc/build.ncl" in
+
+let version = "0.12.4" in
+{
+  name = "neovim",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/neovim/neovim/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "2727da95d2b8b809bc7c71e085452e47dfe1d8aa7cfaa15c68004e23f6f0a6dd",
+      extract = true,
+      strip_prefix = "neovim-%{version}",
+    } | Source,
+    base,
+    cmake,
+    gettext, # msgfmt, for building the locale files
+    make, # cmake/Deps.cmake hard-requires GNU Make even for non-bundled builds
+    ninja,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    nvim = { glob = "usr/bin/nvim" } | OutputBin,
+    data = { glob = "usr/share/**/*" } | OutputData,
+  },
+  runtime_deps = [
+    glibc,
+    libuv,
+    lpeg,
+    luajit,
+    luv,
+    tree-sitter,
+    unibilium,
+    utf8proc,
+    # The treesitter grammars upstream bundles via cmake.deps, packaged
+    # separately here; nvim loads them from usr/lib/nvim/parser/ at runtime.
+    tree-sitter-c,
+    tree-sitter-lua,
+    tree-sitter-markdown,
+    tree-sitter-query,
+    tree-sitter-vim,
+    tree-sitter-vimdoc,
+  ],
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0 AND Vim",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "neovim",
+        repo = "neovim",
+      },
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "nvim --version"],
+          # Boots the editor headless and exits — verifies the runtime dir
+          # (usr/share/nvim/runtime) is found relative to the binary.
+          ["/bin/bash", "-c", "nvim --headless +quit"],
+          # Verifies a packaged grammar loads from usr/lib/nvim/parser/.
+          ["/bin/bash", "-c", "nvim --headless \"+lua assert(vim.treesitter.language.add('c'))\" +quit"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+
+# All third-party deps (luajit, libuv, luv, lpeg, unibilium, utf8proc,
+# tree-sitter and the grammar parsers) come from the registry, so upstream's
+# cmake.deps download step is skipped entirely.
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build

--- a/packages/tree-sitter-c/build.ncl
+++ b/packages/tree-sitter-c/build.ncl
@@ -1,0 +1,37 @@
+let { Attrs, BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.24.1" in
+{
+  name = "tree-sitter-c",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48",
+      extract = true,
+      strip_prefix = "tree-sitter-c-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    parser = { glob = "usr/lib/nvim/parser/*.so" } | OutputLib,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "tree-sitter",
+        repo = "tree-sitter-c",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/tree-sitter-c/build.sh
+++ b/packages/tree-sitter-c/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+CFLAGS="${CFLAGS:-} -O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+# Same shape as neovim's bundled-parser recipe: all of src/ compiled into a
+# <lang>.so loadable from nvim's runtime 'parser/' directory.
+mkdir -p "$OUTPUT_DIR/usr/lib/nvim/parser"
+gcc $CFLAGS -std=c11 -fPIC -I src -shared src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/c.so"

--- a/packages/tree-sitter-lua/build.ncl
+++ b/packages/tree-sitter-lua/build.ncl
@@ -1,0 +1,37 @@
+let { Attrs, BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.5.0" in
+{
+  name = "tree-sitter-lua",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "cf01b93f4b61b96a6d27942cf28eeda4cbce7d503c3bef773a8930b3d778a2d9",
+      extract = true,
+      strip_prefix = "tree-sitter-lua-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    parser = { glob = "usr/lib/nvim/parser/*.so" } | OutputLib,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "tree-sitter-grammars",
+        repo = "tree-sitter-lua",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/tree-sitter-lua/build.sh
+++ b/packages/tree-sitter-lua/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+CFLAGS="${CFLAGS:-} -O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+# Same shape as neovim's bundled-parser recipe: all of src/ compiled into a
+# <lang>.so loadable from nvim's runtime 'parser/' directory.
+mkdir -p "$OUTPUT_DIR/usr/lib/nvim/parser"
+gcc $CFLAGS -std=c11 -fPIC -I src -shared src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/lua.so"

--- a/packages/tree-sitter-markdown/build.ncl
+++ b/packages/tree-sitter-markdown/build.ncl
@@ -1,0 +1,39 @@
+let { Attrs, BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# Ships two grammars from one repo: block-level (markdown.so) and
+# inline-level (markdown_inline.so). Neovim needs both.
+let version = "0.5.3" in
+{
+  name = "tree-sitter-markdown",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6",
+      extract = true,
+      strip_prefix = "tree-sitter-markdown-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    parsers = { glob = "usr/lib/nvim/parser/*.so" } | OutputLib,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "tree-sitter-grammars",
+        repo = "tree-sitter-markdown",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/tree-sitter-markdown/build.sh
+++ b/packages/tree-sitter-markdown/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+CFLAGS="${CFLAGS:-} -O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+# Same shape as neovim's bundled-parser recipe (MarkdownParserCMakeLists.txt):
+# the repo contains two grammars, both loadable from nvim's runtime 'parser/'
+# directory.
+mkdir -p "$OUTPUT_DIR/usr/lib/nvim/parser"
+gcc $CFLAGS -std=c11 -fPIC -I tree-sitter-markdown/src -shared \
+  tree-sitter-markdown/src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/markdown.so"
+gcc $CFLAGS -std=c11 -fPIC -I tree-sitter-markdown-inline/src -shared \
+  tree-sitter-markdown-inline/src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/markdown_inline.so"

--- a/packages/tree-sitter-query/build.ncl
+++ b/packages/tree-sitter-query/build.ncl
@@ -1,0 +1,37 @@
+let { Attrs, BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.8.0" in
+{
+  name = "tree-sitter-query",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-query/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d",
+      extract = true,
+      strip_prefix = "tree-sitter-query-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    parser = { glob = "usr/lib/nvim/parser/*.so" } | OutputLib,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "tree-sitter-grammars",
+        repo = "tree-sitter-query",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/tree-sitter-query/build.sh
+++ b/packages/tree-sitter-query/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+CFLAGS="${CFLAGS:-} -O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+# Same shape as neovim's bundled-parser recipe: all of src/ compiled into a
+# <lang>.so loadable from nvim's runtime 'parser/' directory.
+mkdir -p "$OUTPUT_DIR/usr/lib/nvim/parser"
+gcc $CFLAGS -std=c11 -fPIC -I src -shared src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/query.so"

--- a/packages/tree-sitter-vim/build.ncl
+++ b/packages/tree-sitter-vim/build.ncl
@@ -1,0 +1,37 @@
+let { Attrs, BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.8.1" in
+{
+  name = "tree-sitter-vim",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-vim/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "93cafb9a0269420362454ace725a118ff1c3e08dcdfdc228aa86334b54d53c2a",
+      extract = true,
+      strip_prefix = "tree-sitter-vim-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    parser = { glob = "usr/lib/nvim/parser/*.so" } | OutputLib,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "tree-sitter-grammars",
+        repo = "tree-sitter-vim",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/tree-sitter-vim/build.sh
+++ b/packages/tree-sitter-vim/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+CFLAGS="${CFLAGS:-} -O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+# Same shape as neovim's bundled-parser recipe: all of src/ compiled into a
+# <lang>.so loadable from nvim's runtime 'parser/' directory.
+mkdir -p "$OUTPUT_DIR/usr/lib/nvim/parser"
+gcc $CFLAGS -std=c11 -fPIC -I src -shared src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/vim.so"

--- a/packages/tree-sitter-vimdoc/build.ncl
+++ b/packages/tree-sitter-vimdoc/build.ncl
@@ -1,0 +1,37 @@
+let { Attrs, BuildSpec, Local, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "4.1.0" in
+{
+  name = "tree-sitter-vimdoc",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/neovim/tree-sitter-vimdoc/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "020e8f117f648c8697fca967995c342e92dbd81dab137a115cc7555207fbc84f",
+      extract = true,
+      strip_prefix = "tree-sitter-vimdoc-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    parser = { glob = "usr/lib/nvim/parser/*.so" } | OutputLib,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "neovim",
+        repo = "tree-sitter-vimdoc",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/tree-sitter-vimdoc/build.sh
+++ b/packages/tree-sitter-vimdoc/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+CFLAGS="${CFLAGS:-} -O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+# Same shape as neovim's bundled-parser recipe: all of src/ compiled into a
+# <lang>.so loadable from nvim's runtime 'parser/' directory.
+mkdir -p "$OUTPUT_DIR/usr/lib/nvim/parser"
+gcc $CFLAGS -std=c11 -fPIC -I src -shared src/*.c \
+  -Wl,--build-id=none -o "$OUTPUT_DIR/usr/lib/nvim/parser/vimdoc.so"

--- a/packages/tree-sitter/build.ncl
+++ b/packages/tree-sitter/build.ncl
@@ -5,14 +5,14 @@ let glibc = import "../glibc/build.ncl" in
 let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "0.24.7" in
+let version = "0.26.7" in
 {
   name = "tree-sitter",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "7cbc13c974d6abe978cafc9da12d1e79e07e365c42af75e43ec1b5cdc03ed447",
+      sha256 = "4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84",
       extract = true,
       strip_prefix = "tree-sitter-%{version}",
     } | Source,

--- a/packages/tree-sitter/build.ncl
+++ b/packages/tree-sitter/build.ncl
@@ -5,14 +5,14 @@ let glibc = import "../glibc/build.ncl" in
 let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "0.26.7" in
+let version = "0.25.10" in
 {
   name = "tree-sitter",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84",
+      sha256 = "ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c",
       extract = true,
       strip_prefix = "tree-sitter-%{version}",
     } | Source,

--- a/packages/unibilium/build.ncl
+++ b/packages/unibilium/build.ncl
@@ -1,0 +1,44 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let ninja = import "../ninja/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# Terminfo parsing library. Upstream (mauke/unibilium) is unmaintained; the
+# neovim fork is the actively maintained canonical source.
+let version = "2.1.2" in
+{
+  name = "unibilium",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/neovim/unibilium/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "370ecb07fbbc20d91d1b350c55f1c806b06bf86797e164081ccc977fc9b3af7a",
+      extract = true,
+      strip_prefix = "unibilium-%{version}",
+    } | Source,
+    base,
+    cmake,
+    ninja,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    libs = { glob = "usr/lib/libunibilium*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "LGPL-3.0-or-later",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "neovim",
+        repo = "unibilium",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/unibilium/build.sh
+++ b/packages/unibilium/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+
+# TERMINFO_DIRS is pinned: upstream's cmake probes ncurses*-config for the
+# default, which would silently vary with the build environment.
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=ON \
+  -DTERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build

--- a/packages/utf8proc/build.ncl
+++ b/packages/utf8proc/build.ncl
@@ -1,0 +1,44 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let ninja = import "../ninja/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "2.11.3" in
+{
+  name = "utf8proc",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/juliastrings/utf8proc/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "abfed50b6d4da51345713661370290f4f4747263ee73dc90356299dfc7990c78",
+      extract = true,
+      strip_prefix = "utf8proc-%{version}",
+    } | Source,
+    base,
+    cmake,
+    ninja,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    libs = { glob = "usr/lib/libutf8proc.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfigs = { glob = "usr/lib/pkgconfig/**" } | OutputData,
+    cmake_data = { glob = "usr/lib/cmake/**" } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "juliastrings",
+        repo = "utf8proc",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/utf8proc/build.sh
+++ b/packages/utf8proc/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=ON
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build


### PR DESCRIPTION
## Summary

Adds `neovim` 0.12.4 plus the 11 packages it needs, all built from source against registry deps — upstream's `cmake.deps` bundled-download flow is skipped entirely, so the neovim build needs no network access (`needs.internet` is not set anywhere).

**Stacked on [#381](https://github.com/gominimal/pkgs/pull/381)** (tree-sitter 0.25.10): neovim 0.12 declares `find_package(Treesitter 0.25.0 REQUIRED)`. GitHub will retarget this PR to `main` once #381 merges.

## New library packages

| Package | Version | Notes |
|---|---|---|
| `luajit` | 2.1.1774638290 | Commit-pinned — v2.1 is a rolling branch with no tagged releases; same commit neovim pins. Ships `luajit` bin, `libluajit-5.1`, headers. |
| `lpeg` | 1.1.0 | Lua 5.1 C module built against luajit headers, installed at `usr/lib/lua/5.1/lpeg.so` where neovim's `FindLpeg` looks. Canonical source is PUC-Rio (no `source_provenance`). |
| `luv` | 1.52.1-0 | Two sources: luv + `lua-compat-5.3` 0.13 (a submodule GitHub archives omit). Shared `libluv` against registry libuv/luajit. |
| `unibilium` | 2.1.2 | neovim's maintained fork (upstream mauke/unibilium is dead). `TERMINFO_DIRS` pinned explicitly — upstream cmake probes `ncurses*-config`, which would vary with the build env. |
| `utf8proc` | 2.11.3 | Plain cmake shared build. |

## New treesitter grammar packages

`tree-sitter-c` 0.24.1, `tree-sitter-lua` 0.5.0, `tree-sitter-vim` 0.8.1, `tree-sitter-vimdoc` 4.1.0, `tree-sitter-query` 0.8.0, `tree-sitter-markdown` 0.5.3 (ships both `markdown.so` and `markdown_inline.so`).

Each replicates upstream's bundled-parser recipe (all of `src/*.c` → `<lang>.so`) and installs to `usr/lib/nvim/parser/`, which is on nvim's default runtimepath. They're wired as `runtime_deps` of neovim.

## Provenance

All versions and sha256s match the pins in neovim 0.12.4's `cmake.deps/deps.txt`; every hash was independently re-downloaded and verified, and every GitHub repo checked for redirects (all canonical). Licenses read from the tarballs.

## Verification

- `minimal package` builds all 12 packages clean.
- `minimal check` passes every checker on all 12 (including built-output checks: bin enumeration, output types, runtime-dep completeness).
- Standalone tests pass in the sandbox: `nvim --version`, a headless boot (`nvim --headless +quit`, proving the runtime dir resolves), and `nvim --headless "+lua assert(vim.treesitter.language.add('c'))"` proving grammar packages load from `usr/lib/nvim/parser/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
