### PR TITLE
gcloud: build-time assert that the bundle LICENSE stays Apache (inbox#284)

### DIFF
--- a/packages/gcloud/build.sh
+++ b/packages/gcloud/build.sh
@@ -9,6 +9,16 @@ esac
 
 tar -xof "google-cloud-cli-${MINIMAL_ARG_VERSION}-linux-${PLATFORM}.tar.gz"
 
+# Redistribution guard (gominimal/inbox#284): serving this bundle from the
+# public cache is fine because the bundle's own LICENSE is Apache-2.0 — its
+# ToS clauses govern *use of GCP services*, not redistribution of the CLI.
+# If Google ever changes the bundle license, fail loudly so the
+# redistribution question gets re-audited instead of silently shipping.
+grep -q "Apache License" google-cloud-sdk/LICENSE || {
+  echo "gcloud bundle LICENSE no longer mentions the Apache License — re-audit redistribution (gominimal/inbox#284)" >&2
+  exit 1
+}
+
 mkdir -p $OUTPUT_DIR/usr/{bin,lib}
 mv google-cloud-sdk $OUTPUT_DIR/usr/lib/google-cloud-sdk
 


### PR DESCRIPTION
Resolves the #284 gcloud verify item: the bundle's own LICENSE declares
Apache-2.0 for the CLI and its source; the ToS language in it governs use of
GCP services, not redistribution of the CLI - so public-cache redistribution
is fine. Tom's suggestion: guard that conclusion at build time - if Google
ever ships the bundle under different terms, the build fails loudly and the
redistribution question gets re-audited rather than silently shipping.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a license verification check during the Google Cloud CLI build.
  * Builds now stop when the bundled license cannot be validated, helping prevent releases with unexpected licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->