### PR TITLE
Update atuin to 18.17.1

### DIFF
--- a/packages/atuin/build.ncl
+++ b/packages/atuin/build.ncl
@@ -6,14 +6,14 @@ let toolchain = import "../toolchain/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
-let version = "18.12.1" in
+let version = "18.17.1" in
 {
   name = "atuin",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/atuinsh/atuin/v%{version}.tar.gz",
-      sha256 = "8643a7df1e366e9ad3134514b9bcaf4d6440accb13c64340ec9ec1923d58eb6e",
+      sha256 = "851c3f4870e4bd181b98d2dae60b9fd76ef30f05f16a85efa21ac7e7cf294862",
       extract = true,
       strip_prefix = "atuin-%{version}",
     } | Source,


### PR DESCRIPTION
`18.12.1 -> 18.17.1`. Source mirrored to `gs://…/atuinsh/atuin/v18.17.1.tar.gz` (sha `851c3f48…`, verified before + after upload; object live).

## The 4x size jump is legitimate — and reviewed

This was **dropped from the 2026-07-23 stacked run** on the updater's 2x tarball-size guard (803329 → 3173022 bytes), which correctly suspects the auto-archive/release-asset mixup. I verified it's real growth:

- 18.13→18.17 added a whole new **`atuin-ai` crate** (`crates/atuin-ai/`: driver, FSM, tool-calling, TUI) — 270 commits, ~39 new source files.
- No vendored blobs, no binaries-in-source.
- **pkgscan diff old→new is CLEAN** (risk 0.0).

Shipped with `pkgmgr update --allow-size-jump` (pm#572) — its first real use. License unchanged (MIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)