### PR TITLE
node language-servers: private-libexec install + symlink launchers

### DIFF
--- a/packages/bash-language-server/build.ncl
+++ b/packages/bash-language-server/build.ncl
@@ -28,7 +28,7 @@ let version = "5.4.3" in
 
   outputs = {
     bash-language-server = { glob = "usr/bin/bash-language-server" } | OutputBin,
-    libexec = { glob = "usr/lib/node_modules/**" } | OutputData,
+    libexec = { glob = "usr/libexec/bash-language-server/**", allow_executable = true } | OutputData,
   },
 
   attrs =

--- a/packages/bash-language-server/build.sh
+++ b/packages/bash-language-server/build.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
 set -ex
 
-npm install -g --prefix=$OUTPUT_DIR/usr bash-language-server@$MINIMAL_ARG_VERSION
+# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules, which
+# the node/node-lts runtime owns) so the tool can't collide with it; expose thin
+# symlinks on PATH. The inner `#!/usr/bin/env node` shebang is served by
+# coreutils(env)+node, so no shell is needed. (twitchyliquid64 review on #370.)
+npm install -g --prefix="$OUTPUT_DIR/usr/libexec/bash-language-server" bash-language-server@$MINIMAL_ARG_VERSION
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for _bin in "$OUTPUT_DIR/usr/libexec/bash-language-server/bin/"*; do
+  [ -e "$_bin" ] || continue
+  _tool=${_bin##*/}
+  ln -s "../libexec/bash-language-server/bin/$_tool" "$OUTPUT_DIR/usr/bin/$_tool"
+done

--- a/packages/pyright/build.ncl
+++ b/packages/pyright/build.ncl
@@ -29,7 +29,7 @@ let version = "1.1.398" in
   outputs = {
     pyright = { glob = "usr/bin/pyright" } | OutputBin,
     pyright-langserver = { glob = "usr/bin/pyright-langserver" } | OutputBin,
-    libexec = { glob = "usr/lib/node_modules/**" } | OutputData,
+    libexec = { glob = "usr/libexec/pyright/**", allow_executable = true } | OutputData,
   },
 
   attrs =

--- a/packages/pyright/build.sh
+++ b/packages/pyright/build.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
 set -ex
 
-npm install -g --prefix=$OUTPUT_DIR/usr pyright@$MINIMAL_ARG_VERSION
+# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules, which
+# the node/node-lts runtime owns); expose thin symlinks on PATH (pyright ships two
+# bins: pyright + pyright-langserver). The inner `#!/usr/bin/env node` shebang is
+# served by coreutils(env)+node, so no shell is needed. (twitchyliquid64 on #370.)
+npm install -g --prefix="$OUTPUT_DIR/usr/libexec/pyright" pyright@$MINIMAL_ARG_VERSION
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for _bin in "$OUTPUT_DIR/usr/libexec/pyright/bin/"*; do
+  [ -e "$_bin" ] || continue
+  _tool=${_bin##*/}
+  ln -s "../libexec/pyright/bin/$_tool" "$OUTPUT_DIR/usr/bin/$_tool"
+done

--- a/packages/typescript-language-server/build.ncl
+++ b/packages/typescript-language-server/build.ncl
@@ -30,7 +30,7 @@ let version = "4.3.3" in
     typescript-language-server = { glob = "usr/bin/typescript-language-server" } | OutputBin,
     tsserver = { glob = "usr/bin/tsserver" } | OutputBin,
     tsc = { glob = "usr/bin/tsc" } | OutputBin,
-    libexec = { glob = "usr/lib/node_modules/**" } | OutputData,
+    libexec = { glob = "usr/libexec/typescript-language-server/**", allow_executable = true } | OutputData,
   },
 
   attrs =

--- a/packages/typescript-language-server/build.sh
+++ b/packages/typescript-language-server/build.sh
@@ -7,6 +7,18 @@ set -ex
 # 5.9.3 is the latest 5.x, still ships tsserver, and is what
 # typescript-language-server 4.3.3 targets. Pinning also makes this
 # internet-fetching build deterministic instead of tracking npm's `latest`.
-npm install -g --prefix=$OUTPUT_DIR/usr \
+#
+# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules, which
+# node/node-lts own); expose thin symlinks on PATH. Both npm packages land in the
+# one prefix, so all three bins (typescript-language-server, tsc, tsserver) get a
+# launcher. The inner `#!/usr/bin/env node` shebang is served by coreutils+node.
+npm install -g --prefix="$OUTPUT_DIR/usr/libexec/typescript-language-server" \
   typescript-language-server@$MINIMAL_ARG_VERSION \
   typescript@5.9.3
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for _bin in "$OUTPUT_DIR/usr/libexec/typescript-language-server/bin/"*; do
+  [ -e "$_bin" ] || continue
+  _tool=${_bin##*/}
+  ln -s "../libexec/typescript-language-server/bin/$_tool" "$OUTPUT_DIR/usr/bin/$_tool"
+done


### PR DESCRIPTION
Retrofit the three node **language servers** off the global `usr/lib/node_modules` onto the private-libexec method — the same fix as #370, applied to the existing packages that had the same shape.

## Why
twitchyliquid64's review on #370: a node CLI's `usr/lib/node_modules/**` output glob overlaps the **`node`/`node-lts` runtime's** ownership of that path and welds the tool to one node variant.

## What
Each tool now installs into a package-private `usr/libexec/<pkg>` prefix and exposes its bins as **relative symlinks** on PATH (`usr/bin/<tool>` → `../libexec/<pkg>/bin/<tool>`). The inner `#!/usr/bin/env node` shebang is served by `coreutils`(env)+`node`, so `runtime_deps=[coreutils, node]` stays correct — matching `pnpm`/`agent-browser`. (Deliberately **not** a `#!/bin/sh` wrapper: it'd need `bash` in the closure and fail at runtime with "bad interpreter" while still passing `minimal check` — a review pass caught that.)

## Build-proven
Rebuilt all three; every bin verified as a symlink resolving through `libexec` to the node script, zero leak into `usr/lib/node_modules`:
- **bash-language-server** — 1 bin
- **pyright** — 2 bins (`pyright`, `pyright-langserver`)
- **typescript-language-server** — **3 bins** (`typescript-language-server` + `tsc`/`tsserver` from the pinned `typescript@5.9.3`), all present — the multi-bin loop over `bin/*` catches the sibling package's bins

The `typescript@5.9.3` pin is kept verbatim.

Part of the node-packaging cleanup started in #370. Remaining node packages on the old global pattern (`cf`, `mermaid-cli`, `next`, `wrangler`, `capy`) + the `import-wolfi` generator fix are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging for Bash, Pyright, and TypeScript language servers.
  * Fixed command-line entry points so installed tools remain available on the system `PATH`.
  * Ensured executable files are included correctly in packaged releases.
  * Isolated language-server files to prevent conflicts with other installed Node.js packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->