### PR TITLE
Update stacked: 7 packages (#481 minus c-ares)

### DIFF
--- a/packages/alsa-lib/build.ncl
+++ b/packages/alsa-lib/build.ncl
@@ -5,15 +5,15 @@ let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.2.15.3" in
+let version = "1.2.16.1" in
 {
   name = "alsa-lib",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # http://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.15.3.tar.bz2
+      # http://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.16.1.tar.bz2
       url = "gs://minimal-staging-archives/alsa-lib-%{version}.tar.bz2",
-      sha256 = "7b079d614d582cade7ab8db2364e65271d0877a37df8757ac4ac0c8970be861e",
+      sha256 = "f740db7f488255944ffd4428416ee3390a96742856916433df468c281436480e",
       extract = true,
       strip_prefix = "alsa-lib-%{version}",
     } | Source,

--- a/packages/bottom/build.ncl
+++ b/packages/bottom/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "0.14.5" in
+let version = "0.14.6" in
 {
   name = "bottom",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/ClementTsang/bottom/%{version}.tar.gz",
-      sha256 = "fab3c85606973e3011241a420b012fc39525c6a5211fe1ad0b564b02b3ef165c",
+      sha256 = "ec899586164423377ceaf0d15975b8cb4430e47f3c84db0394411048755c1412",
       extract = true,
       strip_prefix = "bottom-%{version}",
     } | Source,

--- a/packages/chezmoi/build.ncl
+++ b/packages/chezmoi/build.ncl
@@ -3,14 +3,14 @@ let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
-let version = "2.71.0" in
+let version = "2.71.1" in
 {
   name = "chezmoi",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/twpayne/chezmoi/v%{version}.tar.gz",
-      sha256 = "77f85f4d164f8ce0fc784b5d6ca86b0576a00729c5b23a113b92665e0509f252",
+      sha256 = "ecbba845ef7b924c510d32a7342727b9889cc8c77a289e3a04b777226ef8938c",
       extract = true,
       strip_prefix = "chezmoi-%{version}",
     } | Source,

--- a/packages/codex/build.ncl
+++ b/packages/codex/build.ncl
@@ -12,14 +12,14 @@ let glibc = import "../glibc/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 let git = import "../git/build.ncl" in
 
-let version = "0.144.5" in
+let version = "0.144.6" in
 {
   name = "codex",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/openai/codex/archive/refs/tags/rust-v%{version}.tar.gz",
-      sha256 = "cecf7b72d24fa720383edbc49c49595f4b3702802ddfba294ee48faffce991b3",
+      sha256 = "f2e8395538dc15fa6092a135d577be50a295faf3116a2248033631001c75c705",
       extract = true,
       strip_prefix = "codex-rust-v%{version}",
     } | Source,

--- a/packages/croc/build.ncl
+++ b/packages/croc/build.ncl
@@ -5,14 +5,14 @@ let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
-let version = "10.4.13" in
+let version = "10.4.14" in
 {
   name = "croc",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/schollz/croc/v%{version}.tar.gz",
-      sha256 = "6c65f5c60d2cc3e189edcdeb791e83f7ee6cf398c5c4437273320d0221d0fff8",
+      sha256 = "3280b690b81520837e4b17bbc4fa3116ad8d534229e4d8ec2bdf017a2ca7755a",
       extract = true,
       strip_prefix = "croc-%{version}",
     } | Source,

--- a/packages/dua/build.ncl
+++ b/packages/dua/build.ncl
@@ -7,14 +7,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let make = import "../make/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
-let version = "2.37.1" in
+let version = "2.38.1" in
 {
   name = "dua",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/Byron/dua-cli/v%{version}.tar.gz",
-      sha256 = "309194f35a6cabe8a91046641680862cbe1e1379f55c88c94337b541ce987969",
+      sha256 = "b30d76e60be8f4928c3b7d5c3cd2d9034d60ad09c7e044bf2056f01e8596f46e",
       extract = true,
       strip_prefix = "dua-cli-%{version}",
     } | Source,

--- a/packages/eza/build.ncl
+++ b/packages/eza/build.ncl
@@ -7,14 +7,14 @@ let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "0.23.4" in
+let version = "0.23.5" in
 {
   name = "eza",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/eza-community/eza/v%{version}.tar.gz",
-      sha256 = "9fbcad518b8a2095206ac385329ca62d216bf9fdc652dde2d082fcb37c309635",
+      sha256 = "bbf179f2611c904014431740b559e8055276c12fcf978a7e31c271663548337f",
       extract = true,
       strip_prefix = "eza-%{version}",
     } | Source,


### PR DESCRIPTION
Unblocks the seven packages in #481 that were held up by one member.

## What happened to #481

`minimal build` failed on **both arches** in 53s. The check run carries no output (`details_url: https://minimal.dev`, empty title/summary — infra#316), so this came from the builder's own log, run `a94de19c`:

```
make[1]: *** [libnode.target.mk:420: .../libnode/src/cares_wrap.o] Error 1
../src/cares_wrap.h:337: note: candidates are:
  Callback(void*, int, int, const hostent*)
  Callback(void*, ares_status_t, size_t, const ares_dns_record_t*)
```

**`c-ares 1.34.7 → 1.34.8` breaks node's `cares_wrap.cc`.** Overload resolution against the c-ares callback signature fails, and `ares_set_servers` / `ares_get_servers_ports` are now deprecated in favour of the `_csv` forms.

The build order confirms the causal chain rather than merely correlating with it:

| package | started | finished |
|---|---|---|
| `c-ares` | 9:40:57 | **9:41:15** ✅ |
| `node` | **9:41:16** | ❌ failed |

node only rebuilt *because* c-ares changed. #481's own build-risk table predicted the dependents (`node`, `node-lts`); the API break is what it couldn't predict.

## This PR

The same 7 packages, at the **same versions and checksums**, taken from #481's branch unmodified:

| package | | |
|---|---|---|
| alsa-lib | 1.2.15.3 | → 1.2.16.1 |
| bottom | 0.14.5 | → 0.14.6 |
| chezmoi | 2.71.0 | → 2.71.1 |
| codex | 0.144.5 | → 0.144.6 |
| croc | 10.4.13 | → 10.4.14 |
| dua | 2.37.1 | → 2.38.1 |
| eza | 0.23.4 | → 0.23.5 |

`c-ares` stays at 1.34.7 — verified by diff against `main` — so neither `node` nor `node-lts` rebuilds. The diff is version + `sha256` only; no other file is touched.

## Still needs doing

**c-ares 1.34.8 needs its own PR**, pairing the bump with either a `cares_wrap` patch or a node version that compiles against the new API. It should not be re-bundled until that's resolved, or it will block whatever it's bundled with again.

Worth flagging that this was a **patch** release. Nothing about 1.34.7 → 1.34.8 signals an API break — which is the argument for the bundle build gate: the cascade is only visible at build time, never from the version number.

#481 can be closed in favour of this.

> [!NOTE]
> #481 also dropped `atuin` before building — `new tarball size differs more than 2x from the previous artifact`, i.e. the resolver likely picked a GitHub auto-archive instead of a release asset. That's a third, separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated ALSA lib to 1.2.16.1.
  * Updated Bottom to 0.14.6.
  * Updated Chezmoi to 2.71.1.
  * Updated Codex to 0.144.6.
  * Updated Croc to 10.4.14.
  * Updated Dua to 2.38.1.
  * Updated Eza to 0.23.5.
  * Updated package sources and verification data to match the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->