### PR TITLE
Update node + c-ares

### DIFF
--- a/packages/c-ares/build.ncl
+++ b/packages/c-ares/build.ncl
@@ -5,14 +5,14 @@ let make = import "../make/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.34.7" in
+let version = "1.34.8" in
 {
   name = "c-ares",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/c-ares/c-ares/releases/download/v%{version}/c-ares-%{version}.tar.gz",
-      sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+      sha256 = "c222b6d681096f9444d2c4863d2c1174019e27cacca0a4a5c114d36dd7d7bf78",
       extract = true,
       strip_prefix = "c-ares-%{version}",
     } | Source,

--- a/packages/node-lts/build.sh
+++ b/packages/node-lts/build.sh
@@ -6,19 +6,6 @@ export CC=gcc
 tar -xof "node-v${MINIMAL_ARG_VERSION}.tar.gz"
 cd "node-v${MINIMAL_ARG_VERSION}"
 
-# c-ares 1.34.7 (upstream PR #1060) changed ares_host_callback to take
-# `const struct hostent *`. node hasn't adopted it yet, so QueryWrap::Callback's
-# non-const `struct hostent* host` no longer matches the typedef and
-# cares_wrap.cc fails to compile against the shared c-ares. Add the const — the
-# callback body only forwards `host` to cares_wrap_hostent_cpy(dest, const src),
-# so it's a safe minimal fix. Self-verifying: fail loudly if a future node bump
-# changes the line (drop this patch once node ships a c-ares>=1.34.7 cares_wrap).
-sed -i 's/^\(\s*\)struct hostent\* host) {$/\1const struct hostent* host) {/' src/cares_wrap.h
-grep -q 'const struct hostent\* host) {' src/cares_wrap.h || {
-  echo "ERROR: cares_wrap.h const-hostent patch did not apply (node source changed?)" >&2
-  exit 1
-}
-
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;
   aarch64) MARCH="-march=armv8-a" ;;

--- a/packages/node/build.sh
+++ b/packages/node/build.sh
@@ -6,19 +6,6 @@ export CC=gcc
 tar -xof "node-${MINIMAL_ARG_VERSION}.tar.gz"
 cd "node-${MINIMAL_ARG_VERSION}"
 
-# c-ares 1.34.7 (upstream PR #1060) changed ares_host_callback to take
-# `const struct hostent *`. node hasn't adopted it yet, so QueryWrap::Callback's
-# non-const `struct hostent* host` no longer matches the typedef and
-# cares_wrap.cc fails to compile against the shared c-ares. Add the const — the
-# callback body only forwards `host` to cares_wrap_hostent_cpy(dest, const src),
-# so it's a safe minimal fix. Self-verifying: fail loudly if a future node bump
-# changes the line (drop this patch once node ships a c-ares>=1.34.7 cares_wrap).
-sed -i 's/^\(\s*\)struct hostent\* host) {$/\1const struct hostent* host) {/' src/cares_wrap.h
-grep -q 'const struct hostent\* host) {' src/cares_wrap.h || {
-  echo "ERROR: cares_wrap.h const-hostent patch did not apply (node source changed?)" >&2
-  exit 1
-}
-
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;
   aarch64) MARCH="-march=armv8-a" ;;


### PR DESCRIPTION
Bump c-ares, remove the patch that was necessary for `1.34.7` which was apparently an accidental breakage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled networking library to a newer release, bringing the latest maintenance updates.
  - Simplified Node.js build preparation by removing an obsolete compatibility adjustment.
  - Preserved existing build outputs, configuration, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->