### PR TITLE
chromium: 147.0.7727.15 -> 151.0.7922.19 (clears ~63 Critical CVEs)

### DIFF
--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -62,7 +62,7 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 #     (Google publishes no linux-arm64; Playwright still builds arm64).
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1217 ↔ Chrome 147.0.7727.15
+# packages/playwright-core/browsers.json. Revision 1233 ↔ Chrome 151.0.7922.19
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with
 # chromium-headless-shell-bin.
@@ -77,9 +77,9 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # If it doesn't, pass `executablePath: '/bin/chromium'` (or
 # '/bin/chromium-headless-shell' from the headless-shell pkg) to
 # bypass the registry lookup. See packages/chromium-bin/README.md.
-let revision = "1217" in
-let browser_version = "147.0.7727.15" in
-let snapshot_position = "1596534" in
+let revision = "1233" in
+let browser_version = "151.0.7922.19" in
+let snapshot_position = "1654408" in
 {
   name = "chromium-bin",
   build_deps = [
@@ -88,12 +88,12 @@ let snapshot_position = "1596534" in
       { arch = 'Amd64, .. } =>
         {
           url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
-          sha256 = "73ccb8d31d7c9e736ef94fcecf74a8e09e3f2fa9fd34d610781ccc44e7b40b69",
+          sha256 = "c094b77ad8d462bacd54769c5aa1fcd2e9d61f9b146796bbcded9276cdc40a5e",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-linux-arm64.zip",
-          sha256 = "563d09cb67274c26eeba36c67032cbc22dc44534259c15ea469dd818725b1139",
+          sha256 = "aacc401c41eb236aff88c8d2a2d2e8f4c5f67ffd5508339ce2542f8470f846f3",
         } | Source,
     } target,
     base,

--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -28,6 +28,7 @@ let libxkbcommon = import "../libxkbcommon/build.ncl" in
 let libxrandr = import "../libxrandr/build.ncl" in
 let libxrender = import "../libxrender/build.ncl" in
 let libxshmfence = import "../libxshmfence/build.ncl" in
+let libxtst = import "../libxtst/build.ncl" in
 let mesa = import "../mesa/build.ncl" in
 let nss = import "../nss/build.ncl" in
 let nspr = import "../nspr/build.ncl" in
@@ -124,6 +125,7 @@ let snapshot_position = "1654408" in
     libxrandr,
     libxrender,
     libxshmfence,
+    libxtst,
     mesa,
     nss,
     nspr,

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -57,9 +57,9 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # packages/playwright-core/browsers.json. Revision 1217 ↔ Chrome 147.0.7727.15
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with chromium-bin.
-let revision = "1217" in
-let browser_version = "147.0.7727.15" in
-let snapshot_position = "1596534" in
+let revision = "1233" in
+let browser_version = "151.0.7922.19" in
+let snapshot_position = "1654408" in
 {
   name = "chromium-headless-shell-bin",
   build_deps =
@@ -69,12 +69,12 @@ let snapshot_position = "1596534" in
         { arch = 'Amd64, .. } =>
           {
             url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
-            sha256 = "77e0566b9059f5f050a0ce0ebf0edd5ad01978d8c82ab77d0ca6ce1aff81665e",
+            sha256 = "4cd2324a9343cf01fa192902c203250f73a14b6e60f4a775f84a2b26314c5cfa",
           } | Source,
         { arch = 'Arm64, .. } =>
           {
             url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-            sha256 = "6db7041d8a273093b8f2c7a7338766c6d12abb06cd0253fc91feebb71ecd4635",
+            sha256 = "ab7a333e423170cda6eb335cdab54920a0f88e5495e1a29f1ae73e3e3da520f4",
           } | Source,
       } target,
       base,
@@ -90,7 +90,7 @@ let snapshot_position = "1596534" in
           [
             {
               url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
-              sha256 = "73ccb8d31d7c9e736ef94fcecf74a8e09e3f2fa9fd34d610781ccc44e7b40b69",
+              sha256 = "c094b77ad8d462bacd54769c5aa1fcd2e9d61f9b146796bbcded9276cdc40a5e",
             } | Source,
             # headless_command_resources.pak (the pak implementing --dump-dom &
             # friends in standalone headless) ships in NO snapshot artifact —
@@ -100,7 +100,7 @@ let snapshot_position = "1596534" in
             # artifact, same pin).
             {
               url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-              sha256 = "6db7041d8a273093b8f2c7a7338766c6d12abb06cd0253fc91feebb71ecd4635",
+              sha256 = "ab7a333e423170cda6eb335cdab54920a0f88e5495e1a29f1ae73e3e3da520f4",
             } | Source,
           ],
         # Playwright's arm64 bundle is already complete.

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -28,6 +28,7 @@ let libxkbcommon = import "../libxkbcommon/build.ncl" in
 let libxrandr = import "../libxrandr/build.ncl" in
 let libxrender = import "../libxrender/build.ncl" in
 let libxshmfence = import "../libxshmfence/build.ncl" in
+let libxtst = import "../libxtst/build.ncl" in
 let mesa = import "../mesa/build.ncl" in
 let nss = import "../nss/build.ncl" in
 let nspr = import "../nspr/build.ncl" in
@@ -132,6 +133,7 @@ let snapshot_position = "1654408" in
     libxrandr,
     libxrender,
     libxshmfence,
+    libxtst,
     mesa,
     nss,
     nspr,

--- a/packages/libxi/build.ncl
+++ b/packages/libxi/build.ncl
@@ -1,0 +1,55 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let xorgproto = import "../xorgproto/build.ncl" in
+
+let libx11 = import "../libx11/build.ncl" in
+let libxext = import "../libxext/build.ncl" in
+let libxfixes = import "../libxfixes/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# X11 Input extension library (libXi.so.6). Pulled in as a runtime dep of
+# libxtst (and, transitively, chromium-bin — Chrome links libXi.so.6). Deps
+# taken straight from libXi-1.8.3's pkg-config: `Requires.private: x11 xext
+# xfixes` (so it links libXfixes too), plus xorgproto for the input/xproto
+# headers.
+let version = "1.8.3" in
+{
+  name = "libxi",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/libXi-%{version}.tar.xz",
+      sha256 = "7ad60056f01af4f786cfe93b3a7707447711626fc8da2637bec71a90409babe5",
+      extract = true,
+      strip_prefix = "libXi-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+    pkgconf,
+    xorgproto,
+  ],
+  runtime_deps = [
+    libx11,
+    libxext,
+    libxfixes,
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    libs = { glob = "usr/lib/libXi.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfigs = { glob = "usr/lib/pkgconfig/*.pc" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/libxi/build.sh
+++ b/packages/libxi/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr --disable-static
+
+make -j$(nproc)
+make DESTDIR="$OUTPUT_DIR" install

--- a/packages/libxtst/build.ncl
+++ b/packages/libxtst/build.ncl
@@ -1,0 +1,55 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let xorgproto = import "../xorgproto/build.ncl" in
+
+let libx11 = import "../libx11/build.ncl" in
+let libxext = import "../libxext/build.ncl" in
+let libxi = import "../libxi/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# X11 Testing extension library (libXtst.so.6) — provides XTest/XRecord.
+# Chrome links libXtst.so.6 directly, so chromium-bin needs it in its runtime
+# closure (147→151 surfaced this: 151 fails to even print --version without it).
+# Deps from libXtst-1.2.5's pkg-config: `Requires.private: x11 xext xextproto
+# xi` (so it links libXi too), plus xorgproto for the record/xext headers.
+let version = "1.2.5" in
+{
+  name = "libxtst",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/libXtst-%{version}.tar.xz",
+      sha256 = "b50d4c25b97009a744706c1039c598f4d8e64910c9fde381994e1cae235d9242",
+      extract = true,
+      strip_prefix = "libXtst-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+    pkgconf,
+    xorgproto,
+  ],
+  runtime_deps = [
+    libx11,
+    libxext,
+    libxi,
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    libs = { glob = "usr/lib/libXtst.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfigs = { glob = "usr/lib/pkgconfig/*.pc" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/libxtst/build.sh
+++ b/packages/libxtst/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr --disable-static
+
+make -j$(nproc)
+make DESTDIR="$OUTPUT_DIR" install


### PR DESCRIPTION
Updates **chromium-bin + chromium-headless-shell-bin** from **147.0.7727.15 →
151.0.7922.19**, clearing ~63 real Critical Chromium CVEs (the bulk of the
current vuln-digest Critical count).

### Why they were stale

After #414 switched the source to true Chromium, both packages sat at
147.0.7727.15 — ~4 Chrome majors behind. On June 30, 147 *was* the latest (0
known CVEs); since then 148–151 shipped with Critical fixes, so 147 is now below
every one of their fix versions. The scan is correct — this is real, not a false
positive.

### What changed (both packages, in lockstep)

chromium here uses **three interlocked version identifiers** + two shas per arch,
all hand-derived:

| identifier | 147 | **151** | source |
|---|---|---|---|
| `browser_version` | 147.0.7727.15 | **151.0.7922.19** | Playwright browsers.json |
| `revision` | 1217 | **1233** | Playwright browsers.json (arm64 is Playwright-gated → 151 is the achievable target) |
| `snapshot_position` | 1596534 | **1654408** | chromiumdash branch pos 1654411 → nearest available amd64 snapshot |

Four binaries fetched + `sha256`'d fresh: `chrome-linux.zip` + `headless-shell.zip`
(amd64 snapshot 1654408), and the arm64 Playwright `chromium` / `headless-shell`
builds at revision 1233.

Static checks green on both (`parse`/`fmt`/`output-naming`/`disallowed-patterns`);
the build-bot verifies extraction + the `chromium --version` smoketest.

### Why by hand

The auto-updater can't resolve chromium's 3-source scheme (Playwright
browsers.json + chromiumdash + snapshot-bucket probe) and currently **fails
silently** on it (your "Create PR" click produced no PR *and* no error). Both the
resolver and the silent-failure recording are being tracked + fixed in
gominimal/pkgmgr-rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
