### PR TITLE
ci: notify webapp to rebuild prerender on push to main

### DIFF
--- a/.github/workflows/notify-webapp.yml
+++ b/.github/workflows/notify-webapp.yml
@@ -1,0 +1,36 @@
+name: notify-webapp
+
+# On every push to main, tell gominimal/webapp to rebuild. The webapp
+# prerenders /pkgs and /pkgs/<name> by baking lockStateLatest() at build
+# time, so without this nudge those static pages only refresh on a webapp
+# code deploy and drift from the catalog. The matching trigger lives in
+# webapp/.github/workflows/deploy-cloudrun.yml (repository_dispatch:
+# types: [pkgs-updated]).
+on:
+  push:
+    branches: [main]
+
+# Debounce catalog-commit bursts: a rapid series of package updates
+# cancels superseded notify runs so only the last one dispatches, and the
+# webapp rebuild bakes the latest tip (which already includes every earlier
+# commit in the burst) — one rebuild instead of one per commit.
+concurrency:
+  group: notify-webapp
+  cancel-in-progress: true
+
+# No GITHUB_TOKEN scopes needed — the dispatch authenticates with the
+# cross-repo PAT in WEBAPP_DISPATCH_TOKEN, not the workflow token.
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch webapp prerender rebuild
+        env:
+          GH_TOKEN: ${{ secrets.WEBAPP_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          jq -n --arg sha "$GITHUB_SHA" \
+            '{event_type: "pkgs-updated", client_payload: {sha: $sha}}' \
+            | gh api -X POST /repos/gominimal/webapp/dispatches --input -

--- a/.github/workflows/notify-webapp.yml
+++ b/.github/workflows/notify-webapp.yml
@@ -18,17 +18,28 @@ concurrency:
   group: notify-webapp
   cancel-in-progress: true
 
-# No GITHUB_TOKEN scopes needed — the dispatch authenticates with the
-# cross-repo PAT in WEBAPP_DISPATCH_TOKEN, not the workflow token.
+# No GITHUB_TOKEN scopes needed — the dispatch authenticates with a
+# short-lived token minted from the webapp-deployer GitHub App, matching
+# the org's App-based cross-repo pattern (infra pkgsec #162) rather than a
+# long-lived user PAT.
 permissions: {}
 
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
+      # Mint an installation token scoped to gominimal/webapp only.
+      - name: Mint webapp-deployer token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WEBAPP_DEPLOYER_APP_ID }}
+          private-key: ${{ secrets.WEBAPP_DEPLOYER_PRIVATE_KEY }}
+          owner: gominimal
+          repositories: webapp
       - name: Dispatch webapp prerender rebuild
         env:
-          GH_TOKEN: ${{ secrets.WEBAPP_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           jq -n --arg sha "$GITHUB_SHA" \


### PR DESCRIPTION
Fires a `pkgs-updated` `repository_dispatch` to `gominimal/webapp` on each push to `main`, so the webapp re-bakes its prerendered `/pkgs` set against this repo's new tip.

## Why
webapp prerenders `/pkgs` and `/pkgs/<name>` by baking `lockStateLatest()` at build time; its deploy only ran on its own push-to-main + manual dispatch, so between webapp code deploys the static pages drift from this catalog. Matching trigger (`repository_dispatch: types: [pkgs-updated]`) is in webapp PR #435.

## Debounce
`concurrency: { group: notify-webapp, cancel-in-progress: true }` — a burst of package commits cancels superseded notify runs so only the last dispatches; that one webapp rebuild bakes the latest tip → one rebuild, not one per commit.

## Auth — GitHub App (not a PAT)
Mints a short-lived installation token via `actions/create-github-app-token` (SHA-pinned, v3.2.0), scoped to `gominimal/webapp` only. Follows the org's App-based pattern (infra `pkgsec` #162) instead of a long-lived user PAT. No third-party actions beyond that; `permissions: {}` so the workflow token has no scopes.

**Before this can work**, two repo secrets are needed:
- `WEBAPP_DEPLOYER_APP_ID`
- `WEBAPP_DEPLOYER_PRIVATE_KEY`

…from a `webapp-deployer` GitHub App (org `gominimal`) with **Contents: read & write**, installed on **only** `gominimal/webapp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated notifications to the web application when changes are pushed to the main branch.
  * Rapid successive updates are consolidated to avoid redundant notifications.
  * Notifications include the specific revision associated with the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->