### PR TITLE
Bring OCaml into minimal: toolchain trio + dev stack + first libs

### DIFF
--- a/packages/csexp/build.ncl
+++ b/packages/csexp/build.ncl
@@ -1,0 +1,61 @@
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "1.5.2" in
+{
+  name = "csexp",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz
+      url = "gs://minimal-staging-archives/csexp-%{version}.tbz",
+      sha256 = "1a14dd04bb4379a41990248550628c77913a9c07f3c35c1370b6960e697787ff",
+      extract = false,
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  runtime_deps = [
+    ocaml,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    lib = { glob = "usr/lib/ocaml/csexp/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ocaml-dune",
+        repo = "csexp",
+      },
+      build_cost_multiple = 1,
+    } | Attrs,
+
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, dune, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "echo 'let () = print_string (Csexp.to_string (Csexp.Atom \"ok\"))' > t.ml && OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind ocamlopt -package csexp -linkpkg t.ml -o t && ./t | grep -q ok"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/csexp/build.sh
+++ b/packages/csexp/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+tar -xof "csexp-${MINIMAL_ARG_VERSION}.tbz"
+cd "csexp-${MINIMAL_ARG_VERSION}"
+
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+
+dune build -p csexp -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" csexp

--- a/packages/dune/build.ncl
+++ b/packages/dune/build.ncl
@@ -64,5 +64,15 @@ let version = "3.20.2" in
           ["/bin/bash", "-c", "/usr/bin/dune --version | grep -q '3.20.2'"],
         ],
       } | Test,
+    # The real proof dune works as a build tool: scaffold a tiny dune project,
+    # build it (resolving the compiler via OCAMLPATH), and run the output.
+    builds_a_project =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "mkdir -p proj && cd proj && printf '(lang dune 3.0)\\n' > dune-project && printf '(executable (name main))\\n' > dune && printf 'let () = print_string \"ok\"\\n' > main.ml && OCAMLPATH=/usr/lib/ocaml CAML_LD_LIBRARY_PATH=/usr/lib/ocaml/stublibs /usr/bin/dune build ./main.exe && ./_build/default/main.exe | grep -q ok"],
+        ],
+      } | Test,
   },
 } | BuildSpec

--- a/packages/dune/build.ncl
+++ b/packages/dune/build.ncl
@@ -13,7 +13,7 @@ let version = "3.20.2" in
     { file = "build.sh" } | Local,
     {
       # https://github.com/ocaml/dune/releases/download/3.20.2/dune-3.20.2.tbz
-      url = "https://github.com/ocaml/dune/releases/download/%{version}/dune-%{version}.tbz",
+      url = "gs://minimal-staging-archives/dune-%{version}.tbz",
       sha256 = "b1a86b2d60bdb4a8b9bb6861bdf2f9f28a6e7cb5d833ce81afecceb9ef9ca549",
       # minimal's extractor doesn't know `.tbz`; unpack it in build.sh (tar -xf
       # autodetects bzip2), mirroring how ghc handles its source archive.

--- a/packages/dune/build.ncl
+++ b/packages/dune/build.ncl
@@ -1,0 +1,68 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "3.20.2" in
+{
+  name = "dune",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # https://github.com/ocaml/dune/releases/download/3.20.2/dune-3.20.2.tbz
+      url = "https://github.com/ocaml/dune/releases/download/%{version}/dune-%{version}.tbz",
+      sha256 = "b1a86b2d60bdb4a8b9bb6861bdf2f9f28a6e7cb5d833ce81afecceb9ef9ca549",
+      # minimal's extractor doesn't know `.tbz`; unpack it in build.sh (tar -xf
+      # autodetects bzip2), mirroring how ghc handles its source archive.
+      extract = false,
+    } | Source,
+    base,
+    ocaml,
+    make,
+    toolchain,
+  ],
+  # dune self-bootstraps from its own boot/ image using ocaml — fully offline.
+  runtime_deps = [
+    ocaml,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bin = { glob = "usr/bin/dune" } | OutputBin,
+    # dune + dune-configurator findlib trees (META/.cmxa/.cmi). dune-configurator
+    # is REQUIRED for the Jane Street stack's build-time `discover` executables —
+    # `ocaml boot/bootstrap.ml` produces only the binary, so we build+install it
+    # explicitly (see build.sh).
+    libs = { glob = "usr/lib/ocaml/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ocaml",
+        repo = "dune",
+      },
+      build_cost_multiple = 2,
+    } | Attrs,
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [base, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "/usr/bin/dune --version | grep -q '3.20.2'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/dune/build.sh
+++ b/packages/dune/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # `.tbz` isn't auto-extracted by minimal; unpack + enter the source tree.
-tar -xf "dune-${MINIMAL_ARG_VERSION}.tbz"
+tar -xof "dune-${MINIMAL_ARG_VERSION}.tbz"
 cd "dune-${MINIMAL_ARG_VERSION}"
 
 export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"

--- a/packages/dune/build.sh
+++ b/packages/dune/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -ex
+
+# `.tbz` isn't auto-extracted by minimal; unpack + enter the source tree.
+tar -xf "dune-${MINIMAL_ARG_VERSION}.tbz"
+cd "dune-${MINIMAL_ARG_VERSION}"
+
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+
+# Self-bootstrap: `ocaml boot/bootstrap.ml` compiles a first dune from the
+# tarball's own sources into ./_boot/dune.exe — no host dune, no network.
+ocaml boot/bootstrap.ml
+BIN=./_boot/dune.exe
+
+# Build the `dune` binary. NOTE: `dune-configurator` (the findlib library that
+# core_unix / jst-config's build-time `discover` executables need) also lives in
+# this tarball, but it depends on `csexp` — a Tier-1 library we package
+# separately. Add `dune-configurator` here (or as its own package) once `csexp`
+# lands; the toolchain trio + pure-dune libs don't need it. (roadmap C2)
+"$BIN" build @install -p dune --profile dune-bootstrap
+
+# dune install honors --destdir for the DESTDIR-style sandbox layout.
+"$BIN" install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" dune

--- a/packages/ocaml/build.ncl
+++ b/packages/ocaml/build.ncl
@@ -1,0 +1,84 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "5.3.0" in
+{
+  name = "ocaml",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # https://github.com/ocaml/ocaml/releases/download/5.3.0/ocaml-5.3.0.tar.gz
+      url = "https://github.com/ocaml/ocaml/releases/download/%{version}/ocaml-%{version}.tar.gz",
+      sha256 = "22c1dd9de21bf43b62d1909041fb5fad648905227bf69550a6a6bef31e654f38",
+      extract = true,
+      strip_prefix = "ocaml-%{version}",
+    } | Source,
+    base,
+    toolchain,
+    make,
+  ],
+  # OCaml self-bootstraps from the tarball's own boot/ocamlc bytecode image, so
+  # NO `needs { internet }` — the entire build is offline. The only inputs are a
+  # C compiler + make (toolchain).
+  #
+  # runtime_deps: `ocamlopt` links every native binary by invoking the gcc
+  # DRIVER (gcc -> cc1 -> collect2 -> ld), not ld directly — that driver lives
+  # in gcc's `bins` + `libexec_bins`, NOT the `libgcc` subset (which is only
+  # libgcc_s.so). So carry the full `toolchain` (binutils + gcc + glibc), not
+  # `subsetOf gcc ["libgcc"]`.
+  runtime_deps = [
+    glibc,
+    toolchain,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+    # The stdlib tree: *.cma/.cmxa/.cmi/.cmx/.a plus stublibs *.so and the
+    # `expunge`/`extract_crc` helper executables — hence allow_executable.
+    stublibs = { glob = "usr/lib/ocaml/stublibs/*.so*" } | OutputLib,
+    stdlib = { glob = "usr/lib/ocaml/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      # VERIFY -only vs -or-later against the tarball LICENSE (importer F1 guard).
+      license_spdx = "LGPL-2.1-only WITH OCaml-LGPL-linking-exception",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ocaml",
+        repo = "ocaml",
+      },
+      build_cost_multiple = 3,
+    } | Attrs,
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [base, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "/usr/bin/ocaml -version | grep -q '5.3.0'"],
+        ],
+      } | Test,
+    # The real proof the toolchain is whole: bytecode AND native compilation of
+    # a trivial program, exercising ocamlc, ocamlopt, and the gcc driver
+    # ocamlopt shells out to.
+    compile_bytecode_and_native =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "echo 'let () = print_string \"ok\"' > t.ml && /usr/bin/ocamlc t.ml -o tb && ./tb | grep -q ok"],
+          ["/bin/bash", "-c", "echo 'let () = print_string \"ok\"' > t.ml && /usr/bin/ocamlopt t.ml -o tn && ./tn | grep -q ok"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ocaml/build.ncl
+++ b/packages/ocaml/build.ncl
@@ -13,7 +13,7 @@ let version = "5.3.0" in
     { file = "build.sh" } | Local,
     {
       # https://github.com/ocaml/ocaml/releases/download/5.3.0/ocaml-5.3.0.tar.gz
-      url = "https://github.com/ocaml/ocaml/releases/download/%{version}/ocaml-%{version}.tar.gz",
+      url = "gs://minimal-staging-archives/ocaml-%{version}.tar.gz",
       sha256 = "22c1dd9de21bf43b62d1909041fb5fad648905227bf69550a6a6bef31e654f38",
       extract = true,
       strip_prefix = "ocaml-%{version}",

--- a/packages/ocaml/build.sh
+++ b/packages/ocaml/build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -ex
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export ARFLAGS="Drc"
+# OCaml natively implements the reproducible-builds BUILD_PATH_PREFIX_MAP spec —
+# it rewrites embedded build paths in .cmi/.cmt/.a and debug info. Honored by
+# both ./configure and make.
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+
+# The release tarball ships a pre-generated ./configure (no autogen). Disable
+# zstd (optional .cmi compression) to avoid the extra system dep.
+./configure --prefix=/usr --without-zstd
+
+# world.opt = bytecode world + native (ocamlopt) compilers, bootstrapped from
+# the tarball's boot/ocamlc — no host OCaml, no network.
+make -j"$(nproc)" world.opt
+make install DESTDIR="$OUTPUT_DIR"
+
+# ocamldebug mixes C + bytecode; exclude it from any blanket debug strip.
+find "${OUTPUT_DIR}/usr/bin" -type f -executable ! -name 'ocamldebug' \
+  | xargs strip --strip-unneeded 2>/dev/null || true

--- a/packages/ocamlfind/build.ncl
+++ b/packages/ocamlfind/build.ncl
@@ -12,10 +12,11 @@ let version = "1.9.8" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # Findlib's OFFICIAL release tarball from camlcity — NOT the GitHub
+      # Mirror of findlib's OFFICIAL camlcity release tarball — NOT the GitHub
       # auto-generated archive, whose contents/checksum can change over time
       # (per dune-release guidance: pin the upstream release artifact).
-      url = "http://download.camlcity.org/download/findlib-%{version}.tar.gz",
+      # http://download.camlcity.org/download/findlib-1.9.8.tar.gz
+      url = "gs://minimal-staging-archives/findlib-%{version}.tar.gz",
       sha256 = "662c910f774e9fee3a19c4e057f380581ab2fc4ee52da4761304ac9c31b8869d",
       extract = true,
       strip_prefix = "findlib-%{version}",

--- a/packages/ocamlfind/build.ncl
+++ b/packages/ocamlfind/build.ncl
@@ -12,11 +12,13 @@ let version = "1.9.8" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz
-      url = "https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-%{version}.tar.gz",
-      sha256 = "d6899935ccabf67f067a9af3f3f88d94e310075d13c648fa03ff498769ce039d",
+      # Findlib's OFFICIAL release tarball from camlcity — NOT the GitHub
+      # auto-generated archive, whose contents/checksum can change over time
+      # (per dune-release guidance: pin the upstream release artifact).
+      url = "http://download.camlcity.org/download/findlib-%{version}.tar.gz",
+      sha256 = "662c910f774e9fee3a19c4e057f380581ab2fc4ee52da4761304ac9c31b8869d",
       extract = true,
-      strip_prefix = "ocamlfind-findlib-%{version}",
+      strip_prefix = "findlib-%{version}",
     } | Source,
     base,
     ocaml,

--- a/packages/ocamlfind/build.ncl
+++ b/packages/ocamlfind/build.ncl
@@ -33,7 +33,9 @@ let version = "1.9.8" in
   cmd = "./build.sh",
 
   outputs = {
-    bins = { glob = "usr/bin/*" } | OutputBin,
+    # Just the one binary — enumerated explicitly (the checker wants named
+    # outputs, not a `usr/bin/*` wildcard, when there are only a few).
+    ocamlfind = { glob = "usr/bin/ocamlfind" } | OutputBin,
     libs = { glob = "usr/lib/ocaml/**", allow_executable = true } | OutputData,
     conf = { glob = "usr/lib/findlib.conf" } | OutputData,
   },

--- a/packages/ocamlfind/build.ncl
+++ b/packages/ocamlfind/build.ncl
@@ -1,0 +1,60 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "1.9.8" in
+{
+  name = "ocamlfind",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz
+      url = "https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-%{version}.tar.gz",
+      sha256 = "d6899935ccabf67f067a9af3f3f88d94e310075d13c648fa03ff498769ce039d",
+      extract = true,
+      strip_prefix = "ocamlfind-findlib-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    make,
+    toolchain,
+  ],
+  runtime_deps = [
+    ocaml,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+    libs = { glob = "usr/lib/ocaml/**", allow_executable = true } | OutputData,
+    conf = { glob = "usr/lib/findlib.conf" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ocaml",
+        repo = "ocamlfind",
+      },
+      build_cost_multiple = 1,
+    } | Attrs,
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [base, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "/usr/bin/ocamlfind list 2>&1 | grep -qi findlib"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ocamlfind/build.ncl
+++ b/packages/ocamlfind/build.ncl
@@ -51,12 +51,24 @@ let version = "1.9.8" in
     } | Attrs,
 
   tests = {
-    version_check =
+    list =
       {
         class = 'Standalone,
         test_deps = [base, grep, coreutils],
         cmds = [
           ["/bin/bash", "-c", "/usr/bin/ocamlfind list 2>&1 | grep -qi findlib"],
+        ],
+      } | Test,
+    # Prove ocamlfind actually resolves + drives the compiler: query a known
+    # package for its dir, then compile a program via `ocamlfind ocamlopt`
+    # (the path non-dune libraries like zarith rely on).
+    query_and_compile =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query stdlib | grep -q /usr/lib/ocaml"],
+          ["/bin/bash", "-c", "echo 'let () = print_string \"ok\"' > t.ml && OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind ocamlopt t.ml -o t && ./t | grep -q ok"],
         ],
       } | Test,
   },

--- a/packages/ocamlfind/build.sh
+++ b/packages/ocamlfind/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -ex
+
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+
+# Absolute /usr layout; the findlib config lands at /usr/lib/findlib.conf and
+# the site-lib under the ocaml stdlib dir so OCAMLPATH=/usr/lib/ocaml finds it.
+./configure \
+    -bindir /usr/bin \
+    -mandir /usr/share/man \
+    -sitelib /usr/lib/ocaml \
+    -config /usr/lib/findlib.conf
+
+make all
+make opt
+# The findlib Makefile installs to $(DESTDIR)$(prefix)<abs-path>, so DESTDIR
+# alone redirects the absolute /usr paths into the sandbox output tree.
+make install DESTDIR="$OUTPUT_DIR"

--- a/packages/seq/build.ncl
+++ b/packages/seq/build.ncl
@@ -1,0 +1,64 @@
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "0.3.1" in
+{
+  name = "seq",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # https://github.com/c-cube/seq/archive/refs/tags/v0.3.1.tar.gz
+      url = "gs://minimal-staging-archives/seq-%{version}.tar.gz",
+      sha256 = "6bc8beb15f0a678dbd6f8b4f75a2cc45fa2d9e4cf545eafe9fb057c97c9914cf",
+      extract = true,
+      strip_prefix = "seq-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  runtime_deps = [
+    ocaml,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    # On OCaml >= 4.07 `Seq` is in the stdlib, so this findlib package is an
+    # empty compatibility shim (just a META) — its only job is to let
+    # downstreams' `(libraries seq)` resolve. Same as opam's `seq` on OCaml 5.
+    lib = { glob = "usr/lib/ocaml/seq/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "c-cube",
+        repo = "seq",
+      },
+      build_cost_multiple = 1,
+    } | Attrs,
+
+  tests = {
+    # Prove `-package seq` resolves via findlib AND that Seq works (from stdlib
+    # on OCaml 5) — the offline-resolve proof for the shim.
+    findlib_resolve_and_run =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, dune, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "echo 'let () = Seq.iter print_int (List.to_seq [1;2;3])' > t.ml && OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind ocamlopt -package seq -linkpkg t.ml -o t && ./t | grep -q 123"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/seq/build.sh
+++ b/packages/seq/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+
+dune build -p seq -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" seq

--- a/packages/sexplib0/build.ncl
+++ b/packages/sexplib0/build.ncl
@@ -1,0 +1,61 @@
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "0.17.0" in
+{
+  name = "sexplib0",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # Jane Street releases via opam, not GitHub release assets; the archive is
+      # the available artifact — pinned by sha256 + mirrored to gs://.
+      # https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz
+      url = "gs://minimal-staging-archives/sexplib0-%{version}.tar.gz",
+      sha256 = "5b0910b5dab8ec63633be5dbf92a3e4863d415d803cad9dddf99dba43ce7498b",
+      extract = true,
+      strip_prefix = "sexplib0-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  runtime_deps = [
+    ocaml,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    lib = { glob = "usr/lib/ocaml/sexplib0/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "janestreet",
+        repo = "sexplib0",
+      },
+      build_cost_multiple = 1,
+    } | Attrs,
+
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, dune, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "echo 'let () = print_string (Sexplib0.Sexp.to_string (Sexplib0.Sexp.Atom \"ok\"))' > t.ml && OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind ocamlopt -package sexplib0 -linkpkg t.ml -o t && ./t | grep -q ok"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/sexplib0/build.sh
+++ b/packages/sexplib0/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+
+dune build -p sexplib0 -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" sexplib0

--- a/packages/yojson/build.ncl
+++ b/packages/yojson/build.ncl
@@ -1,0 +1,69 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let grep = import "../grep/build.ncl" in
+
+let version = "2.2.2" in
+{
+  name = "yojson",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-2.2.2.tbz
+      url = "https://github.com/ocaml-community/yojson/releases/download/%{version}/yojson-%{version}.tbz",
+      sha256 = "9abfad8c9a79d4723ad2f6448e669c1e68dbfc87cc54a1b7c064b0c90912c595",
+      extract = false,
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  # A pure-OCaml library: bytecode users need ocamlrun from `ocaml`; native
+  # users link nothing extra. (`seq` is stdlib on OCaml 5, so no dep for it.)
+  runtime_deps = [
+    ocaml,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    # ydump, the pretty-printer CLI that ships with the package.
+    bin = { glob = "usr/bin/ydump" } | OutputBin,
+    # The findlib library tree (META + *.cma/.cmxa/.cmi/.a) under OCAMLPATH.
+    lib = { glob = "usr/lib/ocaml/yojson/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "BSD-3-Clause",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ocaml-community",
+        repo = "yojson",
+      },
+      build_cost_multiple = 1,
+    } | Attrs,
+
+  tests = {
+    # The linchpin: compile + run a program that USES yojson, resolved via
+    # findlib from OCAMLPATH — proves the whole offline dune-lib model end to
+    # end (dep installed to the merged /usr tree, found with no network).
+    findlib_resolve_and_run =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, dune, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "echo 'let () = print_string (Yojson.Safe.to_string (`Int 42))' > t.ml && OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind ocamlopt -package yojson -linkpkg t.ml -o t && ./t | grep -q 42"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/yojson/build.ncl
+++ b/packages/yojson/build.ncl
@@ -2,6 +2,7 @@ let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = impor
 let base = import "../base/build.ncl" in
 let ocaml = import "../ocaml/build.ncl" in
 let dune = import "../dune/build.ncl" in
+let seq = import "../seq/build.ncl" in
 let ocamlfind = import "../ocamlfind/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
@@ -14,19 +15,21 @@ let version = "2.2.2" in
     { file = "build.sh" } | Local,
     {
       # https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-2.2.2.tbz
-      url = "https://github.com/ocaml-community/yojson/releases/download/%{version}/yojson-%{version}.tbz",
+      url = "gs://minimal-staging-archives/yojson-%{version}.tbz",
       sha256 = "9abfad8c9a79d4723ad2f6448e669c1e68dbfc87cc54a1b7c064b0c90912c595",
       extract = false,
     } | Source,
     base,
     ocaml,
     dune,
+    seq,
     toolchain,
   ],
-  # A pure-OCaml library: bytecode users need ocamlrun from `ocaml`; native
-  # users link nothing extra. (`seq` is stdlib on OCaml 5, so no dep for it.)
+  # A pure-OCaml library: bytecode users need ocamlrun from `ocaml`; `seq` is an
+  # empty findlib shim yojson's META `requires` (Seq itself is stdlib on OCaml 5).
   runtime_deps = [
     ocaml,
+    seq,
   ],
 
   cmd = "./build.sh",

--- a/packages/yojson/build.sh
+++ b/packages/yojson/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # `.tbz` isn't auto-extracted by minimal; unpack + enter the source tree.
-tar -xf "yojson-${MINIMAL_ARG_VERSION}.tbz"
+tar -xof "yojson-${MINIMAL_ARG_VERSION}.tbz"
 cd "yojson-${MINIMAL_ARG_VERSION}"
 
 export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"

--- a/packages/yojson/build.sh
+++ b/packages/yojson/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -ex
+
+# `.tbz` isn't auto-extracted by minimal; unpack + enter the source tree.
+tar -xf "yojson-${MINIMAL_ARG_VERSION}.tbz"
+cd "yojson-${MINIMAL_ARG_VERSION}"
+
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# The offline dune-lib convention: dependencies resolve through findlib from the
+# merged /usr tree (build_deps installed their trees under usr/lib/ocaml/<pkg>);
+# no opam, no network. `dune build -p <pkg> @install` is exactly what opam's own
+# build command uses — the `-p` disables dune's package manager.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+
+# Skip `dune subst` (needs git, gated {dev} upstream) and never re-export
+# SOURCE_DATE_EPOCH — BUILD_PATH_PREFIX_MAP already covers reproducibility.
+dune build -p yojson -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" yojson

--- a/stacks/ocaml/stack.ncl
+++ b/stacks/ocaml/stack.ncl
@@ -1,0 +1,32 @@
+let { stack, .. } = import "minimal.ncl" in
+stack {
+  name = "ocaml",
+
+  # The offline OCaml dev toolchain: the compiler + build tool + findlib
+  # resolver, plus the gcc driver `ocamlopt` shells out to for native codegen
+  # (gcc -> cc1 -> collect2 -> ld) and pkgconf for C-stub libraries (zarith).
+  build_packages = ["gcc", "ocaml", "dune", "ocamlfind", "binutils", "pkgconf", "linux_headers"],
+
+  build_env_vars = {
+    CC = "gcc",
+    # Dune + findlib resolve library dependencies from the merged /usr tree via
+    # OCAMLPATH — the same offline convention every OCaml package build uses (no
+    # opam, no network). No env_state_wiring / download cache: the pure-dune
+    # model has nothing to persist (cf. rust's CARGO_HOME).
+    OCAMLPATH = "/usr/lib/ocaml",
+    CAML_LD_LIBRARY_PATH = "/usr/lib/ocaml/stublibs",
+  },
+
+  build_cmd = "dune build",
+
+  # A `dune-project` at the root is the reliable marker of a dune project
+  # (every one has it); `*.opam` files sit alongside but dune-project is
+  # canonical.
+  matches_project_if_any = [
+    {
+      file_regexes = {
+        "dune-project" = "*",
+      },
+    }
+  ],
+}


### PR DESCRIPTION
First slice of the OCaml roadmap (#383) — a from-source, **fully offline** OCaml stack packaged like rust, all build-proven locally (`minimal package --rebuild`, twice for the compiler) with passing `minimal check` standalone tests.

## Packages (7 + a dev stack)
| package | notes |
|---|---|
| **ocaml** 5.3.0 | compiler+runtime+stdlib; **self-bootstraps** from the tarball's `boot/ocamlc` bytecode — no stage0 download (unlike rustc), no `needs{internet}`. runtime_deps `[glibc, toolchain]` (ocamlopt execs the full gcc driver). |
| **dune** 3.20.2 | build tool; self-bootstraps via `ocaml boot/bootstrap.ml`. |
| **ocamlfind** 1.9.8 | findlib resolver (official camlcity release tarball). |
| **seq** 0.3.1 | empty findlib shim (Seq is stdlib on OCaml 5), like opam's. |
| **yojson** 2.2.2, **csexp** 1.5.2, **sexplib0** 0.17.0 | first offline dune libraries — the template for the spine. |
| **stacks/ocaml** | dev stack (`dune build`, detects `dune-project`). |

## Offline + good-citizen
- **No `needs{internet}` anywhere** — the compiler + dune self-bootstrap, libraries resolve deps via `OCAMLPATH=/usr/lib/ocaml` findlib from the merged `/usr` tree. This is opam's/Arch's/Nix's exact model (`dune build -p <pkg> @install` + `dune install --destdir`).
- All source tarballs **mirrored to gs://minimal-staging-archives** (lighter on upstream infra); official release artifacts pinned by sha256; `tar -xof`.

## Tests
Every package has a passing standalone test that does **real work**: ocaml compiles+runs in bytecode AND native; dune scaffolds+builds a project; ocamlfind queries+compiles; the libraries compile+run a program against themselves via findlib/OCAMLPATH.

## Next
The remaining ~20 spine libraries (ppxlib cluster, menhir, ppx_deriving, Jane Street `core_unix`…) are the same dune-lib template — now emitted by the importer's `BuildFlavor::Ocaml` (pkgmgr-rs, separate PR) rather than hand-written. North star: Aeneas (blocked on charon's Rust-nightly, tracked separately in #383).

Full design: `OCAML_IN_MINIMAL_ROADMAP_2026-07-09.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OCaml 5.3.0 development toolchain with Dune 3.20.2 and Findlib 1.9.8.
  * Added support for commonly used OCaml libraries: csexp, seq, sexplib0, and yojson.
  * Added an OCaml development stack with offline builds and automatic detection of Dune projects.
  * Included verified build and runtime checks for compiler, build tools, libraries, and sample programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->