### PR TITLE
attrs: fix license_spdx for pkgconf (ISC) and stow (GPL-3.0-or-later)

### DIFF
--- a/packages/pkgconf/build.ncl
+++ b/packages/pkgconf/build.ncl
@@ -38,7 +38,7 @@ let version = "3.0.4" in
   attrs =
     {
       upstream_version = version,
-      license_spdx = "pkgconf",
+      license_spdx = "ISC",
       source_provenance = {
         category = 'GithubRepo,
         owner = "pkgconf",

--- a/packages/stow/build.ncl
+++ b/packages/stow/build.ncl
@@ -43,7 +43,7 @@ let version = "2.4.1" in
     {
       upstream_version = version,
       source_provenance = { category = 'GnuProject, name = "stow" },
-      license_spdx = "GPL-3.0",
+      license_spdx = "GPL-3.0-or-later",
     } | Attrs,
   tests = {
     smoke =


### PR DESCRIPTION
Two catalog data bugs flagged by the attribution manifest's first production run (inbox#282, build-servers#194):

- `pkgconf`: `license_spdx = "pkgconf"` is not an SPDX id — upstream pkgconf is ISC.
- `stow`: `GPL-3.0` is a deprecated SPDX id — GNU Stow is `GPL-3.0-or-later`.

Attr-value-only change: no new schema key (no stdlib bump, safe for all clients), and attrs don't participate in spec_hash (no rebuilds). After merge, the next sealed manifest maps both packages to their canonical license texts instead of carrying an unknown/deprecated id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Corrected the recorded SPDX license metadata for pkgconf to ISC.
  - Updated stow’s license metadata to GPL-3.0-or-later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->