### PR TITLE
pkgconf 3.0.3 + ruby 4.0.6 (unblock the #417 dropouts; pkgconf Critical was a pkgscan FP)

### DIFF
--- a/packages/pkgconf/build.ncl
+++ b/packages/pkgconf/build.ncl
@@ -4,14 +4,14 @@ let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "2.5.1" in
+let version = "3.0.3" in
 {
   name = "pkgconf",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/pkgconf-%{version}.tar.xz",
-      sha256 = "cd05c9589b9f86ecf044c10a2269822bc9eb001eced2582cfffd658b0a50c243",
+      sha256 = "aa033abb2b777ba4e66635495a931e53c49d86e4e4e38af68c0f76d666cbd8cf",
       extract = true,
       strip_prefix = "pkgconf-%{version}",
     } | Source,

--- a/packages/ruby/build.ncl
+++ b/packages/ruby/build.ncl
@@ -16,14 +16,14 @@ let openssl = import "../openssl/build.ncl" in
 let readline = import "../readline/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "4.0.5" in
+let version = "4.0.6" in
 {
   name = "ruby",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-%{version}.tar.gz",
-      sha256 = "7d6149079a63f8ae1d326c9fa65c6019ba2dc3155eae7b39159817911c88958e",
+      sha256 = "837d299e8f7ddf2be31a229a7a7e019d354979825117989acb3b32b1a9be262a",
     } | Source,
     base,
     make,

--- a/packages/ruby/build.ncl
+++ b/packages/ruby/build.ncl
@@ -45,6 +45,9 @@ let version = "4.0.6" in
   ],
 
   cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
   outputs = {
     bins = { glob = "usr/bin/*" } | OutputBin,
     libs = { glob = "usr/lib/libruby*.so*" } | OutputLib,

--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-tar -xof ruby-4.0.5.tar.gz
-cd ruby-4.0.5
+tar -xof "ruby-$MINIMAL_ARG_VERSION.tar.gz"
+cd "ruby-$MINIMAL_ARG_VERSION"
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;


### PR DESCRIPTION
Ships the two members that were dropped from the "Update stacked: 6 packages" run (#417): **pkgconf 2.5.1 → 3.0.3** and **ruby 4.0.5 → 4.0.6**. ruby was only peeled because it depends on pkgconf; the real blocker was a pkgscan false positive on pkgconf.

## Why #417 dropped these

pkgconf's update was flagged **`pkgscan-critical`** and its gs:// mirror withheld → pkgconf dropped → ruby peeled (a new ruby against the old pkgconf would be a broken closure).

**The Critical is a false positive.** Root cause: a **tarball-provenance mismatch**.
- pkgconf's `source_provenance` is `GithubRepo`, so the auto-updater fetched 3.0.3 as a **github git-archive** (`github.com/pkgconf/pkgconf/archive/…/pkgconf-3.0.3.tar.gz`) — the raw source *tree*, including `.github/` CI, `autogen.sh`, and test tooling.
- But the package's real source — and our current 2.5.1 mirror — is the **release tarball** from distfiles, which strips all of that.
- Diffing "stripped release 2.5.1" against "full git tree 3.0.3" makes pkgconf's own release-automation workflow look newly-added, and its SSH deploy-key setup trips the gate:
  ```
  CRIT .github/workflows/release-tarballs.yml:136  CredentialAccess  .ssh/id_
  CRIT .github/workflows/release-tarballs.yml:142  CredentialAccess  .ssh/id_
  ```

Scanning the **actual release tarballs** (2.5.1 → 3.0.3) is completely clean:
```
release 2.5.1 -> release 3.0.3:      Risk -0.0 (CLEAN), 0 findings
release 2.5.1 -> github-archive 3.0.3: Risk 24.0 (CRITICAL), 4 findings (all in .github/)
```
pkgconf 3.0.3 is safe.

## The fix

Source pkgconf from its **release tarball** (mirrored to `gs://minimal-staging-archives/pkgconf-3.0.3.tar.xz`), exactly as the 2.5.1 source already does — not the github archive. This is both the FP fix (like-for-like diff is clean) and simply *correct*: the release tarball ships the pre-generated `configure`; the git archive would need `autogen.sh` (autotools) at build time.

- `pkgconf`: `2.5.1 → 3.0.3` (release tarball, sha `aa033abb…`).
- `ruby`: `4.0.5 → 4.0.6` (unchanged provenance — sources directly from `cache.ruby-lang.org`, sha `837d299e…`).

## Notes
- **pkgconf 2.x → 3.x is a major bump** and pkgconf is a low-level build tool (pkg-config), so its consumers rebuild against it — the buildbot's affected-package rebuild is the real blast-radius check here.
- **Follow-up (the FP class):** the pkgscan diff gate should recognize a release-vs-archive provenance mismatch (or discount `.github/workflows/**`, which is never in the built artifact) so this doesn't recur for other `GithubRepo`-provenance packages whose tracked source is a release tarball. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pkgconf to version 3.0.3.
  * Updated Ruby to version 4.0.6.
  * Refreshed source package checksums for both updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->