### PR TITLE
Update llama.cpp to b10093

### DIFF
--- a/packages/llama.cpp/build.ncl
+++ b/packages/llama.cpp/build.ncl
@@ -10,14 +10,14 @@ let hwdata = import "../hwdata/build.ncl" in
 let pciutils = import "../pciutils/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "b8941" in
+let version = "b10093" in
 {
   name = "llama.cpp",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/ggml-org/llama.cpp/%{version}.tar.gz",
-      sha256 = "fed02e5a3445aa8c6a21cce3ed128d1777dab1bd234135291a21592eafd5e180",
+      sha256 = "6a142f90bf5f2b5858a1d4e5de0198003ca82b4e8fb2e5a027946cba680cb3b5",
       extract = true,
       strip_prefix = "llama.cpp-%{version}",
     } | Source,


### PR DESCRIPTION
## Update llama.cpp `b8941` → `b10093`

**Source:** `github:ggml-org/llama.cpp:tag`
**Release:** https://github.com/ggml-org/llama.cpp/releases/tag/b10093
**Changelog:** https://github.com/ggml-org/llama.cpp/compare/b8941...b10093
**Released:** ~9 hours ago

### Pkgscan (Layer-1 attack detection)

Scanned the `b8941 → b10093` source diff. No gating (Critical/High) findings.

| Severity | File | Pattern | Note |
|---|---|---|---|
| ℹ️ Info | `conversion/__init__.py:330` | `__import__(` | static/allowlist plugin loader (see below) |
| ℹ️ Info | `conversion/__init__.py:339` | `__import__(` | static/allowlist plugin loader |
| ℹ️ Info | `conversion/__init__.py:351` | `__import__(` | static/allowlist plugin loader |
| 🟡 Medium | llama.cpp (upstream release) | recent-bump | b10093 released ~9h ago (non-gating) |

The three `__import__(f"conversion.{module_name}")` calls import sibling modules by **allowlisted** name to fire `@ModelBase.register()` decorators — the new `conversion/` package's plugin loader, not obfuscated execution. pkgmgr's scanner now demotes a static/allowlist `__import__` to Info while keeping a computed/decoded target gated (gominimal/pkgmgr-rs#577).

### Changes

| | Old | New |
|---|---|---|
| **Version** | `b8941` | `b10093` |
| **sha256** | `fed02e5a…` | `6a142f90…` |

Source mirrored to `gs://minimal-staging-archives/ggml-org/llama.cpp/b10093.tar.gz` (verified).

> **Advisory partition** (cleared / still-affecting) is computed by the runner against the vuln DB; this PR was cut from a laptop without DB reachability, so that section is omitted here — the runner's re-scan on merge populates it. llama.cpp carries `GithubRepo` provenance (ggml-org/llama.cpp).

### Why b10093 and not the latest

b10093 is the newest build outside the recency dwell window: b10099 (25 min), b10098 (3.8h), b10094 (5.5h) are all <6h old and would have their mirror write withheld. b10093 (~9h, Medium) ships. This is what the freshness picker now surfaces in the `/pkgs upgrade` modal.

_Merge gate: build + tests must pass, AND a separate human reviewer's approval — the bot only cuts the PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
