### PR TITLE
Update stacked: fontconfig 2.18.2 + pango 1.58.0

### DIFF
--- a/packages/fontconfig/build.ncl
+++ b/packages/fontconfig/build.ncl
@@ -12,15 +12,15 @@ let freetype = import "../freetype/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "2.17.1" in
+let version = "2.18.2" in
 {
   name = "fontconfig",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/2.17.1/fontconfig-2.17.1.tar.xz
+      # https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/2.17.1/fontconfig-2.18.2.tar.xz
       url = "gs://minimal-staging-archives/fontconfig-%{version}.tar.xz",
-      sha256 = "9f5cae93f4fffc1fbc05ae99cdfc708cd60dfd6612ffc0512827025c026fa541",
+      sha256 = "cf8e6576ef0484c15079bdaf77cd9c51c464df5365814ada4d3ee7331ea31eb5",
       extract = true,
       strip_prefix = "fontconfig-%{version}",
     } | Source,

--- a/packages/fontconfig/build.ncl
+++ b/packages/fontconfig/build.ncl
@@ -18,7 +18,7 @@ let version = "2.18.2" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/2.17.1/fontconfig-2.18.2.tar.xz
+      # https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/2.18.2/fontconfig-2.18.2.tar.xz
       url = "gs://minimal-staging-archives/fontconfig-%{version}.tar.xz",
       sha256 = "cf8e6576ef0484c15079bdaf77cd9c51c464df5365814ada4d3ee7331ea31eb5",
       extract = true,

--- a/packages/pango/build.ncl
+++ b/packages/pango/build.ncl
@@ -13,14 +13,14 @@ let freetype = import "../freetype/build.ncl" in
 let cairo = import "../cairo/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "1.56.4" in
+let version = "1.58.0" in
 {
   name = "pango",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/pango-%{version}.tar.xz",
-      sha256 = "17065e2fcc5f5a5bdbffc884c956bfc7c451a96e8c4fb2f8ad837c6413cb5a01",
+      sha256 = "bc5bad6213ad4886a47d1e80292fd850b64159b50db67917a43d9ea80ee2298a",
       extract = true,
       strip_prefix = "pango-%{version}",
     } | Source,


### PR DESCRIPTION
Bundles #488 and #487, which turn out to be **each other's blocker**.

## Why #488 fails

`minimal build` fails on both arches. The check run has no output (infra#316), and `run.jsonl` doesn't carry it either — the error is only in the per-build log (`59.jsonl`, "Project name: pango"):

```
../pango/pangofc-fontmap.c: In function 'pango_fc_font_map_add_font_file':
../pango/pangofc-fontmap.c:4010:8: error: implicit declaration of function
    'FcFreeTypeQueryAll' [-Wimplicit-function-declaration]
 4010 |   if (!FcFreeTypeQueryAll ((const FcChar8 *) filename, -1, NULL, NULL, set))
```

`FcFreeTypeQueryAll` is a **fontconfig** API. 2.18.2 stops declaring it where pango 1.56.4 expects it, and pango compiles with `-Werror=implicit`, so a missing declaration is fatal rather than a warning.

## Why neither PR can land alone

| PR | change | CI | why |
|---|---|---|---|
| #487 | pango 1.56.4 → **1.58.0** | ✅ | still builds against fontconfig **2.17.1**, where the declaration exists |
| #488 | fontconfig 2.17.1 → **2.18.2** | ❌ | pango **1.56.4** can't compile against it |

Each is green or red purely because of the other's absence. Merging #488 breaks the tree; merging #487 alone leaves fontconfig blocked. Same shape as **#485 (node + c-ares)** — pairing the dependent with its dependency was the fix there too.

Versions and checksums taken unmodified from #487 and #488.

## This is a hypothesis, and the gate should decide it

I have **not** verified against pango's source that 1.58.0 drops or re-guards the `FcFreeTypeQueryAll` call — the combination has never been built anywhere. It's the obvious candidate (1.58.0 postdates fontconfig 2.18), but if CI fails here then pango 1.58.0 is *not* the fix, and fontconfig needs a patch or a newer pango.

If this goes green, #487 and #488 can close in favour of it.

> [!NOTE]
> #488's body also flags **5 new pkgscan signals, risk score 10.0** on the fontconfig bump. That's independent of the build failure and still wants a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Fontconfig to version 2.18.2.
  * Updated Pango to version 1.58.0.
  * Refreshed source package verification data for both libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->