### PR TITLE
feat(rust): update rust to 1.97.1

### DIFF
--- a/packages/rust/bootstrap.toml
+++ b/packages/rust/bootstrap.toml
@@ -1,4 +1,4 @@
-change-id = 142379
+change-id = 154587
 
 [build]
 # When compiling from source, you almost always want a full stage 2 build,
@@ -8,8 +8,6 @@ test-stage = 2
 doc-stage = 2
 # When compiling from source, you usually want all tools.
 extended = true
-# Use libtest built from the source tree instead of the precompiled one from stage 0.
-compiletest-use-stage0-libtest = false
 
 docs = false
 
@@ -19,6 +17,10 @@ link-shared = true
 [rust]
 channel = "stable"
 download-rustc = false
+# Load-bearing beyond just "don't build lld": since rust#147157, an unset `lld`
+# makes x86_64-unknown-linux-gnu default to the self-contained rust-lld linker.
+# Explicit `false` opts that target back out, so built binaries keep linking
+# through cc rather than a rust-lld we don't ship.
 lld = false
 llvm-bitcode-linker = false
 

--- a/packages/rust/build.ncl
+++ b/packages/rust/build.ncl
@@ -11,7 +11,7 @@ let libffi = import "../libffi/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "1.95.0" in
+let version = "1.97.1" in
 {
   name = "rust",
   build_deps = [
@@ -19,7 +19,7 @@ let version = "1.95.0" in
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/rustc-%{version}-src.tar.xz",
-      sha256 = "62b67230754da642a264ca0cb9fc08820c54e2ed7b3baba0289876d4cdb48c08",
+      sha256 = "0ed06fdaffd4722a7702e0b4eebfafc897ab8f513e8e1b247cdd7e5c6df6ded2",
       extract = true,
       strip_prefix = "rustc-%{version}-src",
     } | Source,


### PR DESCRIPTION
`rust` builds locally, will let buildbot try the rest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rust source version used during builds.
  * Updated the corresponding source archive verification checksum.
  * Removed an obsolete compilation configuration setting.
  * Added clarification for the existing linker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->