### PR TITLE
redis: declare gawk build dep (fixes 'awk: command not found')

### DIFF
--- a/packages/redis/build.ncl
+++ b/packages/redis/build.ncl
@@ -1,6 +1,7 @@
 let { subsetOf, Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
 let bash = import "../bash/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
+let gawk = import "../gawk/build.ncl" in
 let grep = import "../grep/build.ncl" in
 let make = import "../make/build.ncl" in
 let sed = import "../sed/build.ncl" in
@@ -23,6 +24,7 @@ let version = "8.8.1" in
     } | Source,
     bash,
     coreutils,
+    gawk,
     grep,
     sed,
     make,


### PR DESCRIPTION
redis 8.8's build shells out to `awk` (via its bundled `scripts/lib/manifest.sh`, line 88, invoked from the `build` Makefile target), but `packages/redis/build.ncl` lists its build tools individually — `bash, coreutils, grep, sed, make, binutils, gcc, linux_headers` — and never declared `gawk`. None of those pull `gawk` in transitively, so redis has no `awk` in its sandbox and the build dies:

```
/build/scripts/lib/manifest.sh: line 88: awk: command not found
make: *** [Makefile:109: build] Error 127
```

## Why it surfaced now (and not at the 8.8.1 bump)

This is a latent undeclared build-dep, not a regression. redis's cached artifact was evidently produced under conditions where `awk` was incidentally present (or the entry has since aged out of the res-server build cache), so cold rebuilds only started failing once one actually ran — here, on an unrelated PR's CI (#541, a syft bump, which does not touch redis). Declaring the dep explicitly is the correct fix regardless of the exact masking mechanism: the build genuinely needs `awk`, so it must be in `build_deps`.

## Fix

Add `gawk` (the package `base` uses to provide `awk`) to redis's imports and `build_deps`.

## Verification

Built redis locally arm64-native with a forced cold rebuild (novel-marker cache-bust) after the change: it now builds to completion — no `awk: command not found`, no `Error 127` — and produces the `redis-server` / `redis-cli` binaries. `gawk` was the only missing dep; no cascade.

Unblocks unrelated PRs (e.g. #541) whose CI happens to cold-rebuild redis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added required build tooling to improve the reliability of the Redis package build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->