### PR TITLE
ci: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/notify-webapp.yml
+++ b/.github/workflows/notify-webapp.yml
@@ -33,7 +33,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.WEBAPP_DEPLOYER_APP_ID }}
+          # App id is deprecated in favor of client-id. This is the App's
+          # public client id (an identifier, not a credential) — safe to
+          # inline in this public repo; only the private key is a secret.
+          client-id: Iv23lid5yjpQK4fb4g2p
           private-key: ${{ secrets.WEBAPP_DEPLOYER_PRIVATE_KEY }}
           owner: gominimal
           repositories: webapp


### PR DESCRIPTION
Clears the deprecation warning from the `notify-webapp` run: `create-github-app-token` deprecated `app-id` in favor of `client-id`.

Swaps to the App's **public client id** (`Iv23lid5yjpQK4fb4g2p`), inlined — it's an identifier, not a credential, so it neednt be a secret in this public repo. Only `WEBAPP_DEPLOYER_PRIVATE_KEY` stays a secret. Behavior unchanged.

Follow-up: the `WEBAPP_DEPLOYER_APP_ID` repo secret is now unused and can be deleted after this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment notifications to use the current authentication configuration.
  * Prerender rebuild triggers continue to run as expected after package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->