### PR TITLE
fix(minimal-sshd): bump x/crypto to v0.52.0 — 7 critical SSH CVEs (4 are auth bypasses)

### DIFF
--- a/packages/minimal-sshd/go.mod
+++ b/packages/minimal-sshd/go.mod
@@ -1,16 +1,16 @@
 module minimal-sshd
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/creack/pty v1.1.24
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/pkg/sftp v1.13.7
-	golang.org/x/crypto v0.45.0
+	golang.org/x/crypto v0.52.0
 )
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/kr/fs v0.1.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )


### PR DESCRIPTION
## Why

`minimal-sshd` is an SSH server. Every advisory here is in `x/crypto`'s **SSH implementation**, so unlike most dependency bumps these are on the service's live threat path — and **four of the seven are authentication bypasses**, which for a service whose entire job is authenticating SSH clients is the worst possible category.

`golang.org/x/crypto` was pinned at **v0.45.0**; all of these are fixed in **v0.52.0**.

## The advisories

**CRITICAL (7)**

| GHSA | Issue |
|---|---|
| `GHSA-f5wc-c3c7-36mc` | agent constraints not dropped when forwarding keys |
| `GHSA-jppx-rxg9-jmrx` | key constraints not enforced |
| `GHSA-x527-x647-q7gg` | `VerifiedPublicKeyCallback` permission-skip enforcement |
| `GHSA-5cgq-3rg8-m6cv` | auth bypass via unenforced `@revoked` status |
| `GHSA-rm3j-f69w-wqmq` | infinite loop on large channel writes |
| `GHSA-89gr-r52h-f8rx` | FIDO/U2F physical-presence check bypass |
| `GHSA-vgwf-h737-ff37` | client can deadlock server on unexpected responses |

**HIGH (2)** — `GHSA-q4h4-gmj2-qvw2` (byte-arithmetic underflow/panic), `GHSA-w879-237q-wc7r` (pathological RSA/DSA parameter DoS).

## Side effects (both checked, both benign)

- **`go` directive `1.24.0` → `1.25.0`** — required by x/crypto v0.52.0. The in-repo `packages/go` toolchain is **1.26.5**, so the sandboxed build is unaffected. This is the only part of the change I'd want a second pair of eyes on.
- **`golang.org/x/sys` `0.38.0` → `0.45.0`** — pulled transitively.

## Notes

**`go.sum` intentionally not added.** This package doesn't track one, and `build.sh` runs `go mod tidy` with `needs.internet` at build time. Adding one here would quietly change the package's convention and isn't needed for the fix — but see below.

Verified with `go build ./...` against the bumped module. The package's own `smoketest` (`/bin/minimal-sshd --help`) exercises the built binary in CI.

## Follow-up worth considering separately

Since this repo has no committed `go.sum` for the package, builds re-resolve dependencies at build time. Go still verifies against the checksum database, so this isn't unpinned in the scary sense — but for a security-sensitive service, a repo-pinned `go.sum` would make the build reproducible and the dependency set reviewable in-diff. Out of scope here; flagging because we just spent a PR on a supply-chain CVE.

Part of the org-wide dependency sweep in gominimal/inbox#322 — this plus the matching bump in `gominimal/infra` clears **all 14 critical Dependabot alerts** across the org.
