### PR TITLE
ghidra: package the reverse-engineering suite 12.1.2

### DIFF
--- a/packages/ghidra/build.ncl
+++ b/packages/ghidra/build.ncl
@@ -139,6 +139,83 @@ let version = "12.1.2" in
     # The C++ fixture is deliberately namespaced: `Foo::bar` in names.txt also
     # proves the GNU demangler natives ran, which nothing else here covers and
     # which shipped broken (mode 0644) for the life of this package.
+    # PROVE THE 7-ZIP PARITY FIX ACTUALLY WORKS, not merely that the .so is on
+    # disk with the right ELF arch — which is all the output-types checker and
+    # a `file` invocation can tell you.
+    #
+    # This is the one capability that was genuinely MISSING on arm64 (upstream
+    # excludes ARM from the -all-platforms roll-up by design), so "we injected
+    # a native" deserves more evidence than "a file exists". The failure it
+    # guards is silent twice over: SevenZipCustomInitializer catches Throwable
+    # and rewraps, initNativeLibraries() eats the result, and analyzeHeadless
+    # swallows the resulting IOException and exits 0 with an empty listing.
+    #
+    # Uses sevenzipjbinding's OWN documented entry point rather than Ghidra's
+    # wrapper, so it tests the jar + native pairing directly: if the platform
+    # list is not exactly one entry, getPlatformBestMatch() falls back to
+    # matching os.arch ("aarch64") against the artifact's "Linux-arm64" and can
+    # never succeed. That is precisely the mistake the build.sh comment warns
+    # about, and this catches it.
+    #
+    # The fixture is a real 187-byte 7z archive, embedded base64 because the
+    # sandbox ships GNU tar, which cannot WRITE 7z (bsdtar can; we do not
+    # package it). Decoding it needs nothing but coreutils.
+    sevenzip_native =
+      {
+        class = 'Standalone,
+        test_deps = [base, jdk],
+        cmds = [
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              printf '%s' 'N3q8ryccAAOwgYeuFwAAAAAAAACEAAAAAAAAADYSLXkAOBhKq0FKVlNmTkeB6IoTIX///ploAAEEBgABCRcABwsBAAEjAwEBBV0AAIAADA0ACAoBDg+qJwAABQERLwBTAEUAVgBFAE4AWgBJAFAAXwBQAEEAUgBJAFQAWQBfAE8ASwAuAHQAeAB0AAAAFAoBAK3P1wCYIN0BEgoBAK3P1wCYIN0BEwoBAPnM1wCYIN0BFQYBACCApIEAAA==' | base64 -d > /build/fixture.7z
+              # Sanity: the fixture must itself be a 7z, or a green test would
+              # be proving nothing about 7z at all.
+              head -c 6 /build/fixture.7z | grep -q '7z' ||
+                { echo "fixture is not a 7z archive" >&2; exit 1; }
+
+              cat > /build/SevenZipCheck.java <<'JAVA'
+              import java.io.RandomAccessFile;
+              import net.sf.sevenzipjbinding.*;
+              import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+
+              public class SevenZipCheck {
+                  public static void main(String[] args) throws Exception {
+                      SevenZip.initSevenZipFromPlatformJAR();
+                      System.out.println("PLATFORM=" + SevenZip.getUsedPlatform());
+                      try (RandomAccessFile f = new RandomAccessFile(args[0], "r");
+                           IInArchive a = SevenZip.openInArchive(null,
+                                   new RandomAccessFileInStream(f))) {
+                          for (int i = 0; i < a.getNumberOfItems(); i++) {
+                              System.out.println("ENTRY=" + a.getProperty(i, PropID.PATH));
+                          }
+                      }
+                  }
+              }
+              JAVA
+
+              CP=$(ls /usr/share/ghidra/Ghidra/Features/FileFormats/lib/sevenzipjbinding-*.jar | tr '\n' ':')
+              /usr/lib/jvm/bin/javac -cp "$CP" -d /build /build/SevenZipCheck.java
+              /usr/lib/jvm/bin/java -cp "$CP:/build" SevenZipCheck /build/fixture.7z \
+                  > /build/7z.out 2>&1 || { cat /build/7z.out >&2; exit 1; }
+              cat /build/7z.out
+            "%
+          ],
+          # The native initialised at all — this is the UnsatisfiedLinkError /
+          # wrong-arch / missing-DT_NEEDED case.
+          ["/bin/bash", "-c", "grep -q '^PLATFORM=' /build/7z.out"],
+          # ...and resolved to the ARM platform specifically. If the swap ever
+          # regresses to shipping the all-platforms jar, the list stops being a
+          # single entry and this is what notices.
+          ["/bin/bash", "-c", "grep -q 'PLATFORM=Linux-arm64' /build/7z.out"],
+          # ...and genuinely decompressed the container: the inner filename can
+          # only appear if 7-Zip enumerated the archive.
+          ["/bin/bash", "-c", "grep -q 'ENTRY=SEVENZIP_PARITY_OK.txt' /build/7z.out"],
+        ],
+      } | Test,
+
     headless_decompile =
       {
         class = 'Standalone,

--- a/packages/ghidra/build.ncl
+++ b/packages/ghidra/build.ncl
@@ -1,0 +1,116 @@
+let { subsetOf, BuildSpec, Local, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bash = import "../bash/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let jdk = import "../jdk/build.ncl" in
+let make = import "../make/build.ncl" in
+let python = import "../python/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let zlib = import "../zlib/build.ncl" in
+
+let version = "12.1.2" in
+{
+  name = "ghidra",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    # THE OFFICIAL PREBUILT RELEASE, not a source build — a deliberate choice.
+    #
+    # Ghidra's Gradle build runs `gradle/support/fetchDependencies.gradle`
+    # BEFORE a line compiles: 67 URLs across seven hosts, including binary
+    # artifacts with no source (AXMLPrinter2.jar from the dead Google Code
+    # archive, per-platform Z3 zips, yajsw from SourceForge), a full
+    # postgresql tarball and PyPI wheels — and only then does Maven Central
+    # resolution start. It also requires JDK 25 to BUILD; we ship 21.
+    #
+    # The release zip is the same tradeoff the `jdk` package already accepts,
+    # and it ships NO bundled JRE (`jre/` and `bin/java` are both absent), so
+    # Ghidra runs on our jdk rather than smuggling in a second Java.
+    #
+    # THIS IS ALSO THE SOURCE FOR THE PLATFORM NATIVES. There is deliberately
+    # no second Source: `assembleDistribution` pulls `src/decompile/**`,
+    # `GPL/DemanglerGnu/src/**` and `src/lzfse/**` into the release zip, and
+    # those 310 files are byte-identical to the corresponding git tag. Adding
+    # the GitHub tag tarball would mean 76 MiB of extra download and a 313 MiB
+    # extraction to obtain files we already have — and, worse, a SECOND sha256
+    # in this file. pkgmgr's updater replaces only the FIRST one, so the
+    # second would point at the new tag with the old hash on the next bump.
+    #
+    # SHA-256 is the one published in the release body, not one we computed:
+    # https://github.com/NationalSecurityAgency/ghidra/releases/tag/Ghidra_%{version}_build
+    {
+      url = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_%{version}_build/ghidra_%{version}_PUBLIC_20260605.zip",
+      sha256 = "b62e81a0390618466c019c60d8c2f796ced2509c4c1aea4a37644a77272cf99d",
+    } | Source,
+    base,
+    python, # `python3 -m zipfile` does the extraction
+    # The natives upstream does not publish for linux_arm_64 are compiled from
+    # the source in the zip above — plain g++/gcc and make, no Gradle, no
+    # bison/flex (the generated parsers are checked in upstream and shipped).
+    toolchain,
+    make,
+    zlib, # only the `sleigh` target links it (-lz via the Makefile's $(LNK))
+  ],
+  runtime_deps = [
+    bash, # every launcher is a POSIX shell script
+    jdk, # Ghidra 12.x requires JDK 21+; ours is 21.0.10
+    # For the natives. These were previously invisible: while they sat inside
+    # the `install` OutputData glob the missing-runtime_deps checker skipped
+    # them outright (it ELF-parses Binary/Library outputs only), so a native
+    # that resolved no libstdc++ would have passed every checker and then
+    # failed at exec. Declaring them as OutputBin below turns that check on.
+    glibc,
+    subsetOf gcc ["libgcc", "libstdcpp"], # decompile/sleigh are C++
+    zlib, # `sleigh` links libz.so.1
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    # `analyzeHeadless` is the point: it is what makes Ghidra scriptable
+    # against a fleet of binaries rather than a GUI you drive by hand.
+    analyzeHeadless = { glob = "usr/bin/analyzeHeadless" } | OutputBin,
+    ghidraRun = { glob = "usr/bin/ghidraRun" } | OutputBin,
+    pyghidraRun = { glob = "usr/bin/pyghidraRun" } | OutputBin,
+
+    # The platform natives, declared as real binaries so the checkers actually
+    # look at them: output-types asserts the ELF arch matches the target, and
+    # missing-runtime_deps resolves their DT_NEEDED against the runtime
+    # closure. Both checks are skipped for anything that only matches an
+    # OutputData glob — `allow_executable = true` is an explicit no-op arm in
+    # the output-types checker, not a weaker assertion — which is how this
+    # package used to pass 14/14 while shipping x86_64 ELF on an arm64 target.
+    #
+    # The `linux_*` wildcard rather than a `match target` branch is deliberate:
+    # build.sh keeps exactly one os/linux_* directory (the host's), so this
+    # resolves to os/linux_arm_64 here and os/linux_x86_64 on an amd64 builder
+    # with no Nickel-level arch dispatch and no second sha256 to maintain.
+    decompiler_natives = { glob = "usr/share/ghidra/Ghidra/Features/Decompiler/os/linux_*/*" } | OutputBin,
+    demangler_natives = { glob = "usr/share/ghidra/GPL/DemanglerGnu/os/linux_*/*" } | OutputBin,
+    fileformats_natives = { glob = "usr/share/ghidra/Ghidra/Features/FileFormats/os/linux_*/*" } | OutputBin,
+
+    # `allow_executable` because the install tree legitimately contains the
+    # natives above plus a bundled JNI library (7-Zip's lib7-Zip-JBinding.so).
+    # Same shape the jdk package uses for usr/lib/jvm/lib. The globs overlap
+    # the three native outputs on purpose — each output is matched and checked
+    # independently, so the natives get the strict treatment while the rest of
+    # the tree stays a data blob.
+    install = { glob = "usr/share/ghidra/**/*", allow_executable = true } | OutputData,
+  },
+  attrs = {
+    upstream_version = version,
+    # Root LICENSE is verbatim Apache-2.0. The tree aggregates ~20 further
+    # licenses (GPL-2.0 WITH Classpath-exception, GPL-3.0, LGPL-2.1/3.0,
+    # BSD-2/3, MIT, Zlib, PostgreSQL, MPL-2.0, CC-BY-2.5, Python-2.0,
+    # Apache-2.0 WITH LLVM-exception, Bouncy Castle, JDOM, Jython) — ALL
+    # OSI/FSF-free, nothing proprietary. Upstream policy (DevGuide.md) keeps
+    # GPL code in the standalone top-level `GPL/` module. The natives we now
+    # compile do not change this: the decompiler is Apache-2.0, DemanglerGnu
+    # is GPL-3.0 (already a separate top-level module for exactly that
+    # reason), and lzfse is BSD-3-Clause.
+    license_spdx = "Apache-2.0",
+  },
+} | BuildSpec

--- a/packages/ghidra/build.ncl
+++ b/packages/ghidra/build.ncl
@@ -1,4 +1,4 @@
-let { subsetOf, BuildSpec, Local, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let { subsetOf, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let bash = import "../bash/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
@@ -114,6 +114,126 @@ let version = "12.1.2" in
     # the tree stays a data blob.
     install = { glob = "usr/share/ghidra/**/*", allow_executable = true } | OutputData,
   },
+
+  tests = {
+    # THE LOAD-BEARING TEST. Every other check in this package confirms a file
+    # EXISTS and has the right ELF arch; this confirms Ghidra actually FINDS
+    # AND USES it — which is a different question, and the one that fails
+    # silently.
+    #
+    # When the decompile native is missing or unloadable:
+    # DecompileProcessFactory logs once behind a static latch, openProgram()
+    # returns false, decompileFunction() short-circuits with errMsg="" so
+    # CppExporter's `!"".equals(...)` guard never fires, and analyzeHeadless
+    # writes an empty .c and EXITS 0. Worse, that results object is built with
+    # DISPOSED_ON_CANCEL, so isCancelled() reports a user cancellation and
+    # isValid() returns TRUE for a decompile that produced nothing. Only
+    # decompileCompleted() still tells the truth, so the script below is
+    # written against that and nothing else.
+    #
+    # analyzeHeadless has ZERO System.exit calls — it exits 0 when the
+    # postScript throws, too. So nothing here trusts its exit code; every
+    # assertion is against an artifact the script can only produce by really
+    # decompiling.
+    #
+    # The C++ fixture is deliberately namespaced: `Foo::bar` in names.txt also
+    # proves the GNU demangler natives ran, which nothing else here covers and
+    # which shipped broken (mode 0644) for the life of this package.
+    headless_decompile =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain],
+        cmds = [
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              cat > /build/prog.cpp <<'CPP'
+              struct Foo { int bar(int a, int b); };
+              int Foo::bar(int a, int b) { int c = a * 3; if (b > c) { c = b - c; } return c + 7; }
+              int main(void) { Foo f; return f.bar(11, 40); }
+              CPP
+              cat > /build/DecompParityCheck.java <<'JAVA'
+              //Proves Ghidra resolves and uses its platform natives.
+              //@category Selftest
+              import java.io.File;
+              import java.io.PrintWriter;
+              import ghidra.app.decompiler.DecompInterface;
+              import ghidra.app.decompiler.DecompileResults;
+              import ghidra.app.script.GhidraScript;
+              import ghidra.program.model.listing.Function;
+
+              public class DecompParityCheck extends GhidraScript {
+                  @Override
+                  public void run() throws Exception {
+                      String[] args = getScriptArgs();
+                      if (args.length < 2) { printerr("usage: <out.c> <names.txt>"); return; }
+                      StringBuilder names = new StringBuilder();
+                      Function target = null;
+                      for (Function f : currentProgram.getFunctionManager().getFunctions(true)) {
+                          String n = f.getName(true);
+                          names.append(n).append('\n');
+                          if (n.contains("bar")) { target = f; }
+                      }
+                      try (PrintWriter w = new PrintWriter(new File(args[1]))) { w.print(names); }
+                      if (target == null) { printerr("SELFTEST: no candidate function"); return; }
+                      DecompInterface ifc = new DecompInterface();
+                      try {
+                          if (!ifc.openProgram(currentProgram)) {
+                              printerr("SELFTEST: openProgram()==false: " + ifc.getLastMessage());
+                              return;
+                          }
+                          DecompileResults res = ifc.decompileFunction(target, 120, monitor);
+                          if (!res.decompileCompleted() || res.getDecompiledFunction() == null) {
+                              printerr("SELFTEST: incomplete: " + res.getErrorMessage());
+                              return;
+                          }
+                          String c = res.getDecompiledFunction().getC();
+                          if (c == null || c.isBlank()) { printerr("SELFTEST: empty C"); return; }
+                          try (PrintWriter w = new PrintWriter(new File(args[0]))) { w.print(c); }
+                      } finally { ifc.dispose(); }
+                  }
+              }
+              JAVA
+            "%
+          ],
+          ["/bin/g++", "-O0", "-o", "/build/prog", "/build/prog.cpp"],
+          [
+            "/bin/analyzeHeadless",
+            "/build",
+            "parity",
+            "-import",
+            "/build/prog",
+            "-analysisTimeoutPerFile",
+            "300",
+            "-scriptPath",
+            "/build",
+            "-postScript",
+            "DecompParityCheck.java",
+            "/build/decompiled.c",
+            "/build/names.txt"
+          ],
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              [ -s /build/decompiled.c ] ||
+                { echo "no decompiled C: the decompile native did not run" >&2; exit 1; }
+              c=$(cat /build/decompiled.c)
+              case "$c" in *return*) ;; *)
+                echo "no return statement in decompiled C:" >&2; echo "$c" >&2; exit 1 ;; esac
+              n=$(cat /build/names.txt)
+              case "$n" in *"Foo::bar"*) ;; *)
+                echo "GNU demangler native did not run; names still mangled:" >&2
+                echo "$n" >&2; exit 1 ;; esac
+            "%
+          ],
+        ],
+      } | Test,
+  },
+
   attrs = {
     upstream_version = version,
     # Root LICENSE is verbatim Apache-2.0. The tree aggregates ~20 further

--- a/packages/ghidra/build.ncl
+++ b/packages/ghidra/build.ncl
@@ -63,7 +63,6 @@ let version = "12.1.2" in
     # bison/flex (the generated parsers are checked in upstream and shipped).
     toolchain,
     make,
-    zlib, # only the `sleigh` target links it (-lz via the Makefile's $(LNK))
   ],
   runtime_deps = [
     bash, # every launcher is a POSIX shell script
@@ -323,5 +322,13 @@ let version = "12.1.2" in
     # is GPL-3.0 (already a separate top-level module for exactly that
     # reason), and lzfse is BSD-3-Clause.
     license_spdx = "Apache-2.0",
+    # This package installs UPSTREAM-BUILT binaries — the whole Java tree, and
+    # on amd64 the platform natives too — so record where they came from.
+    #
+    # Worth noting what this does NOT cover: on arm64 the five natives are
+    # COMPILED HERE from the C/C++ sources inside that same release zip,
+    # because upstream publishes no linux_arm_64 build. So the Java is
+    # upstream's binary, and the arm64 decompiler is ours.
+    binary_from = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_%{version}_build/",
   },
 } | BuildSpec

--- a/packages/ghidra/build.ncl
+++ b/packages/ghidra/build.ncl
@@ -42,6 +42,20 @@ let version = "12.1.2" in
       url = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_%{version}_build/ghidra_%{version}_PUBLIC_20260605.zip",
       sha256 = "b62e81a0390618466c019c60d8c2f796ced2509c4c1aea4a37644a77272cf99d",
     } | Source,
+    # The aarch64 7-Zip JNI native. Upstream's `-all-platforms` roll-up
+    # deliberately excludes ARM ("WARNING: Not a part of -AllPlatform or
+    # -AllLinux !!!"), but the per-platform artifact IS published at the exact
+    # version Ghidra vendors. Closes the only genuine arm64/amd64 capability
+    # gap in this package.
+    #
+    # Deliberately SECOND: pkgmgr's updater rewrites only the FIRST sha256, and
+    # this pin must NOT track the Ghidra version — upstream froze it in 2016.
+    # build.sh asserts the vendored version still matches and fails the build
+    # if a Ghidra bump ever revendors it.
+    {
+      url = "https://repo1.maven.org/maven2/net/sf/sevenzipjbinding/sevenzipjbinding-linux-arm64/16.02-2.01/sevenzipjbinding-linux-arm64-16.02-2.01.jar",
+      sha256 = "da89d64861ed45063dc9d655a0c745ca097bd341765d7f0bbedcca1c961d1771",
+    } | Source,
     base,
     python, # `python3 -m zipfile` does the extraction
     # The natives upstream does not publish for linux_arm_64 are compiled from

--- a/packages/ghidra/build.ncl
+++ b/packages/ghidra/build.ncl
@@ -208,7 +208,36 @@ let version = "12.1.2" in
           # ...and resolved to the ARM platform specifically. If the swap ever
           # regresses to shipping the all-platforms jar, the list stops being a
           # single entry and this is what notices.
-          ["/bin/bash", "-c", "grep -q 'PLATFORM=Linux-arm64' /build/7z.out"],
+          # ...and resolved to THIS HOST's platform. Deliberately derived from
+          # uname rather than hardcoded: the first version of this test
+          # asserted Linux-arm64 unconditionally and failed CI on amd64, where
+          # the correct answer is Linux-amd64 — the assertion encoded the
+          # architecture I happened to build on.
+          #
+          # Still catches the regression that matters. On arm64 the answer is
+          # Linux-arm64 ONLY because build.sh replaced the all-platforms jar
+          # with the per-platform one; if that swap regresses, the platform
+          # list stops being a single entry, getPlatformBestMatch() falls back
+          # to matching os.arch ("aarch64") against "Linux-arm64", and fails —
+          # so this reports Linux-amd64 or nothing on an arm64 host, and the
+          # test fails.
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              case "$(uname -m)" in
+                aarch64 | arm64) want=Linux-arm64 ;;
+                x86_64) want=Linux-amd64 ;;
+                *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+              esac
+              grep -q "PLATFORM=$want" /build/7z.out || {
+                echo "expected PLATFORM=$want for $(uname -m); got:" >&2
+                cat /build/7z.out >&2
+                exit 1
+              }
+            "%
+          ],
           # ...and genuinely decompressed the container: the inner filename can
           # only appear if 7-Zip enumerated the archive.
           ["/bin/bash", "-c", "grep -q 'ENTRY=SEVENZIP_PARITY_OK.txt' /build/7z.out"],

--- a/packages/ghidra/build.sh
+++ b/packages/ghidra/build.sh
@@ -1,0 +1,289 @@
+#!/bin/sh
+set -ex
+
+# The asset is `ghidra_<version>_PUBLIC_<builddate>.zip` and extracts to
+# `ghidra_<version>_PUBLIC/`. The build date is globbed rather than pinned as a
+# second build_arg on purpose: pkgmgr's updater rewrites the `version` binding
+# and the first sha256, so a separate date pin would silently go stale on every
+# bump — a near-miss pin that looks maintained is worse than no pin.
+python3 -m zipfile -e ghidra_${MINIMAL_ARG_VERSION}_PUBLIC_*.zip .
+
+SRC="$(pwd)/ghidra_${MINIMAL_ARG_VERSION}_PUBLIC"
+GHIDRA_TREE="$OUTPUT_DIR/usr/share/ghidra"
+
+mkdir -p $OUTPUT_DIR/usr/{bin,share/ghidra}
+cp -r "$SRC"/* "$GHIDRA_TREE/"
+
+# Drop the GhidraClass training material. It is 16 deliberately-crafted ELF
+# executables and shared objects used for teaching RE — nothing execs them, and
+# shipping unowned binaries inside a data output is exactly what the
+# output-types checker is there to catch. (They are also invisible to pkgscan,
+# which is a poor property for binaries we ship.)
+rm -rf "$GHIDRA_TREE/docs/GhidraClass"
+
+# Drop the Windows and macOS natives. This is a Linux package; they are dead
+# weight, and declaring them as executables makes the output checker try to
+# parse PE/Mach-O as ELF. Keeping only os/linux_* also makes the ARCH GAP
+# legible instead of hidden behind three other platforms.
+find "$GHIDRA_TREE" -type d -name "win_*" -prune -exec rm -rf {} +
+find "$GHIDRA_TREE" -type d -name "mac_*" -prune -exec rm -rf {} +
+
+# ...and the 7-Zip JNI blobs, which the two finds above MISS: sevenzipjbinding
+# uses its own platform naming (`Mac-x86_64`, `Windows-amd64`), not Ghidra's
+# `os/<platform>` convention, so 7.7 MB of Mach-O dylib and PE DLL survived the
+# "drop Windows and macOS" step for as long as this package has existed.
+#
+# NOTE the residual gap: the vendored sevenzipjbinding-16.02 jar has NO aarch64
+# build for ANY OS (Linux-amd64, Linux-i386, Mac-x86_64, Windows-amd64,
+# Windows-x86 only), so 7z/RAR *container* browsing is permanently unavailable
+# on arm64 — it degrades to a single Msg.warn from
+# SevenZipFileSystemFactory.initNativeLibraries(). Nothing below can fix that;
+# it needs a newer upstream sevenzipjbinding. ELF import/analysis/decompilation
+# does not touch it.
+rm -rf "$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Mac-x86_64"
+rm -rf "$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Windows-amd64"
+
+# ---------------------------------------------------------------------------
+# Platform natives
+# ---------------------------------------------------------------------------
+#
+# Upstream's release matrix publishes natives for linux_x86_64, mac_arm_64,
+# mac_x86_64 and win_x86_64 — and NOT linux_arm_64. That is a build-farm gap,
+# not a portability gap: every one of these components already declares
+# `targetPlatform "linux_arm_64"` in its own Gradle native model, and the
+# mac_arm_64 binaries in this same zip are built from the identical sources.
+#
+# The consequence on an arm64 host is not a warning, it is a silently degraded
+# run. Application.getModuleOSFile() implements an x86_64 fallback ONLY for
+# WIN_ARM_64 (Windows emulation) and MAC_ARM_64 (Rosetta 2) — there is
+# deliberately no LINUX_ARM_64 arm. So `decompile` is simply not found;
+# DecompileProcessFactory logs one error behind a static latch, openProgram()
+# returns false, and the five callers that ignore that boolean (CppExporter,
+# DecompilerParameterIdCmd, DecompilerCallback, ObjcMessageAnalyzer,
+# FormatStringAnalyzer) carry on. analyzeHeadless then exits 0 having produced
+# no decompiled C.
+#
+# We close the gap by building the natives from the C/C++ sources that the
+# release zip ALREADY SHIPS — `src/decompile/**`, `GPL/DemanglerGnu/src/**`
+# and `src/lzfse/**` are included in the distribution on purpose (see the
+# `assembleDistribution { from(projectDir) { include "src/decompile/**" } }`
+# blocks upstream) and are byte-identical to the git tag. No second Source, no
+# second sha256 for the updater to leave stale, no network.
+case "$(uname -m)" in
+    aarch64 | arm64) HOST_OSDIR=linux_arm_64 ;;
+    x86_64) HOST_OSDIR=linux_x86_64 ;;
+    *)
+        echo "unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+# The three modules that carry `os/<platform>` natives. Everything else under
+# os/ is a README or a Windows-only tool (PDB/pdb.exe, GPL/DMG llio DLLs).
+NATIVE_MODULES="Ghidra/Features/Decompiler GPL/DemanglerGnu Ghidra/Features/FileFormats"
+
+if [ -f "$GHIDRA_TREE/Ghidra/Features/Decompiler/os/$HOST_OSDIR/decompile" ]; then
+    # Upstream started publishing this platform. Say so out loud rather than
+    # letting the build step quietly become a no-op — a silent skip here is
+    # indistinguishable from a silent failure.
+    echo "upstream ships $HOST_OSDIR natives; skipping the local native build"
+else
+    echo "upstream ships no $HOST_OSDIR natives; building them from the source in the release zip"
+
+    # --- decompile + sleigh -------------------------------------------------
+    #
+    # Built via the Makefile upstream ships alongside the sources (Gradle is
+    # NOT required and would want the network). Three overrides, each needed:
+    #
+    #  ARCH_TYPE=   The whole arm64 fix. The Makefile's arch detection is
+    #               `ifeq ($(ARCH),x86_64) -m64 else -m32` and carries an
+    #               in-tree "# TODO: need to revise to support arm64/aarch64",
+    #               so aarch64 falls into the -m32 branch, which aarch64 g++
+    #               does not implement. Note `make ARCH=aarch64` does NOT help
+    #               — every non-x86_64 value takes the else. ARCH_TYPE is a
+    #               plain `=` with no `override`, so the command line wins.
+    #               (OSDIR does NOT need overriding: it is read only by the
+    #               install_ghidra* targets, which copy into $(GHIDRA_BIN) =
+    #               ../../../../../../../ghidra.bin, a sibling dev checkout we
+    #               do not have. We install the artifacts ourselves below.)
+    #
+    #  YACC/LEX     Tripwires, not decoration — see the `touch` note below.
+    #
+    #  ADDITIONAL_FLAGS / MAKE_STATIC
+    #               The two slots the Makefile threads into every recipe:
+    #               ADDITIONAL_FLAGS lands on compile AND link, MAKE_STATIC on
+    #               link only. Determinism flags per pkgs AGENTS.md.
+    cd "$SRC/Ghidra/Features/Decompiler/src/decompile/cpp"
+
+    # `python3 -m zipfile` restores no mtimes, so extracted files inherit
+    # ARCHIVE ORDER — and slghparse.y sits ~130 entries AFTER slghparse.cc.
+    # Make therefore believes the checked-in parser is stale and reaches for
+    # bison, then (via the recipe-less `slghparse.hh: slghparse.y slghparse.cc`
+    # rule cascading into slghscan.cc) for $(LEX), which the Makefile never
+    # assigns — so it falls back to make's builtin `lex`, not even flex.
+    # Neither exists in this sandbox and there is no network to fetch them.
+    # Re-stamp the committed generated parsers so no .y/.l is newer than its
+    # own output. The `[ -f ]` guard matters: a bare `touch` on a file upstream
+    # removed would CREATE an empty stub and break the compile confusingly.
+    for f in grammar.cc grammar.hh xml.cc xml.hh pcodeparse.cc pcodeparse.hh \
+        slghparse.cc slghparse.hh slghscan.cc; do
+        [ -f "$f" ]
+        touch "$f"
+    done
+
+    # Two SEPARATE invocations on purpose. The Makefile selects its dependency
+    # file with a ladder of exact `ifeq ($(MAKECMDGOALS),<goal>)` tests; with
+    # two goals MAKECMDGOALS is the string "ghidra_opt sleigh_opt", matches
+    # none of them, and DEPNAMES falls back to `com_dbg/depend com_opt/depend`
+    # — the console-mode set, which drags in loadimage_bfd.cc (<bfd.h>) and
+    # rulecompile.cc (ruleparse.hh, whose .y has no checked-in output). A bare
+    # `make` with no goal lands in the same fallback.
+    MAKE_OVERRIDES="ARCH_TYPE= YACC=false LEX=false"
+    MAKE_REPRO="ADDITIONAL_FLAGS=-ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+    # shellcheck disable=SC2086
+    make -j"$(nproc)" $MAKE_OVERRIDES \
+        "$MAKE_REPRO" MAKE_STATIC="-Wl,--build-id=none" ghidra_opt
+
+    # `sleigh` is NOT resolved by anything at runtime — there is no
+    # getOSFile("sleigh") anywhere in the shipped Java, support/sleigh launches
+    # the pure-Java ghidra.pcodeCPort.slgh_compile.SleighCompileLauncher, and
+    # 135 prebuilt .sla files ship in the zip. We build it anyway for parity
+    # with every platform upstream publishes, so nobody has to re-derive this
+    # question from a half-populated os/linux_arm_64. It is the only target
+    # that needs zlib (-lz via $(LNK)); if it ever becomes a maintenance
+    # problem, deleting this one invocation plus the zlib deps is safe.
+    # shellcheck disable=SC2086
+    make -j"$(nproc)" $MAKE_OVERRIDES \
+        "$MAKE_REPRO" MAKE_STATIC="-Wl,--build-id=none" sleigh_opt
+
+    # Upstream's own rename (install_ghidraopt does `cp ghidra_opt ... decompile`).
+    install -Dm755 ghidra_opt \
+        "$GHIDRA_TREE/Ghidra/Features/Decompiler/os/$HOST_OSDIR/decompile"
+    install -Dm755 sleigh_opt \
+        "$GHIDRA_TREE/Ghidra/Features/Decompiler/os/$HOST_OSDIR/sleigh"
+
+    # --- demangler_gnu_v2_24 / v2_41 ---------------------------------------
+    #
+    # REQUIRED, not optional: GnuDemangler.demangle() goes straight to
+    # GnuDemanglerNativeProcess with no pure-Java fallback, and the default
+    # analyzer setting is GNU_DEMANGLER_V2_41 — so without these, every C++
+    # binary loses symbol demangling.
+    #
+    # These have no Makefile; they are plain C built by a Gradle native model.
+    # The flags below are transcribed from GPL/DemanglerGnu/build.gradle, which
+    # (unlike the other two buildNatives.gradle files) IS shipped in the zip —
+    # so this recipe stays checkable against the source we build from. The
+    # -DMAIN_CPLUS_DEM asymmetry is load-bearing: v2_24's main() lives inside
+    # `#ifdef MAIN_CPLUS_DEM` in cplus-dem.c, while v2_41 gets its main from
+    # cxxfilt.c and must NOT have the define.
+    for v in 24 41; do
+        case "$v" in
+            24) DEMANGLER_MAIN="-DMAIN_CPLUS_DEM" ;;
+            *) DEMANGLER_MAIN="" ;;
+        esac
+        cd "$SRC/GPL/DemanglerGnu/src/demangler_gnu_v2_$v"
+        # shellcheck disable=SC2086
+        gcc -std=gnu17 $DEMANGLER_MAIN -DHAVE_STDLIB_H -DHAVE_STRING_H \
+            -ffile-prefix-map="$(pwd)=/builddir" -gno-record-gcc-switches \
+            -Wl,--build-id=none \
+            -I headers c/*.c -o "demangler_gnu_v2_$v"
+        install -Dm755 "demangler_gnu_v2_$v" \
+            "$GHIDRA_TREE/GPL/DemanglerGnu/os/$HOST_OSDIR/demangler_gnu_v2_$v"
+    done
+
+    # --- lzfse --------------------------------------------------------------
+    #
+    # Optional (Apple-compressed filesystems only), but it is eight C files and
+    # building it is what lets us drop os/linux_x86_64 wholesale below.
+    #
+    # Flags from Ghidra/Features/FileFormats/buildNatives.gradle at tag
+    # Ghidra_<version>_build. That file is NOT in the release zip, so unlike
+    # the demangler above this recipe is transcribed and must be re-checked
+    # against the tag if the lzfse build ever misbehaves. `c/*.c` currently
+    # resolves to exactly the eight files upstream lists by name.
+    #
+    # -D__arm64__ is a real correctness fix, not a hack: lzfse gates its 64-bit
+    # FSE bitstream and its int64 lzfse_offset/lzvn_offset on
+    # `defined(_M_AMD64) || defined(__x86_64__) || defined(__arm64__)`, and
+    # __arm64__ is an APPLE-only predefined macro — Linux aarch64 compilers
+    # define only __aarch64__. Without it we would silently get the 32-bit
+    # path (slower, and int32 buffer offsets) on the one platform upstream has
+    # never built.
+    case "$HOST_OSDIR" in
+        linux_arm_64) LZFSE_ARCH_DEFINE="-D__arm64__" ;;
+        *) LZFSE_ARCH_DEFINE="" ;;
+    esac
+    cd "$SRC/Ghidra/Features/FileFormats/src/lzfse/c"
+    # shellcheck disable=SC2086
+    gcc -std=c99 -Wall -O2 -DLINUX -D_LINUX $LZFSE_ARCH_DEFINE \
+        -ffile-prefix-map="$(pwd)=/builddir" -gno-record-gcc-switches \
+        -Wl,--build-id=none \
+        ./*.c -o lzfse
+    install -Dm755 lzfse \
+        "$GHIDRA_TREE/Ghidra/Features/FileFormats/os/$HOST_OSDIR/lzfse"
+
+    cd "$SRC/.."
+fi
+
+# The remaining 7-Zip JNI blob is x86_64-only and there is no aarch64 build to
+# put in its place (see above). Drop it on a non-x86_64 host: it can never
+# load here, and removing it makes the outcome deterministic — an absent
+# platform directory raises the SevenZipNativeInitializationException that
+# SevenZipFileSystemFactory.initNativeLibraries() actually catches, rather
+# than an arch-mismatch UnsatisfiedLinkError, which is an Error and not
+# covered by that catch.
+if [ "$HOST_OSDIR" != linux_x86_64 ]; then
+    rm -rf "$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Linux-amd64"
+fi
+
+# Now that os/$HOST_OSDIR is populated for every native module, drop the
+# foreign-arch Linux natives. Before this, an arm64 package shipped 4.8 MB of
+# x86_64 ELF that can never execute here (and, sitting inside an OutputData
+# glob with allow_executable, that the output-types checker explicitly
+# no-ops rather than arch-checks). Restricted to the three native modules on
+# purpose, so the extension-skeleton READMEs under Extensions/.../os/ survive.
+for m in $NATIVE_MODULES; do
+    for d in "$GHIDRA_TREE/$m"/os/linux_*; do
+        [ -d "$d" ] || continue
+        [ "$(basename "$d")" = "$HOST_OSDIR" ] || rm -rf "$d"
+    done
+done
+
+# `python3 -m zipfile` does not preserve the executable bit, so every launcher
+# and every prebuilt native arrives non-executable. Restore them explicitly
+# rather than blanket-chmod'ing the tree.
+#
+# The per-module loop replaces an earlier `Ghidra/Features/*/os` glob that
+# never reached GPL/DemanglerGnu — which is why the two GNU demanglers have
+# been shipping mode 0644 (Ghidra execs them by absolute path via
+# Runtime.exec, so that was a live, silent breakage on x86_64 too). It also
+# stops chmod'ing GhidraServer/os/readme.txt.
+chmod +x "$GHIDRA_TREE/ghidraRun"
+chmod +x "$GHIDRA_TREE"/support/*
+for m in $NATIVE_MODULES; do
+    find "$GHIDRA_TREE/$m/os/$HOST_OSDIR" -type f -exec chmod +x {} \;
+done
+
+# `analyzeHeadless` is the whole reason this is packaged — the GUI is a bonus.
+# Both launchers resolve the install root from their own path, so a symlink
+# would break them; wrap instead.
+#
+# JAVA_HOME is set here rather than left to the session because Ghidra's
+# launcher searches a hardcoded list of distro JDK paths that does not include
+# our merged /usr tree, and fails with "Failed to find a supported JDK" even
+# though `java` is on PATH.
+for launcher in analyzeHeadless ghidraRun pyghidraRun; do
+    [ -f "$GHIDRA_TREE/support/$launcher" ] ||
+        [ -f "$GHIDRA_TREE/$launcher" ] || continue
+    cat > $OUTPUT_DIR/usr/bin/$launcher << EOF
+#!/bin/sh
+export JAVA_HOME=\${JAVA_HOME:-/usr/lib/jvm}
+export GHIDRA_INSTALL_DIR=/usr/share/ghidra
+if [ -x "/usr/share/ghidra/support/$launcher" ]; then
+    exec /usr/share/ghidra/support/$launcher "\$@"
+fi
+exec /usr/share/ghidra/$launcher "\$@"
+EOF
+    chmod +x $OUTPUT_DIR/usr/bin/$launcher
+done

--- a/packages/ghidra/build.sh
+++ b/packages/ghidra/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -eux
 
 # The asset is `ghidra_<version>_PUBLIC_<builddate>.zip` and extracts to
 # `ghidra_<version>_PUBLIC/`. The build date is globbed rather than pinned as a
@@ -30,18 +30,94 @@ find "$GHIDRA_TREE" -type d -name "mac_*" -prune -exec rm -rf {} +
 
 # ...and the 7-Zip JNI blobs, which the two finds above MISS: sevenzipjbinding
 # uses its own platform naming (`Mac-x86_64`, `Windows-amd64`), not Ghidra's
-# `os/<platform>` convention, so 7.7 MB of Mach-O dylib and PE DLL survived the
-# "drop Windows and macOS" step for as long as this package has existed.
-#
-# NOTE the residual gap: the vendored sevenzipjbinding-16.02 jar has NO aarch64
-# build for ANY OS (Linux-amd64, Linux-i386, Mac-x86_64, Windows-amd64,
-# Windows-x86 only), so 7z/RAR *container* browsing is permanently unavailable
-# on arm64 — it degrades to a single Msg.warn from
-# SevenZipFileSystemFactory.initNativeLibraries(). Nothing below can fix that;
-# it needs a newer upstream sevenzipjbinding. ELF import/analysis/decompilation
-# does not touch it.
+# `os/<platform>` convention.
 rm -rf "$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Mac-x86_64"
 rm -rf "$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Windows-amd64"
+
+# Host architecture, resolved ONCE and early because two later sections branch
+# on it. It used to be defined below the 7-Zip block that reads it, so
+# $HOST_OSDIR was empty there and the arm64 arm silently never ran — the build
+# still succeeded and simply produced a package missing the thing it had just
+# been taught to add. `set -u` above now makes that class of mistake fatal
+# instead of quiet.
+case "$(uname -m)" in
+    aarch64 | arm64) HOST_OSDIR=linux_arm_64 ;;
+    x86_64) HOST_OSDIR=linux_x86_64 ;;
+    *)
+        echo "unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 7-Zip JNI native — the one real arm64/amd64 PARITY gap, and it is closable.
+# ---------------------------------------------------------------------------
+#
+# Upstream's `-all-platforms` roll-up ships Linux-amd64, Linux-i386,
+# Mac-x86_64, Windows-amd64 and Windows-x86 — no ARM, BY DESIGN (upstream
+# ReleaseNotes.txt: "ARM (WARNING: Not a part of -AllPlatform or -AllLinux
+# !!!)"). But the per-platform artifact exists at the EXACT version Ghidra
+# vendors, and has since Feb 2020. This was a missing artifact reference, not
+# a missing build — an earlier revision of this file asserted the opposite.
+#
+# Without it an arm64 user loses 7z/RAR/CAB/CHM/LHA/ARJ/WIM/VHD/XAR/RPM
+# containers and — worse, because it is silent — `.zip`/`.apk`/`.jar` quietly
+# fall back to java.util.zip, losing password-protected and obfuscated entries.
+# analyzeHeadless swallows the failure and exits 0.
+#
+# ONE NON-OBVIOUS CONSTRAINT. SevenZip.getPlatformBestMatch() returns
+# availablePlatform.get(0) unconditionally when the list holds exactly ONE
+# entry; otherwise it matches os.name+"-"+os.arch, which here is
+# "Linux-aarch64" and can NEVER equal the artifact's "Linux-arm64". So the
+# arm64 jar must REPLACE the all-platforms jar rather than accompany it
+# (getPlatformList reads the FIRST platforms.properties on the classpath, and
+# GhidraLauncher sorts jars by filename, so "all-platforms" would
+# deterministically win), and the platform must stay spelled "Linux-arm64" —
+# that string indexes BOTH the on-disk data dir AND a classpath resource, so
+# renaming either half breaks the other.
+SZ_VER=16.02-2.01
+SZ_LIB="$GHIDRA_TREE/Ghidra/Features/FileFormats/lib"
+SZ_DATA="$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs"
+
+# This native jar is pinned INDEPENDENTLY of the Ghidra version, which is
+# correct (upstream froze it) but creates skew risk: a Ghidra bump that
+# revendors sevenzipjbinding would pair new Java classes with our old native,
+# and a JNI symbol mismatch degrades SILENTLY. Make that a build failure on the
+# exact PR that causes it, rather than a mystery months later.
+VENDORED=$(basename "$SZ_LIB"/sevenzipjbinding-[0-9]*.jar .jar)
+VENDORED=${VENDORED#sevenzipjbinding-}
+if [ "$VENDORED" != "$SZ_VER" ]; then
+    echo "ghidra revendored sevenzipjbinding $VENDORED; our pinned native is $SZ_VER" >&2
+    exit 1
+fi
+
+if [ "$HOST_OSDIR" = linux_arm_64 ]; then
+    rm -f "$SZ_LIB"/sevenzipjbinding-all-platforms-*.jar
+    cp "sevenzipjbinding-linux-arm64-$SZ_VER.jar" "$SZ_LIB/"
+
+    # Extract ONLY the .so — a plain unzip would scatter META-INF and a stray
+    # platforms.properties into the data directory.
+    python3 - "$SZ_LIB/sevenzipjbinding-linux-arm64-$SZ_VER.jar" "$SZ_DATA/Linux-arm64" <<'PYX'
+import pathlib, sys, zipfile
+jar, dest = sys.argv[1], pathlib.Path(sys.argv[2])
+dest.mkdir(parents=True, exist_ok=True)
+with zipfile.ZipFile(jar) as z:
+    blob = z.read("Linux-arm64/lib7-Zip-JBinding.so")
+(dest / "lib7-Zip-JBinding.so").write_bytes(blob)
+PYX
+
+    # ASSERT THE ARCH of anything we inject. Upstream release CI genuinely does
+    # mislabel assets (Z3 publishes an "arm64" zip containing x86-64 binaries),
+    # and a wrong blob would look exactly like parity while failing at
+    # System.load — inside a data file the output-types checker never opens.
+    python3 -c 'import sys; d=open(sys.argv[1],"rb").read(20); m=int.from_bytes(d[18:20],"little"); sys.exit(0 if m==0xb7 else "not aarch64: e_machine=0x%x" % m)' \
+        "$SZ_DATA/Linux-arm64/lib7-Zip-JBinding.so"
+    chmod 755 "$SZ_DATA/Linux-arm64/lib7-Zip-JBinding.so"
+
+    # Exactly one classes jar + one platform jar. Two platform jars would send
+    # getPlatformBestMatch() back to the os.arch match, which cannot succeed.
+    test "$(ls "$SZ_LIB"/sevenzipjbinding-*.jar | wc -l)" -eq 2
+fi
 
 # ---------------------------------------------------------------------------
 # Platform natives
@@ -69,14 +145,7 @@ rm -rf "$GHIDRA_TREE/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Windows
 # `assembleDistribution { from(projectDir) { include "src/decompile/**" } }`
 # blocks upstream) and are byte-identical to the git tag. No second Source, no
 # second sha256 for the updater to leave stale, no network.
-case "$(uname -m)" in
-    aarch64 | arm64) HOST_OSDIR=linux_arm_64 ;;
-    x86_64) HOST_OSDIR=linux_x86_64 ;;
-    *)
-        echo "unsupported architecture: $(uname -m)" >&2
-        exit 1
-        ;;
-esac
+
 
 # The three modules that carry `os/<platform>` natives. Everything else under
 # os/ is a README or a Windows-only tool (PDB/pdb.exe, GPL/DMG llio DLLs).
@@ -259,9 +328,44 @@ done
 # been shipping mode 0644 (Ghidra execs them by absolute path via
 # Runtime.exec, so that was a live, silent breakage on x86_64 too). It also
 # stops chmod'ing GhidraServer/os/readme.txt.
-chmod +x "$GHIDRA_TREE/ghidraRun"
-chmod +x "$GHIDRA_TREE"/support/*
+# ...and a hand-maintained list has now been wrong TWICE: first the two GNU
+# demanglers (see above), and still today 27 shell scripts — every one of the
+# debugger-launcher `.sh` files and all of `server/` — because `support/*` is a
+# SHALLOW glob. Verified in a built tree: 27 `.sh` files without the exec bit
+# against 1 with it.
+#
+# So stop maintaining a list. Restore the bit on exactly the files UPSTREAM
+# marked executable, read from the zip's own mode metadata, skipping anything
+# we deliberately deleted. This tracks upstream's intent across every future
+# release instead of drifting from it.
+python3 - ghidra_${MINIMAL_ARG_VERSION}_PUBLIC_*.zip "$GHIDRA_TREE" <<'PY'
+import os, sys, zipfile
+
+zpath, tree = sys.argv[1], sys.argv[2]
+restored = skipped = 0
+with zipfile.ZipFile(zpath) as z:
+    for info in z.infolist():
+        if info.is_dir():
+            continue
+        # Strip the leading `ghidra_<version>_PUBLIC/` component.
+        rel = info.filename.split("/", 1)
+        if len(rel) != 2:
+            continue
+        if not (info.external_attr >> 16) & 0o111:
+            continue
+        path = os.path.join(tree, rel[1])
+        if not os.path.exists(path):
+            skipped += 1      # win_*/mac_*/GhidraClass/sevenzip — deleted above
+            continue
+        os.chmod(path, os.stat(path).st_mode | 0o111)
+        restored += 1
+print("exec bit restored on %d files (%d deliberately-deleted skipped)"
+      % (restored, skipped))
+PY
+
+# The natives we BUILT are not in the zip, so they need it explicitly.
 for m in $NATIVE_MODULES; do
+    [ -d "$GHIDRA_TREE/$m/os/$HOST_OSDIR" ] || continue
     find "$GHIDRA_TREE/$m/os/$HOST_OSDIR" -type f -exec chmod +x {} \;
 done
 


### PR DESCRIPTION
The only credible open decompiler for native code, and the anchor of a reverse-engineering loadout. `analyzeHeadless` is the point — it makes Ghidra scriptable across a fleet of binaries rather than a GUI you drive by hand.

Apache-2.0 at the root; the tree aggregates ~20 further licences (GPL-2.0 WITH Classpath-exception, LGPL, BSD, MIT, Zlib, MPL-2.0, Python-2.0 …) — **all OSI/FSF-free, nothing proprietary**.

## Prebuilt release, not a source build

Ghidra's Gradle build runs `fetchDependencies.gradle` **before** compiling anything: 67 URLs across seven hosts, including binaries with no source (AXMLPrinter2.jar from the dead Google Code archive, per-platform Z3 zips), a postgresql tarball and PyPI wheels. It also requires JDK 25 to build; we ship 21.

The release zip is the same tradeoff the `jdk` package already makes, and it bundles **no JRE**, so Ghidra runs on our jdk rather than smuggling in a second Java.

## arm64 was not at parity, and now is

Upstream publishes natives for `linux_x86_64`, `mac_arm_64`, `mac_x86_64`, `win_x86_64` — and **not `linux_arm_64`**. On an arm64 host that is not a warning, it is a **silently degraded run**: `Application.getModuleOSFile()` has x86_64 fallbacks only for `WIN_ARM_64` (emulation) and `MAC_ARM_64` (Rosetta), so `decompile` is simply not found and `analyzeHeadless` exits **0** having produced no C.

Closed by building the five natives from C/C++ sources the release zip **already ships** — no second Source, no network, no Gradle. `ARCH_TYPE=` is the whole fix: the Makefile is `ifeq ($(ARCH),x86_64) -m64 else -m32` with an in-tree `TODO: need to revise to support arm64/aarch64`, so **`make ARCH=aarch64` would look right and do nothing** — every non-x86_64 value takes the `else`.

The 7-Zip gap was closable too, contrary to what an earlier revision of this PR asserted. Upstream's `-all-platforms` roll-up excludes ARM *by design*, but the per-platform artifact exists on Maven Central at the exact version Ghidra vendors.

## Three pre-existing bugs fixed along the way

- **`GPL/DemanglerGnu/os/` was never chmod'd** — verified in a built tree: both demanglers were mode **0644** while the decompiler natives were 0755. Ghidra `Runtime.exec()`s them by absolute path with no fallback, so **C++ demangling was silently broken**, on x86_64 too.
- **27 shell scripts had no exec bit** — every debugger launcher and all of `server/` — because `support/*` is a shallow glob. Now driven from the zip's own mode metadata, so it tracks upstream's intent. It correctly leaves `*setuputils.sh` alone: those are *sourced* libraries.
- **The win/mac prune missed the 7-Zip JNI blobs**, which use `Mac-x86_64`/`Windows-amd64` rather than Ghidra's `os/<platform>` convention.

## Tests, because the failures here are silent

Two, both mutation-tested (breaking each assertion makes `minimal check` fail):

**`headless_decompile`** — compiles a namespaced C++ binary, decompiles it, asserts real C comes back *and* that `Foo::bar` demangled. It is written against `decompileCompleted()` alone, because the alternatives lie: `isValid()` returns **true** for a decompile that produced nothing, and `isCancelled()` reports a *missing native* as a user cancellation. Nothing asserts on `analyzeHeadless`'s exit code — it has **zero `System.exit` calls** and exits 0 when the postScript throws.

**`sevenzip_native`** — proves the 7-Zip fix *works* rather than that a file exists. Its own output:

```
PLATFORM=Linux-arm64
ENTRY=SEVENZIP_PARITY_OK.txt
```

The platform assertion is load-bearing: if the jar swap regresses to shipping `all-platforms` alongside, the platform list stops being a single entry, `getPlatformBestMatch()` falls back to matching `os.arch` (`aarch64`) against `Linux-arm64`, and can never succeed.

## Review feedback applied

- **@twitchyliquid64: set `binary_from`** — correct, and ghidra was the only prebuilt package here not declaring it (chromium-bin, claude-code, gcloud, ampcode, android-sdk, cf, edgedelta all do). The comment records what it does *not* cover: the arm64 natives are compiled here, so the Java is upstream's binary and the arm64 decompiler is ours.
- **CodeRabbit: `zlib` duplicated in `build_deps` and `runtime_deps`** — also correct. Carried real risk since `sleigh` links `-lz` at build time, so I rebuilt rather than assumed: exit 0, 14/14, `sleigh` still links `libz.so`.

## Verified

```
minimal package --rebuild --no-fetch ghidra   exit 0
minimal check --packages ghidra               14/14 pass
natives                                       5/5 ELF aarch64, mode 0755
foreign-arch binaries in tree                 0
reproducibility                               byte-identical across rebuilds
installed size                                850M
```

## Known limits

- **850M installed** — by far the largest package in the repo. Worth a conscious call on cache/closure pressure.
- **Z3 symbolic execution** ships no `linux_arm_64`; fails *loudly*. Closing it means moving off the pinned Z3, whose own "arm64" asset contains x86-64 binaries — which is why the 7-Zip injection asserts `e_machine` on anything it adds.
- **The x86_64 path** takes upstream's natives via a `[ -f ]` guard and could not be exercised on this arm64 host.

Followed by a second PR adding gef, rizin and the `reveng` loadout, which needs this one to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ghidra 12.1.2.
  * Added native arm64 7-Zip archive handling.
  * Added launchers and platform-native libraries for supported environments.
  * Added headless native decompilation with GNU symbol demangling.
* **Tests**
  * Added validation for arm64 archive reading and native decompilation.
* **Documentation**
  * Added package metadata, including licensing and official source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->