### PR TITLE
ci: least-privilege permissions on test-runner workflow (token read-only prep)

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -3,6 +3,9 @@ name: Test Self-Hosted Runner
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: minimal-ubuntu-latest


### PR DESCRIPTION
## Why

The gominimal org is flipping the default `GITHUB_TOKEN` to **read-only**. To make that flip a no-op, every workflow needs an explicit least-privilege `permissions:` block so its access does not silently change when the org default flips.

## What

Adds a top-level block to `.github/workflows/test-runner.yml`:

```yaml
permissions:
  contents: read
```

This is a `workflow_dispatch` checkout + diagnostic test-run workflow (checkout, then `echo`/`ls` of runner info). It performs **no writes** with the repo `GITHUB_TOKEN`, so `contents: read` is the verified least-privilege block — checkout still works, nothing else is needed.

## Impact

- Clears the karkinos `github/actions-missing-permissions` finding for this workflow.
- De-risks the org default-token read-only flip tracked in gominimal/inbox#273 — after this, the flip is a no-op for this workflow.

No other changes.
