### PR TITLE
feat(psmisc): package psmisc version 23.7

### DIFF
--- a/packages/psmisc/build.ncl
+++ b/packages/psmisc/build.ncl
@@ -1,0 +1,57 @@
+let { standaloneTest, BuildSpec, Local, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let make = import "../make/build.ncl" in
+let ncurses = import "../ncurses/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "23.7" in
+{
+  name = "psmisc",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://downloads.sourceforge.net/project/psmisc/psmisc/psmisc-%{version}.tar.xz",
+      sha256 = "58c55d9c1402474065adae669511c191de374b0871eec781239ab400b907c327",
+      extract = true,
+      strip_prefix = "psmisc-%{version}",
+    } | Source,
+    base,
+    make,
+    ncurses,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    ncurses,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+
+    mans = { glob = "usr/share/man/**" } | OutputData,
+    locales = { glob = "usr/share/locale/**" } | OutputData,
+  },
+
+  tests = {
+    smoketest = standaloneTest "/bin/killall --version",
+  },
+
+  attrs = {
+    upstream_version = version,
+    source_provenance = {
+      category = 'Gitlab,
+      host = "gitlab.com",
+      owner = "psmisc",
+      repo = "psmisc",
+    },
+    license_spdx = "GPL-2.0-or-later",
+  },
+} | BuildSpec

--- a/packages/psmisc/build.sh
+++ b/packages/psmisc/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export CXXFLAGS="$CFLAGS"
+
+# psmisc's configure looks for tgetent in -ltinfo/-lncurses/-ltermcap, but our
+# ncurses is built wide-character-only (libncursesw). Expose it under the name
+# configure probes for; the linked binaries still record libncursesw.so.6.
+mkdir -p compat-lib
+ln -sf /usr/lib/libncursesw.so compat-lib/libncurses.so
+export LDFLAGS="-Wl,--build-id=none -L$(pwd)/compat-lib"
+
+./configure --prefix=/usr \
+            --docdir=/usr/share/doc/psmisc-$MINIMAL_ARG_VERSION
+
+make -j$(nproc)
+make DESTDIR=$OUTPUT_DIR install


### PR DESCRIPTION
Because i want `killall` lol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `psmisc` package, providing system process-management utilities such as `killall`.
  * Included related documentation and localization files.
  * Added support for the latest upstream `psmisc` 23.7 release.

* **Tests**
  * Added a validation check to confirm the installed utility reports its version correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->