### PR TITLE
attrs: backfill license_spdx for 12 packages (inbox#281 / inbox#53)

### DIFF
--- a/packages/android-sdk/build.ncl
+++ b/packages/android-sdk/build.ncl
@@ -34,6 +34,7 @@ let version = "11076708" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LicenseRef-Android-SDK-Terms",
       binary_from = "https://dl.google.com/android/repository/",
     } | Attrs,
 

--- a/packages/capy/build.ncl
+++ b/packages/capy/build.ncl
@@ -49,6 +49,7 @@ let version = "0.7.0" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "AGPL-3.0-only",
       source_provenance = {
         category = 'GithubRepo,
         owner = "capysc",

--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -63,6 +63,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LicenseRef-Anthropic-Proprietary",
       binary_from = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
       closed_source = true,
 

--- a/packages/cpio/build.ncl
+++ b/packages/cpio/build.ncl
@@ -35,6 +35,7 @@ let version = "2.15" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-3.0-or-later",
       source_provenance = {
         category = 'GnuProject,
         name = "cpio",

--- a/packages/edgedelta/build.ncl
+++ b/packages/edgedelta/build.ncl
@@ -73,6 +73,7 @@ in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LicenseRef-EdgeDelta-Proprietary",
       binary_from = "https://release.edgedelta.com/",
     } | Attrs,
 } | BuildSpec

--- a/packages/libkrun/build.ncl
+++ b/packages/libkrun/build.ncl
@@ -53,6 +53,7 @@ let version = "1.19.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "Apache-2.0",
     source_provenance = {
       category = 'GithubRepo,
       owner = "containers",

--- a/packages/libkrunfw/build.ncl
+++ b/packages/libkrunfw/build.ncl
@@ -62,6 +62,7 @@ let version = "5.5.0" in
 
   attrs = {
     upstream_version = version,
+    license_spdx = "(LGPL-2.1-only AND GPL-2.0-only)",
     source_provenance = {
       category = 'GithubRepo,
       owner = "containers",

--- a/packages/minimal-sshd/build.ncl
+++ b/packages/minimal-sshd/build.ncl
@@ -1,4 +1,4 @@
-let { standaloneTest, BuildSpec, Local, Needs, OutputBin, .. } = import "minimal.ncl" in
+let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
@@ -19,6 +19,12 @@ let toolchain = import "../toolchain/build.ncl" in
       dns = {},
       internet = {},
     } | Needs,
+
+  attrs =
+    {
+      # Internal package: built from Go sources in this repo (Apache-2.0).
+      license_spdx = "Apache-2.0",
+    } | Attrs,
 
   cmd = "./build.sh",
 

--- a/packages/mono/build.ncl
+++ b/packages/mono/build.ncl
@@ -65,6 +65,7 @@ let version = "6.12.0.206" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "(MIT AND BSD-3-Clause)",
       build_cost_multiple = 2,
       source_provenance = {
         category = 'GithubRepo,

--- a/packages/pyelftools/build.ncl
+++ b/packages/pyelftools/build.ncl
@@ -33,6 +33,7 @@ let version = "0.33" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "LicenseRef-Public-Domain",
       source_provenance = {
         category = 'GithubRepo,
         owner = "eliben",

--- a/packages/virtio-kernel-raw/build.ncl
+++ b/packages/virtio-kernel-raw/build.ncl
@@ -30,5 +30,6 @@ let version = "6.12.94" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "GPL-2.0-only",
     } | Attrs,
 } | BuildSpec

--- a/packages/zsh/build.ncl
+++ b/packages/zsh/build.ncl
@@ -51,6 +51,7 @@ let version = "5.9" in
   attrs =
     {
       upstream_version = version,
+      license_spdx = "MIT-Modern-Variant",
     } | Attrs,
 
   tests = {


### PR DESCRIPTION
Verified against each upstream (LICENSE files / project docs), not guessed:

- android-sdk: LicenseRef-Android-SDK-Terms (Google SDK ToS; no OSI id)
- capy: AGPL-3.0-only (upstream LICENSE; note: strongest copyleft in catalog)
- claude-code: LicenseRef-Anthropic-Proprietary
- cpio: GPL-3.0-or-later (GNU cpio)
- edgedelta: LicenseRef-EdgeDelta-Proprietary
- libkrun: Apache-2.0
- libkrunfw: (LGPL-2.1-only AND GPL-2.0-only) - LGPL wrapper bundling the
  GPL-2.0-only kernel (upstream README states both)
- minimal-sshd: Apache-2.0 (internal Go code in this repo; adds its attrs block)
- mono: (MIT AND BSD-3-Clause) - runtime/libs MIT, vendored third-party BSD-3
- pyelftools: LicenseRef-Public-Domain (upstream LICENSE is a PD dedication)
- virtio-kernel-raw: GPL-2.0-only (Linux kernel)
- zsh: MIT-Modern-Variant (Fedora's mapping for the zsh licence)

Deliberately NOT stamped (left for a policy decision, tracked in inbox#281):
base, base-bootstrap, toolchain, resolver-quad8, microvm-rootfs - internal
aggregates whose contents span many licenses; a single id would be wrong.

Coverage: 373/390 -> 385/390.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SPDX license metadata to multiple packages, improving license visibility and compliance information.
  * Included identifiers for open-source, proprietary, and multi-license packages.
  * Package metadata now clearly communicates applicable licensing terms for Android SDK, Capy, Claude Code, CPIO, EdgeDelta, libkrun, Mono, Zsh, and others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->