### PR TITLE
ocaml, yojson, dune: fix 404 provenance comment URLs

### DIFF
--- a/packages/dune/build.ncl
+++ b/packages/dune/build.ncl
@@ -12,7 +12,7 @@ let version = "3.24.0" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://github.com/ocaml/dune/releases/download/3.20.2/dune-3.24.0.tbz
+      # https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz
       url = "gs://minimal-staging-archives/dune-%{version}.tbz",
       sha256 = "501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034",
       # minimal's extractor doesn't know `.tbz`; unpack it in build.sh (tar -xf

--- a/packages/ocaml/build.ncl
+++ b/packages/ocaml/build.ncl
@@ -12,7 +12,7 @@ let version = "5.5.0" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://github.com/ocaml/ocaml/releases/download/5.3.0/ocaml-5.5.0.tar.gz
+      # https://github.com/ocaml/ocaml/releases/download/5.5.0/ocaml-5.5.0.tar.gz
       url = "gs://minimal-staging-archives/ocaml-%{version}.tar.gz",
       sha256 = "c018052c8264a3791a8f54f84179e6bcc78ed82eb889bacc2773df445259aed3",
       extract = true,

--- a/packages/yojson/build.ncl
+++ b/packages/yojson/build.ncl
@@ -14,7 +14,7 @@ let version = "3.0.0" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      # https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-3.0.0.tbz
+      # https://github.com/ocaml-community/yojson/releases/download/3.0.0/yojson-3.0.0.tbz
       url = "gs://minimal-staging-archives/yojson-%{version}.tbz",
       sha256 = "99414da7609b92a02474ef4b49ecda15edc8cbba5229341b124e7e4695c39610",
       extract = false,


### PR DESCRIPTION
The upstream-URL comment records the release each package was bumped **from**, not the one it ships. The filename carries the new version while the release-tag directory kept the old one — so all three URLs are dead.

Verified in both directions with `curl`:

| package | comment URL today | corrected |
|---|---|---|
| ocaml | `.../download/5.3.0/ocaml-5.5.0.tar.gz` → **404** | `.../download/5.5.0/...` → **200** |
| yojson | `.../download/2.2.2/yojson-3.0.0.tbz` → **404** | `.../download/3.0.0/...` → **200** |
| dune | `.../download/3.20.2/dune-3.24.0.tbz` → **404** | `.../download/3.24.0/...` → **200** |

## Impact is narrow but real

Only the comment is wrong — `version`, `sha256` and the `gs://` url are all correct, and the shipped artifacts are unaffected. The cost falls on a reviewer who follows the comment to check a bump against upstream and lands on a dead link — which is precisely the moment they need it to work.

**Comment lines only.** No `version`, `sha256` or `url` field is touched, so nothing rebuilds.

## Root cause is fixed

pkgmgr's updater rewrote the *filename* in these comments but not the version *path segment* — one line, and it existed in **both** the single-arch and multi-arch rewriters. Fixed in pkgmgr-rs#550, so future bumps won't reintroduce it.

Found when CodeRabbit flagged the identical defect on fontconfig in #493 (corrected there). These three were surfaced by sweeping every `build.ncl` for a provenance comment containing a version that disagrees with `let version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
