### PR TITLE
ocaml: Phase A spine (ppxlib, ppx_deriving, ocamlgraph, zarith + leaves)

### DIFF
--- a/packages/cppo/build.ncl
+++ b/packages/cppo/build.ncl
@@ -1,5 +1,5 @@
 # Auto-bootstrapped from https://github.com/ocaml-community/cppo by `pkgmgr bootstrap` (ocaml/dune build).
-let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let ocaml = import "../ocaml/build.ncl" in
 let dune = import "../dune/build.ncl" in
@@ -25,6 +25,7 @@ let version = "1.6.9" in
   ],
   cmd = "./build.sh",
   outputs = {
+    bin = { glob = "usr/bin/cppo" } | OutputBin,
     cppo = { glob = "usr/lib/ocaml/cppo/**", allow_executable = true } | OutputData,
   },
   runtime_deps = [ocaml],

--- a/packages/cppo/build.ncl
+++ b/packages/cppo/build.ncl
@@ -1,0 +1,47 @@
+# Auto-bootstrapped from https://github.com/ocaml-community/cppo by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "1.6.9" in
+{
+  name = "cppo",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml-community/cppo/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "16036d85c11d330a7c8b56f4e071d6bbe86d8937c89d3d79f6eef0e38bdda26a",
+      extract = true,
+      strip_prefix = "cppo-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    cppo = { glob = "usr/lib/ocaml/cppo/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ocaml-community", repo = "cppo" },
+      license_spdx = "BSD-3-Clause",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query cppo | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/cppo/build.sh
+++ b/packages/cppo/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/ocaml-community/cppo (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p cppo -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" cppo

--- a/packages/ocaml-compiler-libs/build.ncl
+++ b/packages/ocaml-compiler-libs/build.ncl
@@ -1,0 +1,49 @@
+# Auto-bootstrapped from https://github.com/janestreet/ocaml-compiler-libs by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "0.17.0" in
+{
+  name = "ocaml-compiler-libs",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "9b9644d7351db699e57ddba7c767bb4153e6e988ccf45ead2fb238a3bd75cdc7",
+      extract = true,
+      strip_prefix = "ocaml-compiler-libs-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  # Discovery default: the single findlib dir. `--from-build` refines this
+  # for a multi-package dune project or a `usr/bin/*` CLI.
+  outputs = {
+    ocaml-compiler-libs = { glob = "usr/lib/ocaml/ocaml-compiler-libs/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "janestreet", repo = "ocaml-compiler-libs" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query ocaml-compiler-libs | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ocaml-compiler-libs/build.sh
+++ b/packages/ocaml-compiler-libs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/janestreet/ocaml-compiler-libs (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p ocaml-compiler-libs -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" ocaml-compiler-libs

--- a/packages/ocamlgraph/build.ncl
+++ b/packages/ocamlgraph/build.ncl
@@ -1,0 +1,49 @@
+# Auto-bootstrapped from https://github.com/backtracking/ocamlgraph by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "2.2.0" in
+{
+  name = "ocamlgraph",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/backtracking/ocamlgraph/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "0c183118bc62fb0851fac5e195293067cf8863edd2dabf322d20583d65bb7758",
+      extract = true,
+      strip_prefix = "ocamlgraph-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  # Discovery default: the single findlib dir. `--from-build` refines this
+  # for a multi-package dune project or a `usr/bin/*` CLI.
+  outputs = {
+    ocamlgraph = { glob = "usr/lib/ocaml/ocamlgraph/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "backtracking", repo = "ocamlgraph" },
+      # TODO: REVIEWER — set license_spdx.
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query ocamlgraph | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ocamlgraph/build.sh
+++ b/packages/ocamlgraph/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/backtracking/ocamlgraph (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p ocamlgraph -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" ocamlgraph

--- a/packages/ppx_derivers/build.ncl
+++ b/packages/ppx_derivers/build.ncl
@@ -1,0 +1,47 @@
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppx_derivers by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "1.2.1" in
+{
+  name = "ppx_derivers",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml-ppx/ppx_derivers/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "b6595ee187dea792b31fc54a0e1524ab1e48bc6068d3066c45215a138cc73b95",
+      extract = true,
+      strip_prefix = "ppx_derivers-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    ppx_derivers = { glob = "usr/lib/ocaml/ppx_derivers/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ocaml-ppx", repo = "ppx_derivers" },
+      license_spdx = "BSD-3-Clause",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query ppx_derivers | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ppx_derivers/build.sh
+++ b/packages/ppx_derivers/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppx_derivers (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p ppx_derivers -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" ppx_derivers

--- a/packages/ppx_deriving/build.ncl
+++ b/packages/ppx_deriving/build.ncl
@@ -1,0 +1,56 @@
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppx_deriving by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let cppo = import "../cppo/build.ncl" in
+let ppx_derivers = import "../ppx_derivers/build.ncl" in
+let ppxlib = import "../ppxlib/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "6.1.2" in
+{
+  name = "ppx_deriving",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml-ppx/ppx_deriving/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "76d759a112a6cd55d6043911a05a21236a44785bf11792612cf5856ed818387b",
+      extract = true,
+      strip_prefix = "ppx_deriving-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    cppo,
+    ocamlfind,
+    ppx_derivers,
+    ppxlib,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  # Discovery default: the single findlib dir. `--from-build` refines this
+  # for a multi-package dune project or a `usr/bin/*` CLI.
+  outputs = {
+    ppx_deriving = { glob = "usr/lib/ocaml/ppx_deriving/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml, ppxlib, ppx_derivers],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ocaml-ppx", repo = "ppx_deriving" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query ppx_deriving | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ppx_deriving/build.sh
+++ b/packages/ppx_deriving/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppx_deriving (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p ppx_deriving -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" ppx_deriving

--- a/packages/ppx_deriving_yojson/build.ncl
+++ b/packages/ppx_deriving_yojson/build.ncl
@@ -1,0 +1,55 @@
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppx_deriving_yojson by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let yojson = import "../yojson/build.ncl" in
+let ppx_deriving = import "../ppx_deriving/build.ncl" in
+let ppxlib = import "../ppxlib/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "3.10.0" in
+{
+  name = "ppx_deriving_yojson",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "669a06f573024b5517abb1a89f0cc6eea4a217cb4f17de6cfe618001cbe7df20",
+      extract = true,
+      strip_prefix = "ppx_deriving_yojson-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    yojson,
+    ppx_deriving,
+    ppxlib,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  # Discovery default: the single findlib dir. `--from-build` refines this
+  # for a multi-package dune project or a `usr/bin/*` CLI.
+  outputs = {
+    ppx_deriving_yojson = { glob = "usr/lib/ocaml/ppx_deriving_yojson/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml, yojson, ppx_deriving, ppxlib],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ocaml-ppx", repo = "ppx_deriving_yojson" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query ppx_deriving_yojson | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ppx_deriving_yojson/build.sh
+++ b/packages/ppx_deriving_yojson/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppx_deriving_yojson (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p ppx_deriving_yojson -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" ppx_deriving_yojson

--- a/packages/ppxlib/build.ncl
+++ b/packages/ppxlib/build.ncl
@@ -1,0 +1,57 @@
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppxlib by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let ocaml-compiler-libs = import "../ocaml-compiler-libs/build.ncl" in
+let ppx_derivers = import "../ppx_derivers/build.ncl" in
+let sexplib0 = import "../sexplib0/build.ncl" in
+let stdlib-shims = import "../stdlib-shims/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "0.38.0" in
+{
+  name = "ppxlib",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml-ppx/ppxlib/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "cb88f34179731182aa73bb25e4d081f94a6a9a7f99b1f818ddb2969f97123b19",
+      extract = true,
+      strip_prefix = "ppxlib-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    ocaml-compiler-libs,
+    ppx_derivers,
+    sexplib0,
+    stdlib-shims,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  # Discovery default: the single findlib dir. `--from-build` refines this
+  # for a multi-package dune project or a `usr/bin/*` CLI.
+  outputs = {
+    ppxlib = { glob = "usr/lib/ocaml/ppxlib/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml, ocaml-compiler-libs, ppx_derivers, sexplib0, stdlib-shims],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ocaml-ppx", repo = "ppxlib" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query ppxlib | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ppxlib/build.sh
+++ b/packages/ppxlib/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/ocaml-ppx/ppxlib (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p ppxlib -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" ppxlib

--- a/packages/stdlib-shims/build.ncl
+++ b/packages/stdlib-shims/build.ncl
@@ -1,0 +1,47 @@
+# Auto-bootstrapped from https://github.com/ocaml/stdlib-shims by `pkgmgr bootstrap` (ocaml/dune build).
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let dune = import "../dune/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "0.3.0" in
+{
+  name = "stdlib-shims",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml/stdlib-shims/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "6d0386313a021146300011549180fcd4e94f7ac3c3bf021ff165f6558608f0c2",
+      extract = true,
+      strip_prefix = "stdlib-shims-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    dune,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    stdlib-shims = { glob = "usr/lib/ocaml/stdlib-shims/**", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "ocaml", repo = "stdlib-shims" },
+      license_spdx = "LGPL-2.1-only WITH OCaml-LGPL-linking-exception",
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query stdlib-shims | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/stdlib-shims/build.sh
+++ b/packages/stdlib-shims/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-bootstrapped from https://github.com/ocaml/stdlib-shims (ocaml/dune) by `pkgmgr bootstrap`.
+set -eu
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# Dependencies resolve through findlib from the merged /usr tree; no network.
+export OCAMLPATH="/usr/lib/ocaml"
+export CAML_LD_LIBRARY_PATH="/usr/lib/ocaml/stublibs"
+dune build -p stdlib-shims -j "$(nproc)" @install
+dune install --prefix=/usr --libdir=/usr/lib/ocaml --destdir="$OUTPUT_DIR" stdlib-shims

--- a/packages/zarith/build.ncl
+++ b/packages/zarith/build.ncl
@@ -1,0 +1,54 @@
+# Hand-authored: zarith is NON-dune (./configure + make + `ocamlfind install`)
+# and links system GMP — the T3 "C-system-lib" path, Phase A's capstone.
+let { Attrs, BuildSpec, Local, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let ocaml = import "../ocaml/build.ncl" in
+let ocamlfind = import "../ocamlfind/build.ncl" in
+let make = import "../make/build.ncl" in
+let gmp = import "../gmp/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "1.14" in
+{
+  name = "zarith",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/ocaml/Zarith/archive/refs/tags/release-%{version}.tar.gz",
+      sha256 = "5db9dcbd939153942a08581fabd846d0f3f2b8c67fe68b855127e0472d4d1859",
+      extract = true,
+      strip_prefix = "Zarith-release-%{version}",
+    } | Source,
+    base,
+    ocaml,
+    ocamlfind,
+    make,
+    gmp,
+    pkgconf,
+    toolchain,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    zarith = { glob = "usr/lib/ocaml/zarith/**", allow_executable = true } | OutputData,
+    stublibs = { glob = "usr/lib/ocaml/stublibs/dllzarith.so", allow_executable = true } | OutputData,
+  },
+  runtime_deps = [ocaml, gmp],
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "LGPL-2.0-only WITH OCaml-LGPL-linking-exception",
+      source_provenance = { category = 'GithubRepo, owner = "ocaml", repo = "Zarith" },
+    } | Attrs,
+  tests = {
+    findlib_resolve =
+      {
+        class = 'Standalone,
+        test_deps = [base, ocaml, ocamlfind, toolchain, grep, coreutils],
+        cmds = [
+          ["/bin/bash", "-c", "OCAMLPATH=/usr/lib/ocaml /usr/bin/ocamlfind query zarith | grep -q /usr/lib/ocaml"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/zarith/build.sh
+++ b/packages/zarith/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Hand-authored: zarith builds via ./configure + make (NOT dune) and installs
+# through `ocamlfind install`.
+set -ex
+# Reproducibility (AGENTS.md C/C++): strip the build path + non-deterministic
+# build-id / recorded gcc switches so two builds are byte-identical.
+export CFLAGS="${CFLAGS:-} -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+export BUILD_PATH_PREFIX_MAP="/builddir=$(pwd)"
+# `ocamlfind install` would write into the read-only /usr store (deps mount RO)
+# and edit the shared ld.conf — redirect it into the sandbox output tree instead
+# (de-risk C3: the canonical non-dune OCaml install convention).
+export OCAMLFIND_DESTDIR="$OUTPUT_DIR/usr/lib/ocaml"
+export OCAMLFIND_LDCONF=ignore
+mkdir -p "$OCAMLFIND_DESTDIR/stublibs"
+# configure probes GMP via a -lgmp test-compile; gmp (a build_dep) mounts its
+# headers+lib under /usr, so the default search path resolves it.
+./configure
+make
+make install

--- a/packages/zarith/build.sh
+++ b/packages/zarith/build.sh
@@ -14,7 +14,16 @@ export OCAMLFIND_DESTDIR="$OUTPUT_DIR/usr/lib/ocaml"
 export OCAMLFIND_LDCONF=ignore
 mkdir -p "$OCAMLFIND_DESTDIR/stublibs"
 # configure probes GMP via a -lgmp test-compile; gmp (a build_dep) mounts its
-# headers+lib under /usr, so the default search path resolves it.
+# headers+lib under /usr, so the default search path resolves it. configure feeds
+# $LDFLAGS to gcc via `ocamlc -ccopt` here, so the bare `-Wl,--build-id=none`
+# above is what it needs.
 ./configure
-make
+# project.mak passes $(LDFLAGS) STRAIGHT to `ocamlmklib` (the .cma/.cmxa/libzarith
+# link rules), which has its own option parser and rejects the bare
+# `-Wl,--build-id=none` with "Unknown option" — it only forwards C-linker flags
+# via `-ldopt`. Same var, incompatible consumer, so override it to the `-ldopt`
+# form for `make` only (a make-cmdline assignment overrides the Makefile's
+# `LDFLAGS=`, and LDFLAGS reaches nothing here but ocamlmklib). Keeps the build-id
+# stripped on dllzarith.so for reproducibility without breaking the link.
+make LDFLAGS="-ldopt -Wl,--build-id=none"
 make install


### PR DESCRIPTION
Phase A of the OCaml stack roadmap (follows pkgs#384). Nine offline dune libraries forming the **spine** the aeneas closure builds on. Self-contained: `dune build -p <pkg>` + findlib resolve from the merged `/usr` tree, no network.

**Packages (dependency order):**
- `stdlib-shims`, `ppx_derivers`, `cppo` — ppxlib leaves
- `ocaml-compiler-libs` v0.17.0 — ppxlib dep
- `ppxlib` 0.38.0 — PPX infra; its 2-level offline build validates the merged-`/usr` OCAMLPATH model
- `ppx_deriving` 6.1.2 (+ captures the `cppo` binary), `ppx_deriving_yojson` 3.10.0
- `ocamlgraph` 2.2.0
- `zarith` 1.14 — GMP bignum (GMP probe resolves from the `gmp` build_dep)

Each independently useful (unblocks the importer’s OCaml flavor for real libraries). **PR2** builds the rest of the OCaml → aeneas closure (fpottier web + charon-ml + patched aeneas) on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added packaging support for multiple OCaml libraries/tools, including `cppo`, `ocaml-compiler-libs`, `ocamlgraph`, `ppx_derivers`, `ppx_deriving`, `ppx_deriving_yojson`, `ppxlib`, `stdlib-shims`, and `zarith`.
* **Improvements**
  * Introduced deterministic, reproducible build and install workflows for these packages.
  * Added package metadata, dependency declarations, and install/findlib validation checks to ensure correct resolution after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->