### PR TITLE
Revert #477: restore minimum_version 0.0.15, drop redistributable attr (unblock pinned-minimal consumers)

### DIFF
--- a/minimal.toml
+++ b/minimal.toml
@@ -1,5 +1,5 @@
 [stdlib]
-minimum_version = "0.0.18"
+minimum_version = "0.0.15"
 
 [tasks.shell]
 interactive = true

--- a/packages/android-sdk/build.ncl
+++ b/packages/android-sdk/build.ncl
@@ -35,7 +35,6 @@ let version = "11076708" in
     {
       upstream_version = version,
       license_spdx = "LicenseRef-Android-SDK-Terms",
-      redistributable = false,
       binary_from = "https://dl.google.com/android/repository/",
     } | Attrs,
 

--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -64,7 +64,6 @@ in
     {
       upstream_version = version,
       license_spdx = "LicenseRef-Anthropic-Proprietary",
-      redistributable = false,
       binary_from = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
       closed_source = true,
 

--- a/packages/edgedelta/build.ncl
+++ b/packages/edgedelta/build.ncl
@@ -74,7 +74,6 @@ in
     {
       upstream_version = version,
       license_spdx = "LicenseRef-EdgeDelta-Proprietary",
-      redistributable = false,
       binary_from = "https://release.edgedelta.com/",
     } | Attrs,
 } | BuildSpec


### PR DESCRIPTION
Reverts #477. Restores `minimum_version = "0.0.15"` and removes the `redistributable = false` attr from android-sdk, claude-code, edgedelta.

## Why

#477's `minimum_version` bump to 0.0.18 (required so old clients get a legible error instead of a raw decode failure on the new `redistributable` attr) hard-gates **every** consumer whose installed minimal ships stdlib < 0.0.18 — including conservative/pinned-minimal CI that pulls latest pkgs only for security fixes and never touches the three proprietary packages. Because the graph is loaded whole-catalog on every build and attr validation is closed, the new attr breaks those consumers regardless of their closure.

Reverting unblocks them immediately. 0.0.18 is the fix going forward, but it can't retroactively help clients already on an older pin.

## ⚠️ Compliance coupling — read before merging

The build-servers exclusion of these three packages (inbox#290 / #284) is **driven by this attr**. With the attr removed, `is_redistributable` defaults to true and the upload/seal filters stop excluding them, so the **next canonical build re-uploads the proprietary artifacts to the public cache**, undoing the 2026-07-28 purge.

**Sequencing:** this must be paired with a build-servers change that keeps the three packages out of the public cache independent of the pkgs attr (a name-based denylist), landed/deployed **before or immediately after** this merges — otherwise there is a re-exposure window on the next pkgs build. Do not merge this in isolation and leave it.

Kept open (not auto-merged) so the compliance follow-up can be sequenced deliberately.
