### PR TITLE
gdb: package the GNU debugger 17.2

### DIFF
--- a/packages/gdb/build.ncl
+++ b/packages/gdb/build.ncl
@@ -1,0 +1,119 @@
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bash = import "../bash/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let expat = import "../expat/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gmp = import "../gmp/build.ncl" in
+let make = import "../make/build.ncl" in
+let mpfr = import "../mpfr/build.ncl" in
+let ncurses = import "../ncurses/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let python = import "../python/build.ncl" in
+let readline = import "../readline/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let xz = import "../xz/build.ncl" in
+let zlib = import "../zlib/build.ncl" in
+let zstd = import "../zstd/build.ncl" in
+
+let version = "17.2" in
+{
+  name = "gdb",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/gdb-%{version}.tar.xz",
+      sha256 = "1c036c0d72e4b3d1fb5c94c88632add6f9d76f4d7c4d2ea793c12a9f19a3228c",
+    } | Source,
+    base,
+    toolchain,
+    gcc,
+    make,
+    pkgconf,
+    glibc,
+    # Terminal + line editing. Built --with-system-readline so gdb uses OUR
+    # readline rather than its bundled copy — a bundled copy would be invisible
+    # to pkgscan, which is the same reasoning applied to rizin's use_sys_* flags.
+    ncurses,
+    readline,
+    # XML target descriptions and remote memory maps. Effectively required in
+    # practice even though configure treats it as optional.
+    expat,
+    # Debug-info compression formats gdb reads directly from ELF sections.
+    zlib,
+    xz,
+    zstd,
+    # Expression arithmetic.
+    gmp,
+    mpfr,
+    # LOAD-BEARING: gef is a Python extension and cannot load into a gdb built
+    # without --with-python. See build.sh.
+    python,
+  ],
+  runtime_deps = [
+    bash,
+    # `gcore` is a shell script with a `#!/usr/bin/env` shebang, so env must be
+    # present at RUNTIME or the script is unrunnable. Caught by the
+    # missing_runtime_deps checker rather than by us noticing.
+    coreutils,
+    ncurses,
+    readline,
+    expat,
+    zlib,
+    xz,
+    zstd,
+    gmp,
+    mpfr,
+    python,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    gdb = { glob = "usr/bin/gdb" } | OutputBin,
+    gdb_add_index = { glob = "usr/bin/gdb-add-index" } | OutputBin,
+    gcore = { glob = "usr/bin/gcore" } | OutputBin,
+    gdbserver = { glob = "usr/bin/gdbserver" } | OutputBin,
+    # gdb's Python runtime support files — the `python` directory it loads its
+    # own pretty-printers and commands from.
+    gdb_data = { glob = "usr/share/gdb/**" } | OutputData,
+  },
+  tests = {
+    smoketest = standaloneTest "/bin/gdb --version",
+
+    # PIN THE TWO PROPERTIES THE CONFIGURE FLAGS EXIST FOR. Both regress
+    # SILENTLY: configure probes for Python and for target support, and if
+    # either probe fails it prints a note and carries on to a successful build.
+    # You would get a gdb that installs, runs, passes a --version smoketest, and
+    # is useless for the thing it was packaged to do.
+    capabilities =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # --with-python: gef is a Python extension. Without this gdb reports
+          # "Python scripting is not supported in this copy of GDB" and gef
+          # cannot load at all.
+          ["/bin/bash", "-c", "gdb -batch -ex 'python print(\"py-ok\")' | grep -q py-ok"],
+          # --enable-targets=all: a foreign architecture must be selectable, or
+          # gdb cannot disassemble a binary emulated under qemu-user's gdbstub.
+          # i386 is foreign on every arch we build for.
+          ["/bin/bash", "-c", "gdb -batch -ex 'set architecture' 2>&1 | grep -q i386"],
+        ],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "GPL-3.0-or-later",
+      source_provenance = {
+        category = 'GnuProject,
+        name = "gdb",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/gdb/build.sh
+++ b/packages/gdb/build.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -e
+
+tar -xof "gdb-${MINIMAL_ARG_VERSION}.tar.xz"
+cd "gdb-${MINIMAL_ARG_VERSION}"
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+# Reproducibility flags per the pkgs AGENTS.md C/C++ stack: two builds of the
+# same source must be byte-identical.
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--build-id=none"
+export ARFLAGS=Drc
+
+# The gdb tarball ships the ENTIRE binutils-gdb tree — bfd, gas, ld, gprof and
+# the binutils programs are all in here. Building them would silently produce a
+# second `ld`/`objdump`/`as` that collide with our binutils package. Disable all
+# of them; we want exactly one binary out of this tree.
+#
+# --with-python is LOAD-BEARING, not a nicety: gef is a Python extension and
+# cannot load into a gdb built without Python support. Since the whole point of
+# packaging gdb here is to carry gef, a non-Python gdb would satisfy the build
+# and fail the actual goal.
+#
+# --enable-targets=all costs nothing at build time and lets gdb disassemble
+# foreign architectures — which is what makes it useful against a binary being
+# emulated under qemu-user's gdbstub, and mirrors the fix the binutils package
+# still needs.
+#
+# MAKEINFO=true skips building the info manuals so we do not have to package
+# texinfo for a doc format nothing here reads.
+./configure \
+  --prefix=/usr \
+  --disable-binutils \
+  --disable-ld \
+  --disable-gas \
+  --disable-gprof \
+  --disable-gold \
+  --disable-sim \
+  --disable-nls \
+  --disable-werror \
+  --with-python=/usr/bin/python3 \
+  --with-system-readline \
+  --with-system-zlib \
+  --enable-targets=all \
+  MAKEINFO=true
+
+make -j"$(nproc)" MAKEINFO=true
+make install DESTDIR="$OUTPUT_DIR" MAKEINFO=true
+
+# `make install` from this tree also drops libbfd/libopcodes headers and static
+# archives that belong to the binutils package. Remove them so the two packages
+# cannot disagree about who owns bfd.h.
+rm -rf "$OUTPUT_DIR/usr/include" "$OUTPUT_DIR/usr/lib/libbfd."* "$OUTPUT_DIR/usr/lib/libopcodes."*
+rm -rf "$OUTPUT_DIR/usr/share/info" "$OUTPUT_DIR/usr/share/locale"


### PR DESCRIPTION
The distro has had **no debugger**. `strace` shows syscalls and `elfutils` reads sections, but nothing could set a breakpoint, walk a stack, or open a core dump.

It is also the substrate a reverse-engineering loadout needs — gef is a gdb extension, and qemu-user's `-g` gdbstub is worthless without a gdb client. But it stands alone regardless of that work, which is why it lands first and by itself.

## Two configure flags and both fail silently

```
--with-python         gef is a Python extension. Without it gdb reports
                      "Python scripting is not supported in this copy of GDB".
--enable-targets=all  lets gdb disassemble FOREIGN architectures — what makes
                      it useful against a binary emulated under qemu-user.
```

`configure` **probes** for both and carries on to a successful build if either fails. You would get a gdb that installs, runs, passes a `--version` smoketest, and is useless for the reason it was packaged.

So neither is trusted — both are pinned by a standalone test:

```
gdb -batch -ex 'python print("py-ok")' | grep -q py-ok
gdb -batch -ex 'set architecture' 2>&1 | grep -q i386
```

**Mutation-tested:** breaking either assertion makes `minimal check` fail, so the tests are not vacuous — which also proves Python scripting genuinely executes in the sandbox rather than merely being linked in.

## The tarball ships all of binutils

Left alone this tree builds a second `ld`/`as`/`objdump` that collide with our binutils package. All of binutils/ld/gas/gprof/gold/sim are disabled so exactly one program comes out, and the stray `usr/include` + `libbfd`/`libopcodes` artifacts are removed so the two packages cannot disagree about who owns `bfd.h`.

Built `--with-system-readline` rather than gdb's bundled copy, so a readline CVE is **visible to pkgscan** instead of hiding in a vendored tree.

## Sourcing

From the staging mirror, not ftp.gnu.org, which 403s the sandbox fetcher — the same reason `make`/`m4`/`gawk`/`sed` already mirror. Uploaded `gdb-17.2.tar.xz` (24.6 MB, sha256 `1c036c0d…3228c`) after verifying it against the copy fetched from ftp.gnu.org directly.

## Verified

```
minimal package --rebuild --no-fetch gdb    exit 0
minimal check --packages gdb                14/14 pass
built binary                                40M, ELF aarch64, Python support in
two consecutive rebuilds                    byte-identical (reproducible per AGENTS.md)
output tree                                 usr/bin{gdb,gdbserver,gcore,gdb-add-index} + usr/share/gdb
```

`coreutils` is a runtime dep because `gcore` is a script with a `#!/usr/bin/env` shebang. The `missing_runtime_deps` checker caught that, not me — it would have installed fine and failed the first time anyone ran `gcore`.

## Known, and not a defect in this package

`pkgmgr check` reports gdb as `lookup-failed`. **So does the existing `m4`** from this network — ftp.gnu.org is rate-limiting us and the GNU resolver has no mirror fallback. Filed as gominimal/pkgmgr-rs#662 with a proposed fallback design; gdb is no more update-dark than every other GNU package is today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GDB version 17.2 to the available toolchain.
  * Supports Python scripting and i386 target debugging.
  * Includes version verification and capability checks.
* **Documentation**
  * Added licensing and source provenance metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->