### PR TITLE
fix(ci::minimal_check): free disk space to fix errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
   minimal-check:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+        with:
+            remove_android: true
+            remove_dotnet: true
+            remove_haskell: true
       - uses: actions/checkout@v6
       - uses: gominimal/check@v1
         with:


### PR DESCRIPTION
Its failing due to running out of disk sometimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by freeing unused disk space before minimal checks run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->