### PR TITLE
Update chromium to 151.0.7922.34 (security update)

### DIFF
--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -63,7 +63,7 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 #     (Google publishes no linux-arm64; Playwright still builds arm64).
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1233 ↔ Chrome 151.0.7922.19
+# packages/playwright-core/browsers.json. Revision 1234 ↔ Chrome 151.0.7922.34
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with
 # chromium-headless-shell-bin.
@@ -78,8 +78,8 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # If it doesn't, pass `executablePath: '/bin/chromium'` (or
 # '/bin/chromium-headless-shell' from the headless-shell pkg) to
 # bypass the registry lookup. See packages/chromium-bin/README.md.
-let revision = "1233" in
-let browser_version = "151.0.7922.19" in
+let revision = "1234" in
+let browser_version = "151.0.7922.34" in
 let snapshot_position = "1654408" in
 {
   name = "chromium-bin",
@@ -94,7 +94,7 @@ let snapshot_position = "1654408" in
       { arch = 'Arm64, .. } =>
         {
           url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-linux-arm64.zip",
-          sha256 = "aacc401c41eb236aff88c8d2a2d2e8f4c5f67ffd5508339ce2542f8470f846f3",
+          sha256 = "b5ad7d8fe70f230b34198ddb5626d717c016db2f627cb44b922babbcaf3479b9",
         } | Source,
     } target,
     base,

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -55,11 +55,11 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # branched from); arm64 from Playwright's own arm64 build.
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1217 ↔ Chrome 147.0.7727.15
+# packages/playwright-core/browsers.json. Revision 1234 ↔ Chrome 151.0.7922.34
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with chromium-bin.
-let revision = "1233" in
-let browser_version = "151.0.7922.19" in
+let revision = "1234" in
+let browser_version = "151.0.7922.34" in
 let snapshot_position = "1654408" in
 {
   name = "chromium-headless-shell-bin",
@@ -75,7 +75,7 @@ let snapshot_position = "1654408" in
         { arch = 'Arm64, .. } =>
           {
             url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-            sha256 = "ab7a333e423170cda6eb335cdab54920a0f88e5495e1a29f1ae73e3e3da520f4",
+            sha256 = "b03443e1e1a60d06e07b6cdfe650b8c2bfcbb3db497d2b652f73dc6912f4ae15",
           } | Source,
       } target,
       base,
@@ -101,7 +101,7 @@ let snapshot_position = "1654408" in
             # artifact, same pin).
             {
               url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-              sha256 = "ab7a333e423170cda6eb335cdab54920a0f88e5495e1a29f1ae73e3e3da520f4",
+              sha256 = "b03443e1e1a60d06e07b6cdfe650b8c2bfcbb3db497d2b652f73dc6912f4ae15",
             } | Source,
           ],
         # Playwright's arm64 bundle is already complete.


### PR DESCRIPTION
Updates **chromium-bin + chromium-headless-shell-bin** from **151.0.7922.19** to **151.0.7922.34** — a Chromium security update (each Chrome major carries Critical fixes).

chromium pins three interlocked identifiers, resolved from three sources:

| identifier | value | source |
|---|---|---|
| `browser_version` | 151.0.7922.34 | Playwright browsers.json |
| `revision` | 1234 | Playwright browsers.json (arm64 legs are Playwright-gated) |
| `snapshot_position` | 1654408 | chromiumdash branch position → nearest available amd64 snapshot |

Four artifacts fetched + `sha256`'d fresh (amd64 `chrome-linux.zip` + `headless-shell.zip` from the snapshot bucket; arm64 `chromium` / `headless-shell` builds at the Playwright revision). Resolved + rewritten by `pkgmgr` (gominimal/pkgmgr-rs#515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
