### PR TITLE
Add zvelte-check-bin 0.2.0

### DIFF
--- a/packages/zvelte-check-bin/build.ncl
+++ b/packages/zvelte-check-bin/build.ncl
@@ -1,0 +1,51 @@
+let { Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# Imported from the Homebrew formula `ampcode/homebrew-tap/zvelte-check` by `pkgmgr import homebrew`.
+#
+# PREBUILT vendor binary — there is no source build. The pinned sha256
+# per architecture is the ONLY integrity anchor for this package.
+let version = "0.2.0" in
+let target_suffix = match { { arch = 'Amd64, .. } => "x86_64", { arch = 'Arm64, .. } => "aarch64" } target in
+{
+  name = "zvelte-check-bin",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://github.com/ampcode/zvelte-check/releases/download/v%{version}/zvelte-check-linux-x86_64.tar.gz",
+          sha256 = "f3326fe48a0a2bc056b16ce424abd705ca7864d3632fd8f02ace1ea8ecfc8b9b",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://github.com/ampcode/zvelte-check/releases/download/v%{version}/zvelte-check-linux-aarch64.tar.gz",
+          sha256 = "05a2661648952ba12b2da618242698c3065d2db375340cb605288a38f59c4105",
+        } | Source,
+    } target,
+    base,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version, arch = target_suffix },
+
+  outputs = {
+    zvelte-check = { glob = "usr/bin/zvelte-check" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "ampcode",
+        repo = "zvelte-check",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/zvelte-check-bin/build.ncl
+++ b/packages/zvelte-check-bin/build.ncl
@@ -1,7 +1,6 @@
 let { Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
 let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
-let glibc = import "../glibc/build.ncl" in
 
 # Imported from the Homebrew formula `ampcode/homebrew-tap/zvelte-check` by `pkgmgr import homebrew`.
 #
@@ -27,9 +26,8 @@ let target_suffix = match { { arch = 'Amd64, .. } => "x86_64", { arch = 'Arm64, 
     } target,
     base,
   ],
-  runtime_deps = [
-    glibc,
-  ],
+  # No runtime_deps: the installed binary is statically linked
+  # (verified against the built tree, not assumed).
 
   cmd = "./build.sh",
   build_args = { include version, arch = target_suffix },

--- a/packages/zvelte-check-bin/build.ncl
+++ b/packages/zvelte-check-bin/build.ncl
@@ -40,6 +40,22 @@ let target_suffix = match { { arch = 'Amd64, .. } => "x86_64", { arch = 'Arm64, 
     {
       upstream_version = version,
       license_spdx = "MIT",
+      # We install upstream's release BINARIES, not a build of the tree below.
+      # `binary_from` is what says so; without it the package reads as
+      # source-built from source_provenance, which is the exact conflation that
+      # let chromium-bin look like a build of microsoft/playwright.
+      binary_from =
+        match {
+          { arch = 'Amd64, .. } => "https://github.com/ampcode/zvelte-check/releases/download/v%{version}/zvelte-check-linux-x86_64.tar.gz",
+          { arch = 'Arm64, .. } => "https://github.com/ampcode/zvelte-check/releases/download/v%{version}/zvelte-check-linux-aarch64.tar.gz",
+        } target,
+      # Kept alongside `binary_from`, as chromium-bin does. Here the two are the
+      # SAME project — ampcode/zvelte-check builds these artifacts in its own
+      # release workflow — so the repo is the honest identity of the bytes, and
+      # dropping it would cost the CPE identity and the GitHub version-check
+      # tier, i.e. make this a dark package. `closed_source` deliberately absent:
+      # the repo is public and MIT with the Zig source in-tree (verified, not
+      # inferred from the formula).
       source_provenance = {
         category = 'GithubRepo,
         owner = "ampcode",

--- a/packages/zvelte-check-bin/build.sh
+++ b/packages/zvelte-check-bin/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Imported from the Homebrew formula `ampcode/homebrew-tap/zvelte-check` by `pkgmgr import homebrew`.
+# Prebuilt vendor binary: unpacked and installed, never compiled.
+set -ex
+
+tar -xof "zvelte-check-linux-${MINIMAL_ARG_ARCH}.tar.gz"
+install -D -m 755 "zvelte-check" "$OUTPUT_DIR/usr/bin/zvelte-check"


### PR DESCRIPTION
A fast Svelte diagnostic tool written in Zig, from the `ampcode/homebrew-tap` Homebrew formula.

**First package produced by `pkgmgr import homebrew`** (pkgmgr-rs#567) — this PR is partly a test that the importer produces something a reviewer would accept by hand.

## What was verified rather than trusted

- **Both sha256 values were recomputed from the downloaded bytes**, not copied out of the formula. The tap is a cross-check, never the root of trust for the one value anchoring this package's integrity.
- **`strip_prefix` is absent because the archives are genuinely flat** — read off the real tarball (`tar -tzf` → one entry, `zvelte-check`). Homebrew auto-strips a single leading directory before `def install` and minimal does not, so this is unknowable from formula text and a guess would surface at build time as a missing file.
- **Provenance is derived from the artifact URLs**, which are literally `github.com/ampcode/zvelte-check/releases/…`, and cross-checked against the homepage. Never from the homepage alone — that conflation is how `chromium-bin` came to name `microsoft/playwright` for an artifact served out of Google's bucket. This buys real CPE identity (not a dark package) and free version checking via the GitHub tier.

## One thing I want to flag rather than bury

**This is prebuilt, and `zig` IS packaged.** pkgs CLAUDE.md prefers a source build when the toolchain exists. Prebuilt was chosen only because pkgmgr has no Zig `BuildFlavor` yet — *not* because the toolchain is missing, and I didn't want the build.ncl header to imply otherwise.

Mitigating: these are upstream's own release binaries, not a third-party redistribution, and we verify the hashes ourselves. A source-built `zvelte-check` can take the bare name later, which is why this carries `-bin`.

## No reviewer TODOs

Licence, provenance, outputs and deps all resolved mechanically. Requires no stdlib bump and touches nothing else in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `zvelte-check` command-line tool as an installable package.
  * Provides prebuilt binaries for x86_64 and ARM64 Linux systems.
  * Installs the executable for direct use from the system command line.
  * Includes version 0.2.0 with architecture-specific downloads.
  * Verifies downloaded packages to improve installation reliability and integrity across supported systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->