### PR TITLE
charon: the Rust binary + its nightly rustc-dev toolchain (offline)

### DIFF
--- a/packages/charon/build.ncl
+++ b/packages/charon/build.ncl
@@ -1,0 +1,79 @@
+# AeneasVerif/charon — the Rust binary that reads Rust source and emits the
+# `.llbc` that aeneas consumes. A `rustc_private` tool (charon-driver links the
+# compiler's internal librustc_driver.so), so it builds against the pinned
+# `rust-nightly-charon` toolchain, offline from a vendored crate set.
+#
+# Pinned to commit 5a5017333554ec1e95cae3c4fe05f5bd90b44487 (v0.1.223) — the same
+# commit charon-ml is pinned to. Source is the shared AeneasVerif/charon repo
+# tarball; the 347-crate dependency set is vendored (charon-vendor-*.tar.gz) so
+# the build is hermetic + offline (no `needs { internet }`).
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let zlib = import "../zlib/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let grep = import "../grep/build.ncl" in
+let rust-nightly-charon = import "../rust-nightly-charon/build.ncl" in
+let version = "0.1.223" in
+{
+  name = "charon",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      # The AeneasVerif/charon repo (shared with charon-ml); the Rust workspace
+      # lives in its charon/ subdir.
+      url = "gs://minimal-staging-archives/charon-ml-%{version}.tar.gz",
+      sha256 = "a7953f71f598725eefb33671301a99ae5f683055184a6038f8a0da9fbb8b7d9a",
+      extract = true,
+      strip_prefix = "AeneasVerif-charon-5a50173", # github sha-suffixed top-dir
+    } | Source,
+    {
+      # `cargo vendor` of the charon/ workspace (347 crates + 2 git forks),
+      # extracted by build.sh into charon/vendor/ for an offline build.
+      url = "gs://minimal-staging-archives/charon-vendor-%{version}.tar.gz",
+      sha256 = "ac6f4bb27bc5c80f24cec113d4d5957962d71ac1b7661afbbedfdb8ca020dd1b",
+      extract = false,
+    } | Source,
+    base,
+    rust-nightly-charon,
+    gcc,
+    toolchain,
+  ],
+  runtime_deps = [
+    # charon shells out to `rustc --print sysroot`; charon-driver dynamically
+    # links librustc_driver.so — both need the nightly sysroot present.
+    rust-nightly-charon,
+    glibc,
+    zlib,
+    subsetOf gcc ["libgcc", "libstdcpp"],
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    charon = { glob = "usr/bin/charon" } | OutputBin,
+    charon-driver = { glob = "usr/bin/charon-driver" } | OutputBin,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "AeneasVerif",
+        repo = "charon",
+      },
+      build_cost_multiple = 3,
+    } | Attrs,
+  tests = {
+    runs =
+      {
+        class = 'Standalone,
+        test_deps = [base, rust-nightly-charon, glibc, zlib, gcc, grep],
+        cmds = [
+          # --help is before toolchain resolution, so it doesn't need rustup /
+          # CHARON_TOOLCHAIN_IS_IN_PATH — just proves the binary links + runs.
+          ["/bin/sh", "-c", "/usr/bin/charon --help 2>&1 | grep -qiE 'charon|rustc|cargo|llbc'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/charon/build.sh
+++ b/packages/charon/build.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Build the charon + charon-driver Rust binaries offline against the pinned
+# nightly rustc-dev toolchain (rust-nightly-charon → /usr/bin/rustc,cargo) and
+# the vendored crate set. See build.ncl for the pin + why rustc_private.
+set -eu
+
+# rustc defaults to a `cc` linker the sandbox doesn't have; point it at gcc.
+export CC=gcc
+export LD=gcc
+# Reproducibility (pkgs AGENTS.md, Rust): remap the build path out of debuginfo.
+BUILDROOT="$(pwd)"
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$BUILDROOT=/builddir"
+export CARGO_HOME="$BUILDROOT/.cargo-home"
+VENDOR_TARBALL="$BUILDROOT/charon-vendor-0.1.223.tar.gz"
+
+# The Rust workspace is the repo's charon/ subdir.
+cd charon
+
+# Vendored deps → charon/vendor/ (offline; no network).
+tar -xof "$VENDOR_TARBALL"
+
+# Keep rust-toolchain(.toml): our real cargo (not a rustup proxy) ignores it, so
+# it triggers no toolchain switch — and charon's source `include_str!`s the
+# `rust-toolchain` file at compile time, so deleting it breaks the build.
+
+# Point cargo at the vendored sources (crates.io + the two git forks).
+mkdir -p .cargo
+cat > .cargo/config.toml <<'CFG'
+[source.crates-io]
+replace-with = "vendored-sources"
+[source."git+https://github.com/Nadrieril/serde_state?branch=main"]
+git = "https://github.com/Nadrieril/serde_state"
+branch = "main"
+replace-with = "vendored-sources"
+[source."git+https://github.com/Nadrieril/tracing-tree"]
+git = "https://github.com/Nadrieril/tracing-tree"
+replace-with = "vendored-sources"
+[source.vendored-sources]
+directory = "vendor"
+CFG
+
+export CARGO_NET_OFFLINE=1
+cargo build --offline --release --bin charon --bin charon-driver
+
+install -Dm755 target/release/charon "$OUTPUT_DIR/usr/bin/charon"
+install -Dm755 target/release/charon-driver "$OUTPUT_DIR/usr/bin/charon-driver"

--- a/packages/rust-nightly-charon/build.ncl
+++ b/packages/rust-nightly-charon/build.ncl
@@ -1,0 +1,116 @@
+# The pinned nightly Rust toolchain WITH `rustc-dev` that AeneasVerif/charon
+# needs (`rust-toolchain.toml` → nightly-2026-06-01 + rustc-dev/rust-src). charon
+# is a `rustc_private` tool: it links the compiler's internal crates
+# (librustc_driver, …), so a normal stable `rust` won't do.
+#
+# This is a PREBUILT (binary) toolchain — we mirror the official
+# `static.rust-lang.org/dist/2026-06-01/` component tarballs to gs:// and
+# assemble a sysroot via each component's `install.sh`. A rustc-dev toolchain is
+# a bootstrap tool (rustc's own build ships a binary stage0), so a from-source
+# build buys nothing here; every tarball is pinned by sha256.
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } =
+  import "minimal.ncl"
+in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let zlib = import "../zlib/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let date = "2026-06-01" in
+# An arch-selected component tarball (raw — build.sh runs its install.sh).
+let component = fun base_name amd64_sha arm64_sha =>
+  (match {
+    { arch = 'Amd64, .. } =>
+      {
+        url = "gs://minimal-staging-archives/%{base_name}-%{date}-x86_64-unknown-linux-gnu.tar.xz",
+        sha256 = amd64_sha,
+        extract = false,
+      } | Source,
+    { arch = 'Arm64, .. } =>
+      {
+        url = "gs://minimal-staging-archives/%{base_name}-%{date}-aarch64-unknown-linux-gnu.tar.xz",
+        sha256 = arm64_sha,
+        extract = false,
+      } | Source,
+  }
+  ) target
+in
+{
+  name = "rust-nightly-charon",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    # rustc + cargo + rust-std + rustc-dev, per-arch. rust-src is arch-independent.
+    component
+      "rustc-nightly"
+      "85e06d9b1091f2da0f924172be6861ce072e75ad86eaa6ec13d89e371c72c2e5"
+      "5aff9565275eb446d8d27066ab4339540aff4d294f74be9b099a3a3c7cd155be",
+    component
+      "cargo-nightly"
+      "73f5400ac6e4a789e4253acfa507bfcff786d4a8c9b41d03cedb32428ea3dc68"
+      "3a6193c1897239a1e44f5264f7423db109796c5d5a8e6416e07b39e33b4554f3",
+    component
+      "rust-std-nightly"
+      "b97e4593630291e9666f5da3905e44247eead514951c792b4a606fb08d7f6a3d"
+      "e02008ad12b3c834cf6f384dab677f5a747d28e1cd7522ecf0a88485f118eb4e",
+    component
+      "rustc-dev-nightly"
+      "fbc098037c9fa37a0c2c0bda6151734c204c5ec071071395ccbdf797e865b21d"
+      "1ee8a9d97024ab6379e0ec8c0bfc20a40d99c5b2b745465dc42b84f44db2f7ac",
+    {
+      url = "gs://minimal-staging-archives/rust-src-nightly-%{date}.tar.xz",
+      sha256 = "3ce6b9d679b5d1840d3ed276e74c8d6b4b1da5ebef2eeb542b588de04ada039f",
+      extract = false,
+    } | Source,
+    base,
+    toolchain,
+  ],
+  runtime_deps = [
+    glibc,
+    zlib,
+    subsetOf gcc ["libgcc", "libstdcpp"],
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    rustc = { glob = "usr/bin/rustc" } | OutputBin,
+    cargo = { glob = "usr/bin/cargo" } | OutputBin,
+    rustdoc = { glob = "usr/bin/rustdoc" } | OutputBin,
+    # librustc_driver + the bundled libLLVM.so* rustc dynamically links (rustc's
+    # RUNPATH is $ORIGIN/../lib). A narrow librustc_driver-only glob silently
+    # dropped libLLVM → rustc exited 127 at runtime. Captured as OutputData (not
+    # OutputLib) because libLLVM-22-*.so is a symlink to libLLVM.so.22.1-*, which
+    # OutputLib's ELF validator rejects ("unknown file magic").
+    libs = { glob = "usr/lib/*.so*", allow_executable = true } | OutputData,
+    rustlib = { glob = "usr/lib/rustlib/**", allow_executable = true } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = "nightly-%{date}",
+      license_spdx = "MIT OR Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "rust-lang",
+        repo = "rust",
+      },
+    } | Attrs,
+  tests = {
+    # The reason this package exists: prove the assembled toolchain can compile a
+    # `rustc_private` crate — i.e. that rustc-dev's internal crates (rustc_driver,
+    # rustc_interface, …) resolve against the sysroot. `--emit=metadata` type-checks
+    # + resolves the extern crates without codegen/link, so no C linker is needed.
+    rustc_private_resolves =
+      {
+        class = 'Standalone,
+        test_deps = [base, glibc, zlib, gcc],
+        cmds = [
+          ["/usr/bin/rustc", "--version"],
+          [
+            "/bin/sh",
+            "-c",
+            "printf '#![feature(rustc_private)]\\nextern crate rustc_driver;\\nextern crate rustc_interface;\\nextern crate rustc_span;\\npub fn main() {}\\n' > /tmp/probe.rs && /usr/bin/rustc --edition 2021 --crate-type=lib --emit=metadata /tmp/probe.rs -o /tmp/probe.rmeta && echo RUSTC_PRIVATE_RESOLVES_OK",
+          ],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/rust-nightly-charon/build.sh
+++ b/packages/rust-nightly-charon/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Assemble the nightly-2026-06-01 rustc-dev sysroot from the official component
+# tarballs (mirrored to gs://). Each tarball ships an `install.sh` that lays its
+# payload into a --prefix; we install them all into one usr/ tree.
+set -eu
+DEST="$OUTPUT_DIR/usr"
+mkdir -p "$DEST"
+# The Source deps land as raw *.tar.xz files in the build cwd (extract = false).
+for f in *.tar.xz; do
+  tar -xof "$f"
+done
+# Run each component's installer into the shared prefix. --disable-ldconfig:
+# the build sandbox has no ldconfig and the sysroot is relocatable anyway.
+for inst in */install.sh; do
+  d=$(dirname "$inst")
+  ( cd "$d" && ./install.sh --prefix="$DEST" --disable-ldconfig )
+done
+# Drop the debug/doc wrapper SCRIPTS we don't ship — rust-gdb/rust-lldb/
+# rust-gdbgui are shell wrappers; charon just needs rustc + cargo + rustdoc.
+rm -f "$DEST"/bin/rust-gdb "$DEST"/bin/rust-gdbgui "$DEST"/bin/rust-lldb
+# The installer writes an uninstall manifest carrying absolute build paths — drop
+# those files so two builds are byte-identical and no sandbox path leaks.
+rm -f "$DEST"/lib/rustlib/manifest-* "$DEST"/lib/rustlib/install.log \
+      "$DEST"/lib/rustlib/rust-installer-version "$DEST"/lib/rustlib/uninstall.sh 2>/dev/null || true


### PR DESCRIPTION
The **Rust half** of the OCaml→aeneas work — the `charon` binary that reads Rust
source and emits the `.llbc` aeneas consumes. This is the last functional piece
before you can verify Rust in a minimal session. Builds **fully offline**, no
`needs { internet }`.

charon is a `rustc_private` tool (charon-driver dynamically links the compiler's
internal `librustc_driver.so`), so it can't use our stable `rust`. Two packages:

### `rust-nightly-charon` — the pinned toolchain (Slice 1)

charon pins `nightly-2026-06-01` + `rustc-dev`/`rust-src`. A **prebuilt binary
toolchain**: mirror the official `static.rust-lang.org` component tarballs (rustc
+ cargo + rust-std + rustc-dev per-arch, rust-src common; x86_64 **and** aarch64,
~470 MB, sha256-pinned) to gs://, assemble one sysroot via each component's
`install.sh`. A rustc-dev toolchain is a bootstrap tool (rustc's own build ships a
binary stage0), so a from-source build buys nothing.

Verified in-sandbox by a standalone test that **compiles a `rustc_private` crate**
(`extern crate rustc_driver`) with the assembled rustc.

### `charon` — the binary (Slices 2+3)

Source is the shared AeneasVerif/charon repo (pin `5a50173`, v0.1.223 — the
charon-ml commit). Its 347-crate dep set is **vendored** (`cargo vendor` →
`charon-vendor-0.1.223.tar.gz`, 55 MB) and extracted into `charon/vendor` for
`cargo build --offline`. Builds both `charon` (frontend) and `charon-driver` (the
rustc_private worker).

Each build snag the sandbox surfaced is handled + commented: linker (`cc`→gcc),
keeping `rust-toolchain` (the real cargo ignores it, but charon `include_str!`s it
at compile time), and the toolchain's bundled `libLLVM.so` (a broad output glob —
a narrow one silently dropped it → rustc exited 127).

### Verification

`minimal check` is **14/14 green on both packages**, including standalone tests:
the toolchain compiles a rustc_private crate, and `charon --help` runs
(charon: 13 MB, charon-driver: 17 MB aarch64 ELF).

### ⚠️ Reviewer notes

- **Slice 4 (aeneas wiring) is a follow-up, gated on #408.** Wiring `charon` into
  `aeneas`'s `runtime_deps` + an aeneas loadout can't happen here — the `aeneas`
  package only exists on #408, not on `main` yet. It's a small follow-up once #408
  merges.
- **Runtime contract:** charon needs the nightly rustc on PATH + env
  `CHARON_TOOLCHAIN_IS_IN_PATH=1` (it otherwise demands rustup). That env + PATH
  wiring is the aeneas loadout's job (Slice 4). `runtime_deps` already carries the
  toolchain (charon shells to `rustc --print sysroot`; charon-driver links
  librustc_driver.so).
- **Heavy build** (`build_cost_multiple = 3`): a cold offline compile of 347
  crates against rustc-dev.

Design + de-risk write-up: `CHARON_RUST_PR_PLAN_2026-07-14.md` (pkgmgr-rs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
