### PR TITLE
Update ghostscript to 10.07.1

### DIFF
--- a/packages/ghostscript/build.ncl
+++ b/packages/ghostscript/build.ncl
@@ -12,14 +12,14 @@ let openjpeg = import "../openjpeg/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 
-let version = "10.06.0" in
+let version = "10.07.1" in
 {
   name = "ghostscript",
   build_deps = [
     { file = "build.sh" } | Local,
     {
-      url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10060/ghostscript-%{version}.tar.xz",
-      sha256 = "64352648c2c081c8a9fb1a12dc1965e01ead7c57f58b72d1b54f6ef1cef3c561",
+      url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10071/ghostscript-%{version}.tar.xz",
+      sha256 = "1cdb766de8db8f1e589c817f09c5855ea5f65dfc8540e465a69ac14c18416025",
       extract = true,
       strip_prefix = "ghostscript-%{version}",
     } | Source,


### PR DESCRIPTION
## Update ghostscript `10.06.0` → `10.07.1`

**Source:** `github:ArtifexSoftware/ghostpdl-downloads` (release)
**Release:** https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/tag/gs10071
**Changelog:** https://github.com/ArtifexSoftware/ghostpdl-downloads/compare/gs10060...gs10071

### Pkgscan (Layer-1 attack detection)

Scanned the `10.06.0 → 10.07.1` source diff. No gating (Critical/High) findings.

> **Auto-applied structural fix:** rewrote the GitHub release-download tag `gs10060` → `gs10071`. ghostscript's download tag is the version with the dots stripped (`10.06.0` → `gs10060`), so a plain version bump leaves it stale and the URL 404s. The updater now points it at the resolved upstream tag (gominimal/pkgmgr-rs#578) — at both fetch time and in the committed build.ncl, so it builds and stays correct across future bumps.

### Changes

| | Old | New |
|---|---|---|
| **Version** | `10.06.0` | `10.07.1` |
| **URL tag** | `gs10060` | `gs10071` |
| **sha256** | `64352648…` | `1cdb766d…` |

Direct GitHub release download (no gs:// mirror). Tarball sha256 verified.

> **Advisory partition** (cleared / still-affecting) is computed by the runner against the vuln DB; this PR was cut from a laptop without DB reachability, so that section is omitted here — the runner's re-scan on merge populates it.

_Merge gate: build + tests must pass, AND a separate human reviewer's approval — the bot only cuts the PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
