### PR TITLE
attrs: mark android-sdk, claude-code, edgedelta non-redistributable

### DIFF
--- a/minimal.toml
+++ b/minimal.toml
@@ -1,5 +1,5 @@
 [stdlib]
-minimum_version = "0.0.15"
+minimum_version = "0.0.18"
 
 [tasks.shell]
 interactive = true

--- a/packages/android-sdk/build.ncl
+++ b/packages/android-sdk/build.ncl
@@ -35,6 +35,7 @@ let version = "11076708" in
     {
       upstream_version = version,
       license_spdx = "LicenseRef-Android-SDK-Terms",
+      redistributable = false,
       binary_from = "https://dl.google.com/android/repository/",
     } | Attrs,
 

--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -64,6 +64,7 @@ in
     {
       upstream_version = version,
       license_spdx = "LicenseRef-Anthropic-Proprietary",
+      redistributable = false,
       binary_from = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
       closed_source = true,
 

--- a/packages/edgedelta/build.ncl
+++ b/packages/edgedelta/build.ncl
@@ -74,6 +74,7 @@ in
     {
       upstream_version = version,
       license_spdx = "LicenseRef-EdgeDelta-Proprietary",
+      redistributable = false,
       binary_from = "https://release.edgedelta.com/",
     } | Attrs,
 } | BuildSpec


### PR DESCRIPTION
Sets `redistributable = false` on the three packages whose upstream terms do not permit redistribution of built binaries. Build infrastructure stops uploading/indexing/sealing them; consumers build locally from the upstream source. Attrs are unhashed — zero rebuilds.

**DRAFT — do not merge until the toolchain gate clears:**
1. gominimal/minimal#861 (the `redistributable` attr class) merges
2. build servers bump their minimal pin and deploy (attr validation is closed — an older toolchain hard-errors on the unknown attr, which would break every graph load of this catalog)

Mark ready-for-review once both are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)