### PR TITLE
Update croc to 10.6.0

### DIFF
--- a/packages/croc/build.ncl
+++ b/packages/croc/build.ncl
@@ -5,14 +5,14 @@ let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
-let version = "10.4.14" in
+let version = "10.6.0" in
 {
   name = "croc",
   build_deps = [
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/schollz/croc/v%{version}.tar.gz",
-      sha256 = "3280b690b81520837e4b17bbc4fa3116ad8d534229e4d8ec2bdf017a2ca7755a",
+      sha256 = "d9ee32d93e8353fd4330d71ee2683f08e22f4a58b2f3f5a73c1c9d622ffd4598",
       extract = true,
       strip_prefix = "croc-%{version}",
     } | Source,


### PR DESCRIPTION
## Update croc `10.4.14` → `10.6.0`

**Source:** `github:schollz/croc`
**Release:** https://github.com/schollz/croc/releases/tag/v10.6.0
**Changelog:** https://github.com/schollz/croc/compare/v10.4.14...v10.6.0
**Released:** 4 days ago (2026-07-23)

> Pkgscan: **clean** — diff against the prior version surfaced no newly-introduced suspicious patterns.

### Components changed

<details><summary>CycloneDX component delta (declared materials — the package's own version, not a dependency-tree diff)</summary>

| | Component | Old | New |
|---|---|---|---|
| ~ | `croc` | `10.4.14` | `10.6.0` |
| ~ | `croc-upstream` | `10.4.14` | `10.6.0` |

</details>

### Changes

| | Old | New |
|---|---|---|
| **Version** | `10.4.14` | `10.6.0` |
| **SHA256** | `3280b690b8152083...` | `d9ee32d93e8353fd...` |
| **Size** | 615 KB | 2.4 MB |
| **Source** | `gs://minimal-staging-archives/schollz/croc/v10.4.14.tar.gz` | `gs://minimal-staging-archives/schollz/croc/v10.6.0.tar.gz` |

- **License:** `MIT` _(source: GitHub + tarball)_

---
*Created by [pkgmgr](https://github.com/gominimal/pkgmgr-rs)*
