### PR TITLE
dune, jemalloc: make version_check tests resilient to upgrades

### DIFF
--- a/packages/dune/build.ncl
+++ b/packages/dune/build.ncl
@@ -61,7 +61,7 @@ let version = "3.20.2" in
         class = 'Standalone,
         test_deps = [base, grep, coreutils],
         cmds = [
-          ["/bin/bash", "-c", "/usr/bin/dune --version | grep -q '3.20.2'"],
+          ["/bin/bash", "-c", "/usr/bin/dune --version | grep -q '%{version}'"],
         ],
       } | Test,
     # The real proof dune works as a build tool: scaffold a tiny dune project,

--- a/packages/jemalloc/build.ncl
+++ b/packages/jemalloc/build.ncl
@@ -75,7 +75,7 @@ let version = "5.3.1" in
             "-c",
             "cat > t.c <<'EOF'\n#include <jemalloc/jemalloc.h>\n#include <stdio.h>\nint main() {\n  void *p = mallocx(64, 0);\n  if (!p) return 1;\n  dallocx(p, 0);\n  printf(\"ok\\n\");\n  return 0;\n}\nEOF\ngcc t.c -o t $(pkg-config --cflags --libs jemalloc)\n./t | grep -q '^ok$'",
           ],
-          ["/bin/bash", "-c", "jemalloc-config --version | grep -q '^5.3.1'"],
+          ["/bin/bash", "-c", "jemalloc-config --version | grep -q '^%{version}'"],
         ],
       } | Test,
   },


### PR DESCRIPTION
Follow-up to the ocaml 5.5.0 bump (#404), where `version_check` hardcoded `grep -q 5.3.0` and broke the moment the auto-update bumped the version. A fleet sweep found two more packages with the same anti-pattern — `version_check` grepping their **own** version literal:

- **dune** — `dune --version | grep -q 3.20.2`
- **jemalloc** — `jemalloc-config --version | grep -q ^5.3.1`

Both pass now but break on their next bump. Fixed with `%{version}` interpolation (same mechanism `url`/`strip_prefix` use) so the test always checks the CURRENT build version. Interpolation verified.

Left alone: the functional tests (dune project build, jemalloc `mallocx` round-trip) are already version-agnostic; **bc**’s `^4$`/`^3.33$`/`^35$` are arithmetic *results*, not version pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version checks so they automatically validate against the configured build version.
  * Prevented version-check tests from becoming outdated when package versions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->