### PR TITLE
Update TCL and Railway

### DIFF
--- a/packages/railway/build.ncl
+++ b/packages/railway/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "4.30.2" in
+let version = "5.27.2" in
 {
   name = "railway",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/railwayapp/cli/v%{version}.tar.gz",
-      sha256 = "6bf10cdc6b57d025ee846c948633d9f596ea7d5842ed8edaa4e7af9fd58efd31",
+      sha256 = "4ea8241d9e9724656c606bfb5aa2cab6092908a5b64026b526eac54a7a4af6f3",
       extract = true,
       strip_prefix = "cli-%{version}",
     } | Source,

--- a/packages/tcl/build.ncl
+++ b/packages/tcl/build.ncl
@@ -5,14 +5,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "8.6.16" in
+let version = "8.6.18" in
 {
   name = "tcl",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/tcl%{version}-src.tar.gz",
-      sha256 = "91cb8fa61771c63c262efb553059b7c7ad6757afa5857af6265e4b0bdc2a14a5"
+      sha256 = "14f9af32b1767ff718477a8f974ad03c34341097e6b43f4ce54644ee974e268e"
     } | Source,
     base,
     make,
@@ -24,6 +24,7 @@ let version = "8.6.16" in
   ],
 
   cmd = "./build.sh",
+  build_args = { include version },
   outputs = {
     "tclsh8.6" = { glob = "usr/bin/tclsh8.6" } | OutputBin,
     libs = { glob = "usr/lib/**/*.{a,so*}" } | OutputLib,

--- a/packages/tcl/build.sh
+++ b/packages/tcl/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-tar -xof tcl8.6.16-src.tar.gz
-cd tcl8.6.16
+tar -xof tcl$MINIMAL_ARG_VERSION-src.tar.gz
+cd tcl$MINIMAL_ARG_VERSION
 
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;
@@ -25,16 +25,20 @@ sed -e "s|$SRCDIR/unix|/usr/lib|" \
     -e "s|$SRCDIR|/usr/include|"  \
     -i tclConfig.sh
 
-sed -e "s|$SRCDIR/unix/pkgs/tdbc1.1.10|/usr/lib/tdbc1.1.10|" \
-    -e "s|$SRCDIR/pkgs/tdbc1.1.10/generic|/usr/include|"     \
-    -e "s|$SRCDIR/pkgs/tdbc1.1.10/library|/usr/lib/tcl8.6|"  \
-    -e "s|$SRCDIR/pkgs/tdbc1.1.10|/usr/include|"             \
-    -i pkgs/tdbc1.1.10/tdbcConfig.sh
+# The bundled tdbc/itcl versions move between Tcl releases, so read them off the source tree.
+TDBC=$(basename "$SRCDIR"/pkgs/tdbc[0-9]*)
+ITCL=$(basename "$SRCDIR"/pkgs/itcl[0-9]*)
 
-sed -e "s|$SRCDIR/unix/pkgs/itcl4.3.2|/usr/lib/itcl4.3.2|" \
-    -e "s|$SRCDIR/pkgs/itcl4.3.2/generic|/usr/include|"    \
-    -e "s|$SRCDIR/pkgs/itcl4.3.2|/usr/include|"            \
-    -i pkgs/itcl4.3.2/itclConfig.sh
+sed -e "s|$SRCDIR/unix/pkgs/$TDBC|/usr/lib/$TDBC|" \
+    -e "s|$SRCDIR/pkgs/$TDBC/generic|/usr/include|" \
+    -e "s|$SRCDIR/pkgs/$TDBC/library|/usr/lib/tcl8.6|" \
+    -e "s|$SRCDIR/pkgs/$TDBC|/usr/include|" \
+    -i pkgs/$TDBC/tdbcConfig.sh
+
+sed -e "s|$SRCDIR/unix/pkgs/$ITCL|/usr/lib/$ITCL|" \
+    -e "s|$SRCDIR/pkgs/$ITCL/generic|/usr/include|" \
+    -e "s|$SRCDIR/pkgs/$ITCL|/usr/include|" \
+    -i pkgs/$ITCL/itclConfig.sh
 
 unset SRCDIR
 


### PR DESCRIPTION
Did locally, check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Railway CLI to version 5.27.2 and refreshed the associated download verification checksum.
  * Updated Tcl source to 8.6.18.
  * Improved the build process to extract Tcl using the computed version and automatically align bundled component configuration updates with the versions present in the source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->