### PR TITLE
aeneas: wire charon into the package + add the aeneas verification stack (#512)

### DIFF
--- a/packages/aeneas/build.ncl
+++ b/packages/aeneas/build.ncl
@@ -10,8 +10,9 @@
 #   * progress   (progress bar) — cosmetic; stubbed to a no-op reporter.
 #   * domainslib (multicore pool) — aeneas output is deterministic; run sequential.
 # The `charon` Rust binary that produces the .llbc input is a SEPARATE package
-# (a later Rust PR); this package is aeneas's OCaml side, which links charon-ml at
-# build time and shells out to that binary at runtime.
+# (charon, #412) — now carried in runtime_deps so it's on PATH; this package is
+# aeneas's OCaml side, which links charon-ml at build time and shells out to the
+# charon binary at runtime.
 let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let ocaml = import "../ocaml/build.ncl" in
@@ -20,6 +21,7 @@ let ocamlfind = import "../ocamlfind/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let grep = import "../grep/build.ncl" in
 let charon-ml = import "../charon-ml/build.ncl" in
+let charon = import "../charon/build.ncl" in
 let ocamlgraph = import "../ocamlgraph/build.ncl" in
 let ppx_deriving = import "../ppx_deriving/build.ncl" in
 let ppx_deriving_yojson = import "../ppx_deriving_yojson/build.ncl" in
@@ -61,6 +63,7 @@ let version = "20260713" in
     ocaml,
     zarith,
     charon-ml,
+    charon,
   ],
   attrs =
     {

--- a/stacks/aeneas/stack.ncl
+++ b/stacks/aeneas/stack.ncl
@@ -1,0 +1,70 @@
+let { stack, .. } = import "minimal.ncl" in
+# The aeneas verification loadout: everything to take Rust all the way to a
+# machine-checked functional model in one minimal session —
+#
+#   charon rustc foo.rs        # Rust -> foo.llbc  (the charon frontend)
+#   aeneas -backend lean foo.llbc   # .llbc -> Foo.lean  (the translation)
+#   lean Foo.lean              # Lean 4 CHECKS the model
+#
+# It folds in the `ocaml` and `rust` stacks' setup (aeneas is written in OCaml;
+# charon is a rustc_private Rust tool) plus Lean 4 to actually verify the models
+# aeneas emits — so the session is a complete Rust-verification bench, not just a
+# model emitter. Opt-in (no `matches_project_if_any`): a Rust project should get
+# the plain `rust` stack by default; you ask for this one explicitly.
+stack {
+  name = "aeneas",
+
+  build_packages = [
+    # Shared build base (from the ocaml + rust stacks).
+    "gcc",
+    "binutils",
+    "pkgconf",
+    "linux_headers",
+
+    # OCaml dev stack — aeneas is OCaml, and this also lets you build/hack OCaml
+    # in the session (dune + findlib resolve from the merged /usr tree offline).
+    "ocaml",
+    "dune",
+    "ocamlfind",
+
+    # THE Rust toolchain: the pinned nightly with rustc-dev that charon's
+    # `rustc_private` driver links. It's a full toolchain (rustc + cargo +
+    # rust-std), so it serves BOTH charon AND general Rust work — deliberately
+    # NOT the stable `rust` package, which would put a second rustc on PATH that
+    # charon's `rustc --print sysroot` could resolve to (the wrong sysroot, no
+    # librustc_driver).
+    "rust-nightly-charon",
+
+    # The aeneas toolchain: the OCaml translator + the charon Rust frontend
+    # (ships both `charon` and `charon-driver`; charon spawns the driver off PATH).
+    "aeneas",
+    "charon",
+
+    # Lean 4 — the prover for the models aeneas emits, so the loop actually
+    # closes (emit AND check), not just emit `.lean` source.
+    "lean",
+  ],
+
+  build_env_vars = {
+    CC = "gcc",
+
+    # OCaml offline library resolution (from the ocaml stack).
+    OCAMLPATH = "/usr/lib/ocaml",
+    CAML_LD_LIBRARY_PATH = "/usr/lib/ocaml/stublibs",
+
+    # Rust linker via gcc (from the rust stack).
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER = "gcc",
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "gcc",
+
+    # The load-bearing one: charon runs in "toolchain in PATH" mode because there
+    # is no rustup in minimal. Without this, charon panics "Can't find rustup"
+    # (src/bin/charon/main.rs:269). rustc is on PATH via rust-nightly-charon;
+    # charon shells `rustc --print sysroot` at runtime to locate librustc_driver.
+    CHARON_TOOLCHAIN_IS_IN_PATH = "1",
+  },
+
+  # aeneas is a verification tool, not a project builder — there's no canonical
+  # "build this directory". Default to surfacing the toolchain; real use is the
+  # charon -> aeneas -> lean pipeline above, run by hand on a target crate.
+  build_cmd = "aeneas --help",
+}


### PR DESCRIPTION
Closes gominimal/pkgmgr-rs#512 — the final slice of the OCaml→aeneas effort. With `charon` (#412) and `aeneas` (#408) both on main, this wires them into a usable verification loadout.

## The north star
A minimal session where you take Rust all the way to a machine-checked model:
```
charon rustc foo.rs             # Rust  → foo.llbc     (the charon frontend)
aeneas -backend lean foo.llbc   # .llbc → Foo.lean     (the translation)
lean Foo.lean                   # Lean 4 CHECKS the model
```

## Changes
- **`packages/aeneas`** — add `charon` to `runtime_deps`. aeneas shells out to the charon binary at runtime to produce the `.llbc` it consumes; carrying it in `runtime_deps` puts `charon` (and `charon-driver`) on PATH whenever aeneas is installed.
- **`stacks/aeneas/stack.ncl`** — the loadout. Folds in the `ocaml` and `rust` stacks' setup (aeneas is OCaml; charon is a `rustc_private` Rust tool) **plus Lean 4**, so the session emits *and checks* the model, not just emits it.

## Design decisions
- **`rust-nightly-charon` as THE rust toolchain**, not stable `rust`. It's a full toolchain (`rustc` + `cargo` + `rust-std` + `rustc-dev`), so it serves both charon's `rustc_private` linkage and general Rust work. Including stable `rust` too would put a second rustc on PATH that charon's `rustc --print sysroot` could resolve to — the wrong sysroot, no `librustc_driver`.
- **`CHARON_TOOLCHAIN_IS_IN_PATH=1`** — the load-bearing env var. charon runs in "toolchain in PATH" mode because there's no rustup in minimal; without it charon panics `Can't find rustup` (`src/bin/charon/main.rs:269`).
- **Lean included** — it's already packaged (leanprover/lean4: `lean`/`lake`/`leanc`), so the loop closes. Without a prover the loadout could only *emit* `.lean` source.
- **Opt-in** (no `matches_project_if_any`) — a plain Rust project should get the `rust` stack by default; you ask for the aeneas bench explicitly.

## Verification
- `aeneas` static `minimal check` green (parse / imports / fmt / naming / disallowed-patterns); build-dependent checks Skip until built.
- All referenced packages exist on main; charon ships both `charon` + `charon-driver`; rust-nightly-charon ships `rustc`+`cargo`.
- ⏳ **Full `charon → aeneas → lean` e2e** needs the whole closure built (the ~470 MB nightly toolchain + Lean) — running that build now; will confirm the pipeline produces + checks a model before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Aeneas verification environment with Rust, Charon, OCaml, and Lean tooling.
  * Added offline-friendly configuration and cross-platform Rust linking support.
  * Enabled Charon to run directly from the environment without requiring Rustup.
  * Added a validation command that confirms the toolchain is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->