### PR TITLE
chromium-bin: source true Chromium on amd64, not Chrome for Testing (inbox#284)

### DIFF
--- a/packages/chromium-bin/README.md
+++ b/packages/chromium-bin/README.md
@@ -1,9 +1,11 @@
 # chromium-bin
 
 Prebuilt full Chromium browser binary, used in headed mode. amd64 comes
-from Google's Chrome for Testing bucket; arm64 comes from Playwright's
+from Chromium's official snapshot bucket (true Chromium — Chrome for
+Testing is a branded-Chrome build whose ToS forbids redistribution);
+arm64 comes from Playwright's
 own arm64 build hosted on Microsoft's CDN (Google does not publish
-arm64 under CfT).
+arm64 builds at all).
 
 Sibling package: [`chromium-headless-shell-bin`](../chromium-headless-shell-bin/)
 ships the stripped headless-shell variant used by Playwright/Puppeteer

--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -47,19 +47,25 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # this case. The bare `chromium` name is intentionally left available
 # for a future source-built pkg.
 #
-# Source mix: amd64 comes straight from Google's Chrome for Testing
-# bucket (Playwright's own cdn.playwright.dev URL just redirects there
-# for amd64, and that redirect is unreliable on newer revisions — MS's
-# CDN doesn't host amd64 zips). For linux-arm64 — which Google does
-# not publish under CfT — we use Playwright's own arm64 build hosted
-# on Microsoft's CDN via cdn.playwright.dev. The same Playwright
-# revision identifies matching builds across both arches; the
-# corresponding Chrome version (used to address the CfT bucket) lives
-# in `browser_version`.
+# Source mix — both legs are true open-source Chromium (BSD-3-Clause),
+# deliberately NOT Chrome for Testing: CfT is a *branded Google Chrome*
+# build governed by the Chrome ToS, which does not permit redistribution
+# — and our binary cache redistributes (gominimal/inbox#284). Playwright
+# itself stopped publishing its own linux-x64 Chromium (its registry now
+# fetches CfT directly for x64), so:
+#   amd64 → Chromium's official snapshot bucket
+#     (chromium-browser-snapshots), pinned to `snapshot_position` — the
+#     main-branch position Chrome `browser_version` branched from
+#     (chromiumdash fetch_version), i.e. the same code the arm64 build
+#     was cut from, minus branch cherry-picks.
+#   arm64 → Playwright's own arm64 Chromium build on cdn.playwright.dev
+#     (Google publishes no linux-arm64; Playwright still builds arm64).
 #
 # `revision` is the Playwright browser-revision number from
 # packages/playwright-core/browsers.json. Revision 1217 ↔ Chrome 147.0.7727.15
-# ↔ playwright-core ^1.58.0. Keep in lockstep with chromium-headless-shell-bin.
+# ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
+# `browser_version` bumps. Keep all three in lockstep with
+# chromium-headless-shell-bin.
 #
 # Consumer note (Playwright): files are laid out under
 # /usr/share/playwright-browsers/chromium-<rev>/ in Playwright's
@@ -72,7 +78,8 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # '/bin/chromium-headless-shell' from the headless-shell pkg) to
 # bypass the registry lookup. See packages/chromium-bin/README.md.
 let revision = "1217" in
-let browser_version = "150.0.7871.46" in
+let browser_version = "147.0.7727.15" in
+let snapshot_position = "1596534" in
 {
   name = "chromium-bin",
   build_deps = [
@@ -80,8 +87,8 @@ let browser_version = "150.0.7871.46" in
     match {
       { arch = 'Amd64, .. } =>
         {
-          url = "https://storage.googleapis.com/chrome-for-testing-public/%{browser_version}/linux64/chrome-linux64.zip",
-          sha256 = "ad115a7498a17f53f6ed0914458326c6516addc756224db14c32184a9b1ab078",
+          url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
+          sha256 = "73ccb8d31d7c9e736ef94fcecf74a8e09e3f2fa9fd34d610781ccc44e7b40b69",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
@@ -149,7 +156,7 @@ let browser_version = "150.0.7871.46" in
       },
       binary_from =
         match {
-          { arch = 'Amd64, .. } => "https://storage.googleapis.com/chrome-for-testing-public/%{browser_version}/linux64/chrome-linux64.zip",
+          { arch = 'Amd64, .. } => "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
           { arch = 'Arm64, .. } => "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-linux-arm64.zip",
         } target,
     } | Attrs,

--- a/packages/chromium-bin/build.sh
+++ b/packages/chromium-bin/build.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 # One zip arrives in the cwd. Extract into a scratch dir so we can
 # discover its (arch-dependent) top-level directory name.
 mkdir -p _full
-# amd64 zip from CfT is named chrome-linux64.zip; arm64 zip from
-# Playwright's CDN is chromium-linux-arm64.zip. Each build fetches
-# exactly one zip into the cwd, so a broad glob is fine.
+# amd64 zip from the chromium-browser-snapshots bucket is named
+# chrome-linux.zip; arm64 zip from Playwright's CDN is
+# chromium-linux-arm64.zip. Each build fetches exactly one zip into
+# the cwd, so a broad glob is fine.
 unzip -q chrom*-linux*.zip -d _full
 
 # The zip is expected to extract to exactly one top-level directory —
@@ -18,9 +19,14 @@ if [ "${#entries[@]}" -ne 1 ] || [ ! -d "${entries[0]}" ]; then
 fi
 FULL_INNER=$(basename "${entries[0]}")
 
-# Inner dir differs by arch:
-#   amd64 → chrome-linux64/chrome  (CfT direct)
-#   arm64 → chrome-linux/chrome    (Playwright arm64)
+# Both zips extract to chrome-linux/, but Playwright's x64 registry
+# expects chrome-linux64/chrome (its arm64 registry expects
+# chrome-linux/chrome) — normalize on x86_64 so registry discovery via
+# PLAYWRIGHT_BROWSERS_PATH keeps working on both arches.
+if [ "$(uname -m)" = "x86_64" ] && [ "$FULL_INNER" = "chrome-linux" ]; then
+  mv _full/chrome-linux _full/chrome-linux64
+  FULL_INNER=chrome-linux64
+fi
 
 REV="${MINIMAL_ARG_REVISION}"
 # Shared with chromium-headless-shell-bin so that

--- a/packages/chromium-headless-shell-bin/README.md
+++ b/packages/chromium-headless-shell-bin/README.md
@@ -2,9 +2,10 @@
 
 Prebuilt Chromium headless-shell binary — the stripped headless build
 that Playwright's `chromium.launch()` and Puppeteer drive in default
-headless mode. amd64 comes from Google's Chrome for Testing bucket;
+headless mode. amd64 comes from Chromium's official snapshot bucket (true Chromium
+— Chrome for Testing is branded Chrome, ToS forbids redistribution);
 arm64 comes from Playwright's own arm64 build hosted on Microsoft's
-CDN (Google does not publish arm64 under CfT).
+CDN (Google publishes no linux-arm64 builds at all).
 
 Sibling package: [`chromium-bin`](../chromium-bin/) ships the full
 headed Chromium browser. Each pkg fetches and installs only its own

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -45,16 +45,21 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # rendering (mermaid-cli, e.g.) depend on this pkg alone to avoid
 # pulling the full browser.
 #
-# Source mix mirrors chromium-bin: amd64 from Google's Chrome for
-# Testing bucket, arm64 from Playwright's own arm64 build via
-# cdn.playwright.dev. The same Playwright revision identifies both
-# arches.
+# Source mix mirrors chromium-bin (see its header for the full
+# rationale): both legs are true open-source Chromium, deliberately NOT
+# Chrome for Testing (a branded Google Chrome build whose ToS does not
+# permit redistribution — our cache redistributes, gominimal/inbox#284).
+# amd64 comes from Chromium's official snapshot bucket at
+# `snapshot_position` (the main-branch position `browser_version`
+# branched from); arm64 from Playwright's own arm64 build.
 #
 # `revision` is the Playwright browser-revision number from
 # packages/playwright-core/browsers.json. Revision 1217 ↔ Chrome 147.0.7727.15
-# ↔ playwright-core ^1.58.0. Keep in lockstep with chromium-bin.
+# ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
+# `browser_version` bumps. Keep all three in lockstep with chromium-bin.
 let revision = "1217" in
-let browser_version = "150.0.7871.46" in
+let browser_version = "147.0.7727.15" in
+let snapshot_position = "1596534" in
 {
   name = "chromium-headless-shell-bin",
   build_deps = [
@@ -62,8 +67,8 @@ let browser_version = "150.0.7871.46" in
     match {
       { arch = 'Amd64, .. } =>
         {
-          url = "https://storage.googleapis.com/chrome-for-testing-public/%{browser_version}/linux64/chrome-headless-shell-linux64.zip",
-          sha256 = "0395e5db8d1631d5ed879d4f05fec423425537018fa1d73a58b1ade13288f447",
+          url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
+          sha256 = "77e0566b9059f5f050a0ce0ebf0edd5ad01978d8c82ab77d0ca6ce1aff81665e",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
@@ -131,7 +136,7 @@ let browser_version = "150.0.7871.46" in
       },
       binary_from =
         match {
-          { arch = 'Amd64, .. } => "https://storage.googleapis.com/chrome-for-testing-public/%{browser_version}/linux64/chrome-headless-shell-linux64.zip",
+          { arch = 'Amd64, .. } => "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
           { arch = 'Arm64, .. } => "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
         } target,
     } | Attrs,

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -92,6 +92,16 @@ let snapshot_position = "1596534" in
               url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
               sha256 = "73ccb8d31d7c9e736ef94fcecf74a8e09e3f2fa9fd34d610781ccc44e7b40b69",
             } | Source,
+            # headless_command_resources.pak (the pak implementing --dump-dom &
+            # friends in standalone headless) ships in NO snapshot artifact —
+            # the full build rolls it into chrome's resources.pak. It's tiny
+            # (~3 KB), arch-independent grit data, so borrow it from the
+            # same-branch Playwright arm64 bundle (the arm64 leg's exact
+            # artifact, same pin).
+            {
+              url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
+              sha256 = "6db7041d8a273093b8f2c7a7338766c6d12abb06cd0253fc91feebb71ecd4635",
+            } | Source,
           ],
         # Playwright's arm64 bundle is already complete.
         { arch = 'Arm64, .. } => [],

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -62,23 +62,41 @@ let browser_version = "147.0.7727.15" in
 let snapshot_position = "1596534" in
 {
   name = "chromium-headless-shell-bin",
-  build_deps = [
-    { file = "build.sh" } | Local,
-    match {
-      { arch = 'Amd64, .. } =>
-        {
-          url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
-          sha256 = "77e0566b9059f5f050a0ce0ebf0edd5ad01978d8c82ab77d0ca6ce1aff81665e",
-        } | Source,
-      { arch = 'Arm64, .. } =>
-        {
-          url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-          sha256 = "6db7041d8a273093b8f2c7a7338766c6d12abb06cd0253fc91feebb71ecd4635",
-        } | Source,
-    } target,
-    base,
-    unzip,
-  ],
+  build_deps =
+    [
+      { file = "build.sh" } | Local,
+      match {
+        { arch = 'Amd64, .. } =>
+          {
+            url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
+            sha256 = "77e0566b9059f5f050a0ce0ebf0edd5ad01978d8c82ab77d0ca6ce1aff81665e",
+          } | Source,
+        { arch = 'Arm64, .. } =>
+          {
+            url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
+            sha256 = "6db7041d8a273093b8f2c7a7338766c6d12abb06cd0253fc91feebb71ecd4635",
+          } | Source,
+      } target,
+      base,
+      unzip,
+    ]
+    @ (
+      match {
+        # The snapshot bucket's headless-shell.zip ships only the binary + its
+        # .paks — no icudtl.dat / v8 snapshot / GL fallback libs (the CfT and
+        # Playwright bundles carry them inline). Graft them from the full-browser
+        # zip at the SAME snapshot position; build.sh copies just those members.
+        { arch = 'Amd64, .. } =>
+          [
+            {
+              url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
+              sha256 = "73ccb8d31d7c9e736ef94fcecf74a8e09e3f2fa9fd34d610781ccc44e7b40b69",
+            } | Source,
+          ],
+        # Playwright's arm64 bundle is already complete.
+        { arch = 'Arm64, .. } => [],
+      } target
+    ),
   runtime_deps = [
     bash,
     glibc,

--- a/packages/chromium-headless-shell-bin/build.sh
+++ b/packages/chromium-headless-shell-bin/build.sh
@@ -4,11 +4,14 @@ set -euo pipefail
 # One zip arrives in the cwd. Extract into a scratch dir so we can
 # discover its (arch-dependent) top-level directory name.
 mkdir -p _shell
-# amd64 zip from the chromium-browser-snapshots bucket is named
-# headless-shell.zip; arm64 zip from Playwright's CDN is
-# chromium-headless-shell-linux-arm64.zip. Each build fetches exactly
-# one zip into the cwd, so a broad glob is fine.
-unzip -q *headless-shell*.zip -d _shell
+# The primary zip is arch-specific by NAME, and on amd64 the cwd also
+# holds the arm64 donor zip (for the command-resources pak below), so
+# extraction must be explicit rather than a glob.
+if [ "$(uname -m)" = "x86_64" ]; then
+  unzip -q headless-shell.zip -d _shell
+else
+  unzip -q chromium-headless-shell-linux-arm64.zip -d _shell
+fi
 
 # The zip is expected to extract to exactly one top-level directory —
 # fail loudly if that ever changes.
@@ -47,6 +50,14 @@ if [ "$(uname -m)" = "x86_64" ] && [ "$SHELL_INNER" = "headless-shell" ]; then
     "chrome-linux/vk_swiftshader_icd.json" \
     -d _support
   cp _support/chrome-linux/* "_shell/$SHELL_INNER/"
+
+  # --dump-dom & friends live in headless_command_resources.pak, which no
+  # snapshot artifact ships (the full build rolls it into resources.pak —
+  # which is why chromium-bin's launch_check passes without it). Borrow the
+  # tiny arch-independent pak from the same-branch Playwright arm64 bundle.
+  unzip -q chromium-headless-shell-linux-arm64.zip \
+    "chrome-linux/headless_command_resources.pak" -d _cmdres
+  cp _cmdres/chrome-linux/headless_command_resources.pak "_shell/$SHELL_INNER/"
 fi
 
 # Inner binary differs by source:

--- a/packages/chromium-headless-shell-bin/build.sh
+++ b/packages/chromium-headless-shell-bin/build.sh
@@ -29,6 +29,24 @@ if [ "$(uname -m)" = "x86_64" ] && [ "$SHELL_INNER" = "headless-shell" ]; then
   mv _shell/headless-shell _shell/chrome-headless-shell-linux64
   SHELL_INNER=chrome-headless-shell-linux64
   ln -s headless_shell "_shell/$SHELL_INNER/chrome-headless-shell"
+
+  # The snapshot headless-shell.zip ships only the binary + .paks; the
+  # runtime also needs ICU data, the v8 context snapshot, and the
+  # GL/SwiftShader fallback libs (all of which the CfT and Playwright
+  # bundles carry inline — headless_shell FATALs on missing icudtl.dat).
+  # Graft them from the full-browser zip at the same snapshot position,
+  # which build_deps fetches on amd64 only.
+  mkdir -p _support
+  unzip -q chrome-linux.zip \
+    "chrome-linux/icudtl.dat" \
+    "chrome-linux/v8_context_snapshot.bin" \
+    "chrome-linux/libEGL.so" \
+    "chrome-linux/libGLESv2.so" \
+    "chrome-linux/libvulkan.so.1" \
+    "chrome-linux/libvk_swiftshader.so" \
+    "chrome-linux/vk_swiftshader_icd.json" \
+    -d _support
+  cp _support/chrome-linux/* "_shell/$SHELL_INNER/"
 fi
 
 # Inner binary differs by source:

--- a/packages/chromium-headless-shell-bin/build.sh
+++ b/packages/chromium-headless-shell-bin/build.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 # One zip arrives in the cwd. Extract into a scratch dir so we can
 # discover its (arch-dependent) top-level directory name.
 mkdir -p _shell
-# amd64 zip from CfT is named chrome-headless-shell-linux64.zip;
-# arm64 zip from Playwright's CDN is chromium-headless-shell-linux-arm64.zip.
-# Each build fetches exactly one zip into the cwd, so a broad glob is fine.
-unzip -q chrom*-headless-shell-linux*.zip -d _shell
+# amd64 zip from the chromium-browser-snapshots bucket is named
+# headless-shell.zip; arm64 zip from Playwright's CDN is
+# chromium-headless-shell-linux-arm64.zip. Each build fetches exactly
+# one zip into the cwd, so a broad glob is fine.
+unzip -q *headless-shell*.zip -d _shell
 
 # The zip is expected to extract to exactly one top-level directory —
 # fail loudly if that ever changes.
@@ -18,9 +19,21 @@ if [ "${#entries[@]}" -ne 1 ] || [ ! -d "${entries[0]}" ]; then
 fi
 SHELL_INNER=$(basename "${entries[0]}")
 
-# Inner dir + binary differ by arch:
-#   amd64 → chrome-headless-shell-linux64/chrome-headless-shell  (CfT direct)
-#   arm64 → chrome-linux/headless_shell                          (Playwright arm64)
+# The snapshot zip extracts to headless-shell/headless_shell, but
+# Playwright's x64 registry expects
+# chrome-headless-shell-linux64/chrome-headless-shell — normalize the
+# dir and add a compat symlink so registry discovery keeps working.
+# (arm64 extracts to chrome-linux/headless_shell, which already matches
+# Playwright's arm64 registry.)
+if [ "$(uname -m)" = "x86_64" ] && [ "$SHELL_INNER" = "headless-shell" ]; then
+  mv _shell/headless-shell _shell/chrome-headless-shell-linux64
+  SHELL_INNER=chrome-headless-shell-linux64
+  ln -s headless_shell "_shell/$SHELL_INNER/chrome-headless-shell"
+fi
+
+# Inner binary differs by source:
+#   snapshot amd64 → headless_shell (+ chrome-headless-shell symlink)
+#   Playwright arm64 → headless_shell
 if [ -x "_shell/$SHELL_INNER/chrome-headless-shell" ]; then
   SHELL_BIN=chrome-headless-shell
 elif [ -x "_shell/$SHELL_INNER/headless_shell" ]; then


### PR DESCRIPTION
The amd64 legs shipped Chrome for Testing - a *branded Google Chrome* build
governed by the Chrome ToS, which does not permit redistribution - while
declaring license_spdx BSD-3-Clause (true only of Chromium). Our public
binary cache redistributes, so this was both mislabeled and a ToS problem
(gominimal/inbox#284). Bonus drift: amd64 shipped Chrome 150.0.7871.46 while
arm64 shipped rev-1217 Chromium (147.0.7727.15) - different browser versions
per arch.

Playwright itself no longer publishes linux-x64 Chromium (its registry
fetches CfT directly for x64; verified against playwright-core 1.58/1.59
registry code - the amd64 zips are gone from cdn.playwright.dev after ~rev
1194), so the fix sources amd64 from Chromium's official snapshot bucket at
snapshot_position 1596534 - the main-branch position Chrome 147.0.7727.15
branched from (chromiumdash), i.e. the same code the arm64 build was cut
from, minus branch cherry-picks. arm64 legs unchanged.

build.sh normalizes the snapshot layouts to what Playwright's x64 registry
expects (chrome-linux -> chrome-linux64; headless-shell ->
chrome-headless-shell-linux64 + an in-dir chrome-headless-shell symlink to
headless_shell), so PLAYWRIGHT_BROWSERS_PATH discovery keeps working on both
arches. Layout logic dry-run-verified against the real zips; the amd64
runtime is exercised by this PR's build via the launch_check standalone test.

browser_version corrected to 147.0.7727.15 (a downgrade for amd64 from the
branded 150, and now truthful + arch-consistent). license_spdx BSD-3-Clause
is now accurate on both arches.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
