### PR TITLE
stow: GNU Stow 2.4.1 — symlink farm manager (Perl)

### DIFF
--- a/packages/stow/build.ncl
+++ b/packages/stow/build.ncl
@@ -1,5 +1,4 @@
 # Imported from Wolfi `stow` by `pkgmgr import-wolfi` (autotools build).
-# TODO: REVIEWER — verify deps/outputs/runtime_deps + the build.sh opts.
 let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let autoconf = import "../autoconf/build.ncl" in
@@ -52,8 +51,6 @@ let version = "2.4.1" in
         class = 'Standalone,
         test_deps = [base],
         cmds = [
-          # TODO: REVIEWER — ported from the Wolfi test block; verify each
-          # against minimal's toolchain (bins on PATH, flags supported).
           ["/bin/bash", "-c", "stow --version\nstow --help\n\nmkdir test links\ncd test || exit\necho 'this is a test' > test.file\n\nstow -S -t ../links .\nls -1 ../links/test.file"],
         ],
       } | Test,

--- a/packages/stow/build.ncl
+++ b/packages/stow/build.ncl
@@ -1,0 +1,61 @@
+# Imported from Wolfi `stow` by `pkgmgr import-wolfi` (autotools build).
+# TODO: REVIEWER — verify deps/outputs/runtime_deps + the build.sh opts.
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let autoconf = import "../autoconf/build.ncl" in
+let automake = import "../automake/build.ncl" in
+let libtool = import "../libtool/build.ncl" in
+let m4 = import "../m4/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let perl = import "../perl/build.ncl" in
+let version = "2.4.1" in
+{
+  name = "stow",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    autoconf,
+    automake,
+    libtool,
+    m4,
+    make,
+    pkgconf,
+    toolchain,
+    glibc,
+    perl,
+    {
+      url = "gs://minimal-staging-archives/stow-%{version}.tar.gz",
+      sha256 = "2a671e75fc207303bfe86a9a7223169c7669df0a8108ebdf1a7fe8cd2b88780b",
+      extract = true,
+      strip_prefix = "stow-%{version}",
+    } | Source,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    # Discovery catch-all — rerun with `--from-build <artifact>` to refine
+    # into precise, typed outputs (bins/libs/includes/…).
+    everything = { glob = "usr/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [perl],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GnuProject, name = "stow" },
+      license_spdx = "GPL-3.0",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # TODO: REVIEWER — ported from the Wolfi test block; verify each
+          # against minimal's toolchain (bins on PATH, flags supported).
+          ["/bin/bash", "-c", "stow --version\nstow --help\n\nmkdir test links\ncd test || exit\necho 'this is a test' > test.file\n\nstow -S -t ../links .\nls -1 ../links/test.file"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/stow/build.sh
+++ b/packages/stow/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Imported from Wolfi `stow` (2.4.1, autotools) by pkgmgr import-wolfi.
-# TODO: REVIEWER — the Wolfi recipe passed no configure opts; add any this
-# build needs (check upstream INSTALL).
 set -eu
 # Reproducibility flags (see AGENTS.md).
 export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"

--- a/packages/stow/build.sh
+++ b/packages/stow/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Imported from Wolfi `stow` (2.4.1, autotools) by pkgmgr import-wolfi.
+# TODO: REVIEWER — the Wolfi recipe passed no configure opts; add any this
+# build needs (check upstream INSTALL).
+set -eu
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+export ARFLAGS=Drc
+
+# The GNU tarball ships pre-built texinfo docs (doc/stow.info,
+# doc/manual-single.html), but minimal has no texinfo/makeinfo to regenerate
+# them — make's doc rules would `rm` the shipped file then fail on the missing
+# tool. Shim `makeinfo` to restore the shipped doc into each rule's -o target.
+mkdir -p .shim/docs
+cp -a doc/*.info doc/*.html .shim/docs/ 2>/dev/null || true
+cat > .shim/makeinfo <<'SHIM'
+#!/bin/sh
+out=""; prev=""
+for a in "$@"; do [ "$prev" = "-o" ] && out=$a; prev=$a; done
+[ -n "$out" ] || exit 0
+mkdir -p "$(dirname "$out")"
+shipped="$SHIM_DOCS/$(basename "$out")"
+if [ -f "$shipped" ]; then cp "$shipped" "$out"; else : > "$out"; fi
+SHIM
+chmod +x .shim/makeinfo
+export SHIM_DOCS="$PWD/.shim/docs"
+export PATH="$PWD/.shim:$PATH"
+
+if [ ! -x ./configure ]; then autoreconf -fi; fi
+./configure --prefix=/usr --enable-deterministic-archives
+make -j"$(nproc)"
+make DESTDIR="$OUTPUT_DIR" install
+# Drop libtool archives — they embed absolute build-time paths.
+find "$OUTPUT_DIR" -name '*.la' -delete


### PR DESCRIPTION
Adds **GNU Stow 2.4.1** — the symlink farm manager

Builds + installs clean and **passes all 14 checkers**, including the build-dependent ones (`enumerate-bins`, `missing-runtime_deps`, and `standalone-tests`, which runs `stow -S` end to end to farm + verify symlinks).

## Notes for review
- **First GNU-project package via the importer's new GNU-source path** — `git.savannah.gnu.org` source → ftp.gnu.org release tarball, mirrored to `gs://minimal-staging-archives/stow-2.4.1.tar.gz`, `'GnuProject` provenance.
- **Perl package:** Stow is a Perl script, not an ELF binary, so `runtime_deps = [perl]` (not glibc).
- **`makeinfo` shim in build.sh:** the GNU tarball ships pre-built texinfo docs, but minimal has no `texinfo`/`makeinfo` to regenerate them — `make`'s doc rules would `rm` the shipped file then fail on the missing tool. The shim restores the shipped `doc/*.{info,html}` into make's outputs, so the real manual installs without needing texinfo. (Follow-up options: generalize the shim into the importer's autotools template, or add a `texinfo` package — noted in pkgmgr#472.)
- Reviewer TODO from the importer: verify the tag resolves to Wolfi's expected-commit `544aed007b9b26a73ca321c17d3f3b8f7172f9d4`.

Verified: `minimal package --rebuild --no-fetch stow` → `usr/bin/stow` (a real `#!/usr/bin/perl` script) + `chkstow` + the `Stow.pm`/`Util.pm` modules + the manual; `minimal check --packages stow` → 14/14 Pass.
