### PR TITLE
ocamlgraph: set license_spdx (lint's first real catch; inbox#281)

### DIFF
--- a/packages/ocamlgraph/build.ncl
+++ b/packages/ocamlgraph/build.ncl
@@ -34,7 +34,7 @@ let version = "2.2.0" in
     {
       upstream_version = version,
       source_provenance = { category = 'GithubRepo, owner = "backtracking", repo = "ocamlgraph" },
-      # TODO: REVIEWER — set license_spdx.
+      license_spdx = "LGPL-2.1-only WITH OCaml-LGPL-linking-exception",
     } | Attrs,
   tests = {
     findlib_resolve =


### PR DESCRIPTION
Upstream LICENSE: LGPL 2.1 plus the standard OCaml static-linking special
exception. Replaces the TODO the license-lint (pkgs#413) flagged - its first
real catch. inbox#281.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the package’s license metadata to explicitly identify the LGPL-2.1-only license with the OCaml linking exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->