### PR TITLE
graphviz: single slash in the mirror URL

### DIFF
--- a/packages/graphviz/build.ncl
+++ b/packages/graphviz/build.ncl
@@ -27,7 +27,7 @@ let version = "14.1.1" in
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "gs://minimal-staging-archives//graphviz-%{version}.tar.bz2",
+      url = "gs://minimal-staging-archives/graphviz-%{version}.tar.bz2",
       sha256 = "975f4b9a7a7a7b614900ecd12919ccbd36a680818cc6fc527389b93e919410f0",
       extract = true,
       strip_prefix = "graphviz-%{version}",


### PR DESCRIPTION
One-character fix unblocking the graphviz 14.1.1 → 15.1.0 update dropped from pkgs#515.

The gs:// URL carried a **double slash** after the bucket. Fetches tolerated it (the object lives at the clean name — verified 200, and no slash-prefixed twin exists), but the updater derives the GCS object path from this URL and got `/graphviz-15.1.0.tar.bz2`, which its path-traversal guard **correctly** rejects. Guard right, data typo'd.

Swept `packages/` for the class: only instance.

After merge, the next update run should carry graphviz 15.1.0 normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)