### PR TITLE
sqlite: point at the 3.53.3 archive (now mirrored)

### DIFF
--- a/packages/sqlite/build.ncl
+++ b/packages/sqlite/build.ncl
@@ -12,7 +12,12 @@ let version = "3.53.3" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "gs://minimal-staging-archives/sqlite-autoconf-3500400.tar.gz",
+      # ⚠ Nothing below derives from `version` above: the mirrored archive name
+      # carries the zero-padded release number (3.53.3 -> 3530300) and the
+      # sha256 is its own copy. A bump must change all three together — this
+      # line was left on 3500400 while version+sha256 moved to 3.53.3, so every
+      # build failed HashMismatch until the 3.53.3 archive was mirrored.
+      url = "gs://minimal-staging-archives/sqlite-autoconf-3530300.tar.gz",
       sha256 = "c917d7db16648ec95f714974ace5e5dcf46b7dc70e26600a0a102a3141125db0"
     } | Source,
     base-bootstrap,

--- a/packages/sqlite/build.sh
+++ b/packages/sqlite/build.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-tar -xof sqlite-autoconf-3500400.tar.gz
+# Both names must match the archive in build.ncl. The 3.53.3 bump updated the
+# `cd` but not the `tar`, so this extracted 3.50.4 and then changed into a
+# directory that did not exist.
+tar -xof sqlite-autoconf-3530300.tar.gz
 cd sqlite-autoconf-3530300
 
 case $(uname -m) in


### PR DESCRIPTION
Every build of sqlite has been failing:

```
HashMismatch want=c917d7db… got=a3db587a…
```

`version` and `sha256` were bumped to 3.53.3 but the URL stayed on **3.50.4's** archive — so the fetch pulled 3.50.4's bytes and checked them against 3.53.3's hash. A permanent failure, on the old toolchain and the new min/mip stack alike.

Verified by hashing both objects directly:

| | sha256 |
|---|---|
| mirrored `…-3500400.tar.gz` | `a3db587a…` ← the `got=` |
| upstream 3.53.3 tarball | `c917d7db…` ← the pin, correct |

## What changed

The 3.53.3 archive was simply **never mirrored**. It is now — fetched from canonical upstream, sha256 verified against this pin both before and after upload — so this PR only moves the URL to the object that should always have been there. Source stays on `gs://` per LICENSING.md §3 rather than redirecting upstream.

```diff
- url = "gs://minimal-staging-archives/sqlite-autoconf-3500400.tar.gz",
+ url = "gs://minimal-staging-archives/sqlite-autoconf-3530300.tar.gz",
```

## Root cause worth naming

**Nothing here derives from `version`.** The zero-padded release number in the archive name (`3.53.3` → `3530300`) and the sha256 are independent copies. An updater that rewrites the sha but *not* the URL turns a routine bump into a silent break. Comment added at the site.

The general fix belongs in pkgmgr — it should refuse to rewrite a sha next to a version-bearing literal URL it cannot also update — and I'm filing that separately.

I checked the other 20 packages whose literal URL lacks their version: **all legitimate** (toolchain bootstrap *seeds* like glibc 2.43 building from a `glibc_2.40` prebuilt, libkrunfw's bundled kernel, tamarin-prover's stackage snapshot). sqlite was the only real instance.

Found while getting package builds working on the new `min`/`mip` stack — a previous session read this as a credentials problem, but source fetches are hardcoded anonymous (`mctx/src/lib.rs:605`) and the bucket answers anonymously, so it was never auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the SQLite build process to use the correct archive for version 3.53.3.
  - Prevented builds from extracting an outdated archive or switching to an incorrect directory.
  - Synchronized archive references to avoid checksum and build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->