### PR TITLE
ci: report-only dwell (soak) check for main -> stable (inbox#20/#21)

### DIFF
--- a/.github/scripts/dwell_report.py
+++ b/.github/scripts/dwell_report.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Report-only DWELL (soak) check for main -> stable promotion (inbox#20/#21).
+
+The soak gate is DWELL: how long a package's *current version* has lived on
+`main`, git-derived (not upstream release age -- that's #279's advisory signal).
+A package is eligible to promote main -> stable once its main version has dwelled
+>= a reference minimum (default 7 days, gominimal/inbox#20; Debian britney2
+minimum-soak precedent).
+
+This script is PURE GIT: no `minimal dump`, no network, no secrets. It NEVER
+exits non-zero for a policy reason (still-soaking / unknown) -- it only reports,
+appending a Markdown table to $GITHUB_STEP_SUMMARY. It exits non-zero solely on a
+programming error, which the workflow downgrades to a warning. It MUST NOT be a
+branch-protection required check.
+
+Dwell of package P (version V on main):
+  the commit date at which "V" was last introduced to packages/P/build.ncl on
+  `main` (first-parent). Found with a single `git log -S` pickaxe on the exact
+  quoted token `"V"` -- quoting both sides so a version prefix (1.2.3) can't
+  false-match a longer one (1.2.30). A non-version edit to build.ncl does not
+  reset dwell, because the introduction of V predates it.
+
+Modes:
+  --all                  every package whose main version differs from stable
+                         (the promotion candidates); the dashboard.
+  --packages-file FILE   an explicit newline-delimited package list (a promotion
+                         PR passes the packages it would change on stable).
+
+Versions/paths come from tracked build.ncl only; nothing is composed into a URL
+or a shell, so there is no SSRF/injection surface here (unlike #279). Untrusted
+values are still Markdown-escaped before they reach the summary table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+# `let version = "X.Y.Z" in` is the canonical version binding in every build.ncl
+# (upstream_version = version). Anchored to the start of a line (re.M).
+_VERSION_RE = re.compile(r'^\s*let\s+version\s*=\s*"([^"]+)"', re.M)
+
+
+def git(*args: str, timeout: int = 60) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], capture_output=True, text=True,
+                          timeout=timeout)
+
+
+def version_at(ref: str, name: str) -> str | None:
+    """The `let version` binding of packages/<name>/build.ncl at a git ref, or
+    None if the file/binding is absent (deleted, pre-dating the convention)."""
+    p = git("show", f"{ref}:packages/{name}/build.ncl")
+    if p.returncode != 0:
+        return None
+    m = _VERSION_RE.search(p.stdout)
+    return m.group(1) if m else None
+
+
+def dwell_start(branch: str, name: str, version: str) -> str | None:
+    """ISO date at which `version` was last introduced to the package's build.ncl
+    on `branch` (first-parent history). One pickaxe call; the newest match is the
+    (re-)introduction of the current version. None if not derivable."""
+    # -S is a FIXED string (not regex); quote both sides so 1.2.3 can't match
+    # inside 1.2.30. Passed as a list arg, so no shell/globbing concerns.
+    p = git("log", "--first-parent", branch, "--format=%cI",
+            "-S", f'"{version}"', "--", f"packages/{name}/build.ncl")
+    if p.returncode != 0:
+        return None
+    lines = [ln.strip() for ln in p.stdout.splitlines() if ln.strip()]
+    if lines:
+        return lines[0]  # newest count-change of "version" == its introduction
+    # Fallback: the file's most recent touch on the branch (version predates any
+    # recorded pickaxe change, e.g. introduced in the file's first commit under a
+    # squash that the pickaxe attributes elsewhere). Better an approximate floor
+    # than UNKNOWN.
+    p = git("log", "--first-parent", branch, "-1", "--format=%cI", "--",
+            f"packages/{name}/build.ncl")
+    lines = [ln.strip() for ln in p.stdout.splitlines() if ln.strip()]
+    return lines[0] if lines else None
+
+
+def dwell_days(iso: str | None) -> int | None:
+    if not iso:
+        return None
+    # git %cI emits a trailing "Z" for UTC commits; datetime.fromisoformat only
+    # accepts "Z" on Python 3.11+. Normalize so this works on the CI runner AND
+    # an older local interpreter (matches version_age_report.py's care here).
+    s = iso.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt).days
+
+
+def list_packages(ref: str) -> list[str]:
+    """Package directory names at `ref` (tracked, not the working tree)."""
+    p = git("ls-tree", "-d", "--name-only", ref, "packages/")
+    if p.returncode != 0:
+        # Fall back to the working tree (checkout is the branch under report).
+        try:
+            return sorted(d for d in os.listdir("packages")
+                          if os.path.isdir(os.path.join("packages", d)))
+        except OSError:
+            return []
+    return sorted(ln.split("/", 1)[1] for ln in p.stdout.splitlines()
+                  if ln.startswith("packages/") and "/" in ln)
+
+
+def md_cell(s: str) -> str:
+    """Escape an untrusted build.ncl value for one Markdown table cell."""
+    return (str(s).replace("\\", "\\\\").replace("|", "\\|")
+            .replace("`", "\\`").replace("\r", " ").replace("\n", " "))
+
+
+def emit(markdown: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a") as f:
+            f.write(markdown)
+    else:
+        print("\n" + markdown)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    grp = ap.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--all", action="store_true",
+                     help="report every package whose main version differs from stable")
+    grp.add_argument("--packages-file",
+                     help="newline-delimited package names to report")
+    ap.add_argument("--main-ref", default="origin/main")
+    ap.add_argument("--stable-ref", default="origin/stable")
+    ap.add_argument("--min-dwell-days", type=int, default=7)  # #20 soak reference
+    args = ap.parse_args()
+
+    # Resolve refs defensively: on some events origin/<b> may be absent but the
+    # local branch exists. Fall back local, then to HEAD for main.
+    def resolve_ref(preferred: str, local: str) -> str | None:
+        for r in (preferred, local):
+            if git("rev-parse", "--verify", "--quiet", r).returncode == 0:
+                return r
+        return None
+
+    main_ref = resolve_ref(args.main_ref, "main")
+    stable_ref = resolve_ref(args.stable_ref, "stable")
+    if main_ref is None:
+        emit("## dwell report (informational, non-blocking)\n\n"
+             "> Could not resolve the `main` ref; skipping. Non-blocking.\n")
+        return 0
+    if stable_ref is None:
+        emit("## dwell report (informational, non-blocking)\n\n"
+             "> Could not resolve the `stable` ref (does it exist yet?); "
+             "skipping. Non-blocking.\n")
+        return 0
+
+    if args.all:
+        names = list_packages(main_ref)
+    else:
+        try:
+            with open(args.packages_file) as f:
+                names = [ln.strip() for ln in f if ln.strip()]
+        except OSError as e:
+            emit("## dwell report (informational, non-blocking)\n\n"
+                 f"> Could not read packages file ({type(e).__name__}); "
+                 "skipping. Non-blocking.\n")
+            return 0
+
+    rows = []
+    promotable = soaking = unknown = in_stable = 0
+    for name in names:
+        mv = version_at(main_ref, name)
+        sv = version_at(stable_ref, name)
+        if mv is None:
+            # Not a versioned package (meta/renamed); nothing to soak.
+            continue
+        if mv == sv:
+            in_stable += 1
+            if not args.all:  # explicit list: still show it as already-in-stable
+                rows.append((name, mv, "—", sv or "—", "· already in stable"))
+            continue
+        # main differs from stable -> a promotion candidate. Measure its dwell.
+        days = dwell_days(dwell_start(main_ref, name, mv))
+        if days is None:
+            unknown += 1
+            verdict = "❓ dwell unknown"
+            dcell = "—"
+        elif days >= args.min_dwell_days:
+            promotable += 1
+            verdict = "✅ promotable"
+            dcell = str(days)
+        else:
+            soaking += 1
+            verdict = f"⏳ soaking ({days}/{args.min_dwell_days}d)"
+            dcell = str(days)
+        rows.append((name, mv, dcell, sv or "— (new)", verdict))
+        print(f"{name} main={mv} stable={sv} dwell={dcell}d -> {verdict}")
+
+    # Promotable first, then soaking (closest to eligible first), then unknown.
+    def sort_key(r):
+        v = r[4]
+        rank = 0 if v.startswith("✅") else 1 if v.startswith("⏳") else 2 if v.startswith("❓") else 3
+        # within soaking, more-soaked first
+        try:
+            d = -int(r[2])
+        except (ValueError, TypeError):
+            d = 0
+        return (rank, d, r[0])
+    rows.sort(key=sort_key)
+
+    out = [
+        "## dwell report (informational, non-blocking)", "",
+        f"Soak reference: **{args.min_dwell_days} days** dwell in `main` "
+        "(gominimal/inbox#20; Debian britney2 minimum-soak precedent). "
+        "Dwell is git-derived — how long each package's *current* `main` version "
+        "has lived there.", "",
+        f"**{promotable} promotable** · **{soaking} soaking** · "
+        f"**{unknown} dwell-unknown** · {in_stable} already in `stable`.", "",
+    ]
+    if rows:
+        out += [
+            "| package | main version | dwell (days) | stable version | status |",
+            "| --- | --- | ---: | --- | --- |",
+        ]
+        for r in rows:
+            out.append("| " + " | ".join(md_cell(c) for c in r) + " |")
+    else:
+        out.append("_No packages differ between `main` and `stable`._")
+    out += [
+        "",
+        "> Report-only; intentionally excluded from branch-protection required "
+        "checks. ✅ = its `main` version has soaked long enough to promote to "
+        "`stable` *today*; ⏳ = still soaking; ❓ = dwell not derivable from git.",
+    ]
+    emit("\n".join(out) + "\n")
+    return 0  # report-only: success regardless of verdicts
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dwell.yml
+++ b/.github/workflows/dwell.yml
@@ -1,0 +1,85 @@
+name: dwell
+
+# REPORT-ONLY, NON-BLOCKING. Computes each package's git-derived DWELL in `main`
+# (how long its current version has lived there) and reports which packages have
+# soaked >= the reference minimum (7d, gominimal/inbox#20) and are therefore
+# eligible to promote main -> stable. It writes nothing to the tree, needs no
+# secrets, and MUST NOT be added to branch-protection required checks — this is
+# the "report-only spec first" step of the promotion criteria (inbox#20/#21). It
+# complements #279 (upstream version-age advisory) and #280 (stable closure).
+#
+# Pure git: no `minimal dump`, no network. The dwell walk is a per-package
+# `git log -S` pickaxe over first-parent `main` history.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "17 6 * * *" # daily "what's promotable to stable" dashboard
+  pull_request:
+    branches: ["stable"] # promotion PRs: per-changed-package dwell (gate preview)
+
+# Least privilege. Posts via GITHUB_STEP_SUMMARY, which needs no write scope.
+permissions:
+  contents: read
+
+concurrency:
+  group: dwell-${{ github.ref }}
+  cancel-in-progress: true # a superseded report run is worthless; drop it
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to a SHA (matches version-age.yml / aggregate-unstable.yml).
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # full history for the version-introduction pickaxe
+
+      - name: Fetch main + stable refs
+        run: |
+          set -uo pipefail
+          # The dwell walk reads origin/main; the comparison reads origin/stable.
+          # Tolerate a fetch error (stay green; the script resolves refs
+          # defensively and no-ops if one is missing) — never block.
+          git fetch --no-tags --quiet origin main stable \
+            || echo "::warning::could not fetch main/stable (non-blocking)"
+
+      - name: Package set
+        id: pkgset
+        env:
+          # SHAs via env per repo convention (zizmor template-injection), not
+          # inline ${{ }} in run:.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            # Promotion PR into stable: report dwell of each package it changes.
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'packages/*/build.ncl' \
+              | cut -d/ -f2 | sort -u > pkgs.txt || : > pkgs.txt
+            echo "mode=file" >> "$GITHUB_OUTPUT"
+            echo "count=$(wc -l < pkgs.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          else
+            : > pkgs.txt # --all computes the differing set itself
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+            echo "count=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dwell report
+        if: steps.pkgset.outputs.count != '0'
+        run: |
+          set -uo pipefail
+          # Report-only: the script returns 0 for any verdict; a genuine
+          # programming error is downgraded to a warning so the check never reds.
+          if [ "${{ steps.pkgset.outputs.mode }}" = "file" ]; then
+            python3 .github/scripts/dwell_report.py --packages-file pkgs.txt --min-dwell-days 7 \
+              || echo "::warning::dwell report hit an internal error; see logs (non-blocking)"
+          else
+            python3 .github/scripts/dwell_report.py --all --min-dwell-days 7 \
+              || echo "::warning::dwell report hit an internal error; see logs (non-blocking)"
+          fi
+
+      - name: No package changes
+        if: steps.pkgset.outputs.count == '0'
+        run: echo "No packages/*/build.ncl changed by this promotion PR — nothing to report." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The soak gate for `main` → `stable` promotion is **dwell** — how long a package's *current version* has lived on `main` (git-derived) — per the key reframe in gominimal/inbox#20. The two supporting-data checks already landed report-only (#279 upstream version-age, #280 stable runtime-closure); **the dwell signal itself was the missing piece.** This adds it, report-only, matching the "spec-first, gate later" strategy.

## What

**`.github/scripts/dwell_report.py`** — for each package, finds the commit date at which its current `main` version was introduced (a single `git log -S` pickaxe on the quoted version token, first-parent — so a non-version edit to `build.ncl` doesn't reset the clock, and a version prefix like `1.2.3` can't false-match `1.2.30`). Compares `main` vs `stable` and classifies each package:

- ✅ **promotable** — differs from `stable` and has dwelled ≥ 7d in `main`
- ⏳ **soaking** — differs from `stable`, < 7d
- · already in `stable`

Pure git: **no `minimal dump`, no network, no secrets.** Runs the full catalog in ~10s.

**`.github/workflows/dwell.yml`** — runs it:
- `workflow_dispatch` + daily `schedule` → full-catalog "what's promotable to `stable`" dashboard
- `pull_request` into `stable` → per-changed-package dwell (the promotion gate preview)

Hardened exactly like `version-age.yml` (pinned action SHA, env-passed SHAs, `contents: read`, report-only) and **must not be added to branch-protection required checks**.

## Sample output (full catalog, today)

> **70 promotable · 77 soaking · 0 dwell-unknown · 229 already in `stable`.**

| package | main version | dwell (days) | stable version | status |
| --- | --- | ---: | --- | --- |
| bun | 1.3.14 | 35 | 1.3.13 | ✅ promotable |
| binutils | 2.46.1 | 31 | 2.46.0 | ✅ promotable |
| caddy | 2.11.4 | 32 | 2.11.3 | ✅ promotable |
| abseil-cpp | 20260526.0 | 2 | 20250814.1 | ⏳ soaking (2/7d) |
| codex | 0.144.1 | 2 | 0.130.0 | ⏳ soaking (2/7d) |

## Notes
- Validated locally on Python 3.9 and the CI runner's 3.12 (git `%cI` emits a trailing `Z`, normalized for `fromisoformat` compatibility below 3.11).
- The `pull_request: [stable]` trigger activates once this file reaches `stable` (GitHub reads the workflow from the PR base branch); the dispatch/schedule modes work immediately from `main`.
- Report-only: never blocks, intentionally excluded from required checks. Wire to *required* only after watching it run on real promotions (inbox#20 strategy).

Closes part of gominimal/inbox#20 (dwell soak criterion) · building block for gominimal/inbox#21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
