### PR TITLE
abseil-cpp: 20260526.0 + gcc-15 bmi2intrin patch (fix amd64 FTBFS)

### DIFF
--- a/packages/abseil-cpp/abseil-cpp-gcc15-bmi2intrin.patch
+++ b/packages/abseil-cpp/abseil-cpp-gcc15-bmi2intrin.patch
@@ -1,0 +1,26 @@
+From 8878695bde809ff5c4e3aaf40db809e78cdbdbb5 Mon Sep 17 00:00:00 2001
+From: minimal <pkgs@minimal.dev>
+Date: Fri, 10 Jul 2026 15:26:52 -0700
+Subject: [PATCH] abseil: use <x86intrin.h> not <bmi2intrin.h> (gcc-15 rejects
+ the direct include under -march=x86-64-v3)
+
+---
+ absl/container/internal/raw_hash_set.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/absl/container/internal/raw_hash_set.h b/absl/container/internal/raw_hash_set.h
+index a50a488..f23cd58 100644
+--- a/absl/container/internal/raw_hash_set.h
++++ b/absl/container/internal/raw_hash_set.h
+@@ -226,7 +226,7 @@
+ #endif
+ 
+ #ifdef __BMI2__
+-#include <bmi2intrin.h>
++#include <x86intrin.h>
+ #endif  // __BMI2__
+ 
+ namespace absl {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/packages/abseil-cpp/build.ncl
+++ b/packages/abseil-cpp/build.ncl
@@ -5,17 +5,20 @@ let make = import "../make/build.ncl" in
 let cmake = import "../cmake/build.ncl" in
 let ninja = import "../ninja/build.ncl" in
 
+let patch = import "../patch/build.ncl" in
+
 let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "20250814.1" in
+let version = "20260526.0" in
 {
   name = "abseil-cpp",
   build_deps = [
     { file = "build.sh" } | Local,
+    { file = "abseil-cpp-gcc15-bmi2intrin.patch" } | Local,
     {
       url = "https://github.com/abseil/abseil-cpp/releases/download/%{version}/abseil-cpp-%{version}.tar.gz",
-      sha256 = "1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1",
+      sha256 = "6e1aee535473414164bf83e4ebc40240dec71a4701f8a642d906e95bea1aea0c",
       extract = true,
       strip_prefix = "abseil-cpp-%{version}",
     } | Source,
@@ -23,6 +26,7 @@ let version = "20250814.1" in
     make,
     cmake,
     ninja,
+    patch,
     toolchain,
   ],
   runtime_deps = [

--- a/packages/abseil-cpp/build.sh
+++ b/packages/abseil-cpp/build.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# gcc-15 rejects abseil's direct `#include <bmi2intrin.h>` (raw_hash_set.h)
+# under -march=x86-64-v3 (which defines __BMI2__) — swap it for the sanctioned
+# `<x86intrin.h>` umbrella header, exactly as gcc's own diagnostic advises.
+patch -Np1 -i "abseil-cpp-gcc15-bmi2intrin.patch"
+
 mkdir build &&
 cd    build
 


### PR DESCRIPTION
Bumps abseil-cpp `20250814.1 → 20260526.0` and fixes the amd64 FTBFS that dropped it from the last base-soup cycle.

## Root cause
`20260526.0` newly added to `absl/container/internal/raw_hash_set.h` (the Swiss-table core header, pulled in almost everywhere):
```c
#ifdef __BMI2__
#include <bmi2intrin.h>
#endif
```
`-march=x86-64-v3` (abseil's amd64 flag) defines `__BMI2__`, so the direct include fires — and **gcc-15.2 rejects it**: *"Never use `<bmi2intrin.h>` directly; include `<x86intrin.h>` instead."* It's an upstream regression (our `20250814.1` doesn't have this line), and abseil's *other* intrinsic files already use `<x86intrin.h>`.

## Fix
A one-line vendored patch swapping `<bmi2intrin.h>` → `<x86intrin.h>` — exactly gcc's own recommendation. Applied before the out-of-source cmake build.

## Verified
- Patch applies clean against the real tarball.
- `20260526.0` builds + installs + passes **14/14** checkers on arm64 (the `__BMI2__` path is amd64-only, so the buildbot is the final gate on the intrinsic compile itself).

## Cascade note
SONAME bumps `2508 → 2605`, so abseil's consumers (`re2`, `jsoncpp`, `grpc`) relink against the new `.so` — content-addressing rebuilds them automatically; watch the buildbot for any consumer that doesn't build against the new abseil.
