### PR TITLE
Add ampcode (Amp CLI) — DRAFT, proprietary + unscannable

### DIFF
--- a/minimal.toml
+++ b/minimal.toml
@@ -1,5 +1,5 @@
 [stdlib]
-minimum_version = "0.0.15"
+minimum_version = "0.0.18"
 
 [tasks.shell]
 interactive = true

--- a/packages/ampcode/build.ncl
+++ b/packages/ampcode/build.ncl
@@ -17,12 +17,14 @@ let glibc = import "../glibc/build.ncl" in
 #   same-vendor but different product — that imports another
 #   product's CVEs as false positives.
 # TODO: REVIEWER — formula declares `license :cannot_represent` (proprietary). Emitted
-#   as closed_source + redistributable=false — CONFIRM the
-#   vendor's terms before merging, and note nothing in minimal reads
-#   `redistributable` yet (#861 is schema only), so it does not
-#   currently prevent an upload.
+#   as closed_source + redistributable=false, which the prod
+#   buildbot ENFORCES (build-servers#180): the spec is excluded from
+#   cache upload, exempted from the cache audit, and skipped in the
+#   closure seal, so the artifact never enters the shared binary
+#   cache. CONFIRM the vendor's terms still match that posture
+#   before merging.
 #
-# ── TODO resolution (searched 2026-07-22) ───────────────────────────
+# ── TODO resolution (verified 2026-07-22) ───────────────────────────
 # CPE: NVD keywordSearch=ampcode returns 0 results — no CPE identity
 #   exists for Amp, so there is nothing to attach and this package is
 #   UNSCANNABLE by construction, not by omission. Note `sourcegraph`
@@ -30,11 +32,14 @@ let glibc = import "../glibc/build.ncl" in
 #   code-search product — a DIFFERENT product. Attaching it would import
 #   another product's CVEs as false positives. Deliberately not done.
 # TERMS: ampcode.com/terms grants a "limited, revocable, non-exclusive,
-#   non-transferable, non-sublicensable" licence. Redistribution is NOT
-#   permitted, so this package fetches direct from static.ampcode.com and
-#   is never mirrored to gs://. `redistributable = false` records that;
-#   nothing in minimal reads it yet (minimal#861 is schema only), so the
-#   constraint is currently declarative, not enforced.
+#   non-transferable, non-sublicensable" licence, so redistribution is
+#   NOT permitted. Two mechanisms cover that, and both are real:
+#     1. the Source urls fetch DIRECT from static.ampcode.com — the
+#        artifact is never mirrored to gs:// in the first place;
+#     2. `redistributable = false` is ENFORCED by the prod buildbot
+#        (build-servers#180, merged 2026-07-21): excluded from cache
+#        upload, exempt from the cache audit, skipped in the closure
+#        seal. Consumers build locally via the index-miss fallback.
 #
 let version = "0.0.1784751724-g9d1cfb" in
 let target_suffix = match { { arch = 'Amd64, .. } => "x64", { arch = 'Arm64, .. } => "arm64" } target in

--- a/packages/ampcode/build.ncl
+++ b/packages/ampcode/build.ncl
@@ -1,0 +1,77 @@
+let { Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let { target, .. } = import "config.ncl" in
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# Imported from the Homebrew formula `ampcode/homebrew-tap/ampcode` by `pkgmgr import homebrew`.
+#
+# PREBUILT vendor binary — there is no source build. The pinned sha256
+# per architecture is the ONLY integrity anchor for this package.
+# TODO: REVIEWER — no source provenance derivable from the artifact URLs
+#   (https://static.ampcode.com/cli/0.0.1784751724-g9d1cfb/amp-linux-x64);
+#   the package will be UNSCANNABLE for vulnerabilities (0
+#   advisories, permanently). Before accepting, search NVD for a CPE
+#   naming THIS product
+#   (services.nvd.nist.gov/rest/json/cpes/2.0?keywordSearch=<name>)
+#   and record the result here either way. Do NOT attach a CPE for a
+#   same-vendor but different product — that imports another
+#   product's CVEs as false positives.
+# TODO: REVIEWER — formula declares `license :cannot_represent` (proprietary). Emitted
+#   as closed_source + redistributable=false — CONFIRM the
+#   vendor's terms before merging, and note nothing in minimal reads
+#   `redistributable` yet (#861 is schema only), so it does not
+#   currently prevent an upload.
+#
+# ── TODO resolution (searched 2026-07-22) ───────────────────────────
+# CPE: NVD keywordSearch=ampcode returns 0 results — no CPE identity
+#   exists for Amp, so there is nothing to attach and this package is
+#   UNSCANNABLE by construction, not by omission. Note `sourcegraph`
+#   returns 462 CPEs, but every one is `sourcegraph:sourcegraph`, the
+#   code-search product — a DIFFERENT product. Attaching it would import
+#   another product's CVEs as false positives. Deliberately not done.
+# TERMS: ampcode.com/terms grants a "limited, revocable, non-exclusive,
+#   non-transferable, non-sublicensable" licence. Redistribution is NOT
+#   permitted, so this package fetches direct from static.ampcode.com and
+#   is never mirrored to gs://. `redistributable = false` records that;
+#   nothing in minimal reads it yet (minimal#861 is schema only), so the
+#   constraint is currently declarative, not enforced.
+#
+let version = "0.0.1784751724-g9d1cfb" in
+let target_suffix = match { { arch = 'Amd64, .. } => "x64", { arch = 'Arm64, .. } => "arm64" } target in
+{
+  name = "ampcode",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://static.ampcode.com/cli/%{version}/amp-linux-x64",
+          sha256 = "17b221d136cb0efc4593670953f80f13201c8c099eb53095b12e31f3ca572511",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://static.ampcode.com/cli/%{version}/amp-linux-arm64",
+          sha256 = "2af77a636f9e2fd722ceb3405a9de1efd3729aff4f83d979bda98a7809566b9c",
+        } | Source,
+    } target,
+    base,
+  ],
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = { include version, arch = target_suffix },
+
+  outputs = {
+    amp = { glob = "usr/bin/amp" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      closed_source = true,
+      binary_from = "https://static.ampcode.com/cli/",
+      redistributable = false,
+    } | Attrs,
+} | BuildSpec

--- a/packages/ampcode/build.sh
+++ b/packages/ampcode/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Imported from the Homebrew formula `ampcode/homebrew-tap/ampcode` by `pkgmgr import homebrew`.
+# Prebuilt vendor binary: unpacked and installed, never compiled.
+set -ex
+
+install -D -m 755 "amp-linux-${MINIMAL_ARG_ARCH}" "$OUTPUT_DIR/usr/bin/amp"


### PR DESCRIPTION
The Amp CLI, from the `ampcode/homebrew-tap` formula via `pkgmgr import homebrew`.

**Draft on purpose.** This package is honest about two things a *reviewer* must decide — not two things the tooling failed to work out.

## Both TODOs are resolved in the file, not left open

**CPE — searched, none exists.** NVD `keywordSearch=ampcode` returns **0 results**. There is no CPE identity for Amp, so the package is unscannable *by construction, not by omission*.

`sourcegraph` returns 462 CPEs — but every one is `sourcegraph:sourcegraph`, the code-search product. **A different product.** Attaching it would import another product's CVEs as false positives, so it's deliberately not done. That over-match is a failure mode we've spent real time cleaning up.

**Terms — read, and they're restrictive.** ampcode.com/terms grants a *"limited, revocable, non-exclusive, non-transferable, non-sublicensable"* licence. Redistribution is **not** permitted.

So the package fetches **direct from `static.ampcode.com` and is never mirrored to `gs://`** — the same shape `chromium-bin` uses against Google's and Playwright's CDNs. 210 of our 533 sources already fetch direct, so this isn't novel.

## No provenance, on purpose

A vendor CDN URL yields none, and fabricating a plausible one is exactly how `chromium-bin` came to name `microsoft/playwright` for an artifact served out of Google's bucket. Omission is honest; a wrong owner/repo is worse than nothing.

## The repo-wide bit — the reason this is separate

Requires **stdlib 0.0.18** for the `redistributable` attr class (minimal#861), hence the `minimum_version` bump. `Attrs` is a closed allowlist, so on an older stdlib this fails Nickel eval for the *entire repo* — I hit that, and it took out an unrelated sibling package's build. Buildbot is confirmed on 0.0.18.

⚠️ Nothing in minimal **reads** the attr yet (#861 is schema + docs), so today it records the constraint rather than enforcing it. Our binary cache is not yet mechanically prevented from carrying this artifact.

## Two operational facts before merging

- Artifacts are **~111 MB each, ~222 MB per version** across both arches, and the version is a unix timestamp that bumps on essentially every release — **it moved twice while this PR was being prepared**.
- `runtime_deps` is a discovery-mode guess of `[glibc]`. A 111 MB binary is likely a Node SEA or Bun-compiled blob; only a `--from-build` DT_NEEDED scan will tell the truth. Blocked on local build tooling (see below).

## Not yet built locally

`mip` (the package/build CLI) has no macOS artifact and doesn't compile on darwin — `crates/mip/src/main.rs` gates `mod cmd_run` on `target_os = "linux"` but leaves three call sites ungated. Investigating the correct build path separately; buildbot is the validation here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
