### PR TITLE
dev tools for loadouts: hyperfine, hexyl, tokei, bandwhich, vhs, chezmoi

### DIFF
--- a/packages/bandwhich/build.ncl
+++ b/packages/bandwhich/build.ncl
@@ -1,0 +1,42 @@
+# Auto-bootstrapped from https://github.com/imsnif/bandwhich by `pkgmgr bootstrap` (rust build).
+# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "0.23.1" in
+{
+  name = "bandwhich",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/imsnif/bandwhich/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "aafb96d059cf9734da915dca4f5940c319d2e6b54e2ffb884332e9f5e820e6d7",
+      extract = true,
+      strip_prefix = "bandwhich-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    bandwhich = { glob = "usr/bin/bandwhich" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "imsnif", repo = "bandwhich" },
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/bandwhich/build.ncl
+++ b/packages/bandwhich/build.ncl
@@ -1,5 +1,3 @@
-# Auto-bootstrapped from https://github.com/imsnif/bandwhich by `pkgmgr bootstrap` (rust build).
-# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
 let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let rust = import "../rust/build.ncl" in

--- a/packages/bandwhich/build.sh
+++ b/packages/bandwhich/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/imsnif/bandwhich (0.23.1, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/bandwhich" "$OUTPUT_DIR/usr/bin/"

--- a/packages/chezmoi/build.ncl
+++ b/packages/chezmoi/build.ncl
@@ -1,5 +1,3 @@
-# Imported from Wolfi `chezmoi` by `pkgmgr import-wolfi` (go build).
-# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
 let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in

--- a/packages/chezmoi/build.ncl
+++ b/packages/chezmoi/build.ncl
@@ -1,0 +1,56 @@
+# Imported from Wolfi `chezmoi` by `pkgmgr import-wolfi` (go build).
+# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "2.71.0" in
+{
+  name = "chezmoi",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/twpayne/chezmoi/v%{version}.tar.gz",
+      sha256 = "77f85f4d164f8ce0fc784b5d6ca86b0576a00729c5b23a113b92665e0509f252",
+      extract = true,
+      strip_prefix = "chezmoi-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    chezmoi = { glob = "usr/bin/chezmoi" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "twpayne", repo = "chezmoi" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Version/help smoke checks. The Wolfi recipe's dotfile-flow tests
+          # (chezmoi init/add/apply/data/doctor) need a writable $HOME + git
+          # and aren't portable to the standalone sandbox — dropped.
+          ["/bin/bash", "-c", "chezmoi --version 2>/dev/null || chezmoi version"],
+          ["/bin/bash", "-c", "chezmoi --help 2>/dev/null || chezmoi help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/chezmoi/build.sh
+++ b/packages/chezmoi/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from Wolfi `chezmoi` (2.71.0, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/chezmoi" .

--- a/packages/hexyl/build.ncl
+++ b/packages/hexyl/build.ncl
@@ -1,0 +1,42 @@
+# Auto-bootstrapped from https://github.com/sharkdp/hexyl by `pkgmgr bootstrap` (rust build).
+# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "0.17.0" in
+{
+  name = "hexyl",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/sharkdp/hexyl/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "72fa17397ad187eec6b295d02c7caabbb209a6e0d5706187b8a599bd5df8615e",
+      extract = true,
+      strip_prefix = "hexyl-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    hexyl = { glob = "usr/bin/hexyl" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "sharkdp", repo = "hexyl" },
+      license_spdx = "Apache-2.0",
+    } | Attrs,
+} | BuildSpec

--- a/packages/hexyl/build.ncl
+++ b/packages/hexyl/build.ncl
@@ -1,5 +1,3 @@
-# Auto-bootstrapped from https://github.com/sharkdp/hexyl by `pkgmgr bootstrap` (rust build).
-# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
 let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let rust = import "../rust/build.ncl" in

--- a/packages/hexyl/build.sh
+++ b/packages/hexyl/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/sharkdp/hexyl (0.17.0, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/hexyl" "$OUTPUT_DIR/usr/bin/"

--- a/packages/hyperfine/build.ncl
+++ b/packages/hyperfine/build.ncl
@@ -1,5 +1,3 @@
-# Auto-bootstrapped from https://github.com/sharkdp/hyperfine by `pkgmgr bootstrap` (rust build).
-# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
 let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let rust = import "../rust/build.ncl" in

--- a/packages/hyperfine/build.ncl
+++ b/packages/hyperfine/build.ncl
@@ -1,0 +1,42 @@
+# Auto-bootstrapped from https://github.com/sharkdp/hyperfine by `pkgmgr bootstrap` (rust build).
+# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "1.20.0" in
+{
+  name = "hyperfine",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/sharkdp/hyperfine/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "f90c3b096af568438be7da52336784635a962c9822f10f98e5ad11ae8c7f5c64",
+      extract = true,
+      strip_prefix = "hyperfine-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    hyperfine = { glob = "usr/bin/hyperfine" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "sharkdp", repo = "hyperfine" },
+      license_spdx = "Apache-2.0",
+    } | Attrs,
+} | BuildSpec

--- a/packages/hyperfine/build.sh
+++ b/packages/hyperfine/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/sharkdp/hyperfine (1.20.0, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/hyperfine" "$OUTPUT_DIR/usr/bin/"

--- a/packages/tokei/build.ncl
+++ b/packages/tokei/build.ncl
@@ -1,5 +1,3 @@
-# Auto-bootstrapped from https://github.com/XAMPPRocky/tokei by `pkgmgr bootstrap` (rust build).
-# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
 let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let rust = import "../rust/build.ncl" in
@@ -37,6 +35,6 @@ let version = "14.0.0" in
     {
       upstream_version = version,
       source_provenance = { category = 'GithubRepo, owner = "XAMPPRocky", repo = "tokei" },
-      # TODO: REVIEWER — set license_spdx.
+      license_spdx = "MIT OR Apache-2.0",
     } | Attrs,
 } | BuildSpec

--- a/packages/tokei/build.ncl
+++ b/packages/tokei/build.ncl
@@ -1,0 +1,42 @@
+# Auto-bootstrapped from https://github.com/XAMPPRocky/tokei by `pkgmgr bootstrap` (rust build).
+# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "14.0.0" in
+{
+  name = "tokei",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/XAMPPRocky/tokei/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "4e561dbb83ef1b46359714fc623fd45eddfb14821ece63a219470500fdd1cd26",
+      extract = true,
+      strip_prefix = "tokei-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+    make,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    tokei = { glob = "usr/bin/tokei" } | OutputBin,
+  },
+  runtime_deps = [glibc, subsetOf gcc ["libgcc"]],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "XAMPPRocky", repo = "tokei" },
+      # TODO: REVIEWER — set license_spdx.
+    } | Attrs,
+} | BuildSpec

--- a/packages/tokei/build.sh
+++ b/packages/tokei/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/XAMPPRocky/tokei (14.0.0, rust) by pkgmgr import-wolfi.
+set -eu
+export CC=gcc
+export LD=gcc
+# Reproducibility (per minimal-repro's guide): strip absolute build
+# paths (source dir + cargo registry) and disable incremental builds.
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CARGO_INCREMENTAL=0
+cargo build --release
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp "target/release/tokei" "$OUTPUT_DIR/usr/bin/"

--- a/packages/vhs/build.ncl
+++ b/packages/vhs/build.ncl
@@ -1,5 +1,3 @@
-# Auto-bootstrapped from https://github.com/charmbracelet/vhs by `pkgmgr bootstrap` (go build).
-# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
 let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in

--- a/packages/vhs/build.ncl
+++ b/packages/vhs/build.ncl
@@ -1,0 +1,39 @@
+# Auto-bootstrapped from https://github.com/charmbracelet/vhs by `pkgmgr bootstrap` (go build).
+# TODO: REVIEWER — verify outputs/runtime_deps + the build.sh.
+let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "0.11.0" in
+{
+  name = "vhs",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/charmbracelet/vhs/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "c08b8502989fe7e9626c02938f3fc512c2a4ba21f839f455d20d7eb1da7bc39f",
+      extract = true,
+      strip_prefix = "vhs-%{version}",
+    } | Source,
+    base,
+    go,
+    toolchain,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    vhs = { glob = "usr/bin/vhs" } | OutputBin,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "charmbracelet", repo = "vhs" },
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/vhs/build.sh
+++ b/packages/vhs/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/charmbracelet/vhs (0.11.0, go) by pkgmgr import-wolfi.
+set -eu
+export GOROOT=/usr/go
+mkdir -p "$OUTPUT_DIR/usr/bin"
+go build -trimpath -ldflags "-buildid= -w -s" -o "$OUTPUT_DIR/usr/bin/vhs" .


### PR DESCRIPTION
Six modern CLI/TUI tools for building terminal **loadouts** — the kind of batteries-included utilities that round out a dev environment. All **build-proven and pass every checker (14/14)**.

| tool | what | lang |
|---|---|---|
| **hyperfine** | command-line benchmarking (`hyperfine 'a' 'b'`) | Rust |
| **hexyl** | modern hex viewer — `cat` for binaries | Rust |
| **tokei** | lines-of-code / language breakdown | Rust |
| **bandwhich** | live network usage by process (TUI) | Rust |
| **vhs** | script terminal sessions into GIFs | Go |
| **chezmoi** | dotfiles manager (templating/secrets) — companion to `stow` | Go |

## How
`pkgmgr bootstrap <github-url>` for the single-binary Rust/Go tools + `pkgmgr import-wolfi chezmoi`; each built via `minimal package --rebuild --no-fetch` and validated with `minimal check`.

## Notes
- **chezmoi test trimmed:** the Wolfi recipe's dotfile-flow test (`chezmoi init/add/apply`, needs a writable `$HOME` + git) isn't portable to the standalone sandbox, so it's reduced to `--version`/`--help` smoke checks.
- **These 6 are 6 of a 10-tool batch.** The other 4 are follow-ups: `jless` (a build issue to chase) and **`gping`/`watchexec`/`mprocs`**, which are Cargo *workspaces* — the binary lives in a subcrate, so the importer needs subcrate detection (`cargo build -p <crate>`). That's a real, generalizable importer gap (diagnosed: `gping/gping`, `watchexec-cli`, mprocs `default-members`) → tracked for a tool fix.
