### PR TITLE
capstone, upx, fq: complete the reverse-engineering workbench

### DIFF
--- a/packages/capstone/build.ncl
+++ b/packages/capstone/build.ncl
@@ -36,11 +36,16 @@ let version = "5.0.9" in
     {
       upstream_version = version,
       source_provenance = { category = 'GithubRepo, owner = "capstone-engine", repo = "capstone" },
-      # BSD-3-Clause (LICENSE.TXT). The tree also carries LICENSE_LLVM.TXT —
-      # Apache-2.0 WITH LLVM-exception — covering the arch decoders generated
-      # from LLVM's tables. Both are permissive; BSD-3-Clause is the stricter
-      # on attribution, so it is the honest single value.
-      license_spdx = "BSD-3-Clause",
+      # Two licences, both permissive, and the tree ships both files:
+      #   LICENSE.TXT       BSD-3-Clause (COSEINC)
+      #   LICENSE_LLVM.TXT  University of Illinois/NCSA Open Source License,
+      #                     covering the arch decoders generated from LLVM's
+      #                     tables. This is the OLD "LLVM Release License" —
+      #                     capstone 5.x predates LLVM's relicensing, so it is
+      #                     NCSA here, NOT Apache-2.0 WITH LLVM-exception.
+      # Recorded as the aggregate rather than the headline licence, since
+      # NCSA's attribution clause travels with the binary too.
+      license_spdx = "(BSD-3-Clause AND NCSA)",
     } | Attrs,
   tests = {
     smoketest = standaloneTest "/bin/cstool -v",

--- a/packages/capstone/build.ncl
+++ b/packages/capstone/build.ncl
@@ -1,0 +1,108 @@
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let ninja = import "../ninja/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let version = "5.0.9" in
+{
+  name = "capstone",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    cmake,
+    ninja,
+    pkgconf,
+    toolchain,
+    glibc,
+    {
+      url = "https://github.com/capstone-engine/capstone/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "0619da31af08152600af95c481527ef6d756c0a8404fca7544a4fdf6dfc2c0f9",
+      extract = true,
+      strip_prefix = "capstone-%{version}",
+    } | Source,
+  ],
+  cmd = "./build.sh",
+  outputs = {
+    cstool = { glob = "usr/bin/cstool" } | OutputBin,
+    libs = { glob = "usr/lib/libcapstone.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfig = { glob = "usr/lib/pkgconfig/*.pc" } | OutputData,
+    cmake_files = { glob = "usr/lib/cmake/**" } | OutputData,
+  },
+  runtime_deps = [glibc],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "capstone-engine", repo = "capstone" },
+      # BSD-3-Clause (LICENSE.TXT). The tree also carries LICENSE_LLVM.TXT —
+      # Apache-2.0 WITH LLVM-exception — covering the arch decoders generated
+      # from LLVM's tables. Both are permissive; BSD-3-Clause is the stricter
+      # on attribution, so it is the honest single value.
+      license_spdx = "BSD-3-Clause",
+    } | Attrs,
+  tests = {
+    smoketest = standaloneTest "/bin/cstool -v",
+
+    # DISASSEMBLE, don't just run --version.
+    #
+    # The failure this guards is a build that works and is quietly less
+    # capable. `CAPSTONE_ARCHITECTURE_DEFAULT` gates every per-arch
+    # `CAPSTONE_<ARCH>_SUPPORT` option, so changing one value drops whole
+    # architectures out of the library while cstool still builds, still runs,
+    # and still reports the same version. Nothing else here would notice:
+    # `enumerate bins` sees a binary, `output types valid` sees a .so, a
+    # smoke test sees a version string.
+    #
+    # So the assertions are real instructions on real bytes, including two
+    # fringe architectures — the ones a "slim it down" change removes first,
+    # and the ones an RE workbench misses last.
+    disassembles =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # x86-64: push rbp / mov rbp, rsp — the universal function prologue.
+          ["/bin/bash", "-c", "cstool x64 '554889e5' | grep -qi push && cstool x64 '554889e5' | grep -qi mov"],
+          # arm64: mul x1, x1, x2 — capstone's own test vector.
+          ["/bin/bash", "-c", "cstool arm64 '217c029b' | grep -qi mul"],
+          # 32-bit ARM: a branch-with-link.
+          ["/bin/bash", "-c", "cstool arm 'edffffeb' | grep -qi bl"],
+          # Fringe #1 — riscv64 (0x00000013 = nop).
+          ["/bin/bash", "-c", "cstool riscv64 '13000000' | grep -qiE 'nop|addi'"],
+          # Fringe #2 — ppc64, BIG-endian. `ppc64` alone is CS_MODE_LITTLE_ENDIAN
+          # in capstone 5 (cstool.c: "ppc64" => CS_MODE_64|CS_MODE_LITTLE_ENDIAN),
+          # and 7c0802a6 is the big-endian encoding of `mflr r0` — the mode
+          # name has to match the bytes or this decodes to garbage. Caught by
+          # running it: the first version used `ppc64` and failed.
+          ["/bin/bash", "-c", "cstool ppc64be '7c0802a6' | grep -qi mflr"],
+          # CONTROL: an architecture that does not exist must FAIL. Without
+          # this, every grep above could be matching an error message rather
+          # than disassembly, and the whole test would prove nothing.
+          ["/bin/bash", "-c", "! cstool no-such-arch 00 >/dev/null 2>&1"],
+        ],
+      } | Test,
+
+    # The shared library is the reason to package this rather than let each
+    # consumer vendor it. `BUILD_SHARED_LIBS` defaults to **OFF** upstream, so
+    # a stock build produces libcapstone.a only — and anything linking that
+    # absorbs capstone statically, making a capstone CVE invisible to pkgscan.
+    # That default is one line in build.sh away from silently coming back.
+    ships_shared_lib =
+      {
+        class = 'Standalone,
+        test_deps = [base, pkgconf],
+        cmds = [
+          ["/bin/bash", "-c", "test -e /usr/lib/libcapstone.so"],
+          # A real versioned SONAME, not just the dev symlink.
+          ["/bin/bash", "-c", "ls /usr/lib/libcapstone.so.* >/dev/null 2>&1"],
+          # ...and no static archive, so nobody links it by accident.
+          ["/bin/bash", "-c", "! test -e /usr/lib/libcapstone.a"],
+          # pkg-config must resolve, or a downstream build quietly falls back
+          # to its own vendored capstone.
+          ["/bin/bash", "-c", "PKG_CONFIG_PATH=/usr/lib/pkgconfig pkg-config --exists capstone"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/capstone/build.sh
+++ b/packages/capstone/build.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+export ARFLAGS=Drc
+
+# BUILD_SHARED_LIBS defaults to OFF and BUILD_STATIC_LIBS to ON upstream — the
+# opposite of what a distro wants. Left alone, this package would ship
+# libcapstone.a and every consumer would absorb capstone statically, which puts
+# a capstone CVE beyond pkgscan's reach: nothing in the consumer's tree would
+# name capstone at all. So shared on, static off, deliberately.
+#
+# CMAKE_INSTALL_LIBDIR=lib keeps the installed .pc and cmake files pointing at
+# usr/lib rather than the GNUInstallDirs 64-bit default lib64.
+#
+# CAPSTONE_ARCHITECTURE_DEFAULT=ON is the upstream default and is set here
+# explicitly because it is load-bearing: it gates every per-architecture
+# CAPSTONE_<ARCH>_SUPPORT option at once, and turning it off yields a working
+# cstool that silently cannot disassemble whole architectures. The
+# `disassembles` test pins the consequence rather than trusting this line.
+#
+# Tests off: upstream's suite needs its own fixtures and adds build time; the
+# standalone tests in build.ncl assert the properties we actually care about.
+cmake -S . -B build -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILD_STATIC_LIBS=OFF \
+  -DCAPSTONE_BUILD_CSTOOL=ON \
+  -DCAPSTONE_BUILD_TESTS=OFF \
+  -DCAPSTONE_BUILD_CSTEST=OFF \
+  -DCAPSTONE_ARCHITECTURE_DEFAULT=ON \
+  -DCAPSTONE_X86_REDUCE=OFF
+
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build

--- a/packages/fq/build.ncl
+++ b/packages/fq/build.ncl
@@ -1,0 +1,101 @@
+let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let go = import "../go/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let version = "0.17.0" in
+{
+  name = "fq",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    go,
+    toolchain,
+    {
+      url = "https://github.com/wader/fq/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "c5658b2bc635a1d344c64e37d7311157f0fc4b20cc3cfa4d09bdd2f023692d57",
+      extract = true,
+      strip_prefix = "fq-%{version}",
+    } | Source,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  outputs = {
+    fq = { glob = "usr/bin/fq" } | OutputBin,
+  },
+  # Empty by design: built CGO_ENABLED=0, so the binary is pure-Go static with
+  # no DT_NEEDED at all. Same shape as `helm`. If CGO ever creeps back in, the
+  # `missing runtime_deps` checker is what notices.
+  runtime_deps = [],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "wader", repo = "fq" },
+      license_spdx = "MIT",
+    } | Attrs,
+  tests = {
+    smoketest = standaloneTest "/bin/fq --version",
+
+    # DECODE SOMETHING. `fq --version` and even `fq -n '1+1'` pass on a build
+    # with every format decoder broken or absent: the jq engine is one Go
+    # package and the ~120 format decoders are another, and only the decoders
+    # are the reason to ship this tool.
+    #
+    # The gzip case is the sharp one — asserting on `compression_method`
+    # alone would only prove fq read two header bytes. Asserting on
+    # `uncompressed` proves it ran the DEFLATE decoder over the payload and
+    # got the original bytes back, which is the actual capability.
+    decodes =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              msg="hello world hello world"
+              printf '%s' "$msg" | gzip -n > /build/t.gz
+
+              # 1. The header field decodes symbolically, not as a raw number.
+              m=$(fq -d gzip -r '.members[0].compression_method | tovalue' /build/t.gz)
+              [ "$m" = "deflate" ] || { echo "compression_method=$m" >&2; exit 1; }
+
+              # 2. THE REAL ONE: fq inflated the payload and got our bytes back.
+              got=$(fq -d gzip -r '.members[0].uncompressed | tostring' /build/t.gz)
+              [ "$got" = "$msg" ] || {
+                echo "inflate mismatch: '$got' != '$msg'" >&2; exit 1; }
+            "%
+          ],
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              # 3. A second, unrelated decoder over a real file: fq's own ELF.
+              #
+              # Derived from uname rather than hardcoded — an earlier package
+              # in this loadout pinned an architecture literal and only failed
+              # once it reached amd64 CI. fq renders EM_ARM64 as "arm64" and
+              # EM_X86_64 as "x86_64" (format/elf/elf.go machineNames).
+              case "$(uname -m)" in
+                aarch64 | arm64) want=arm64 ;;
+                x86_64) want=x86_64 ;;
+                *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+              esac
+              got=$(fq -d elf -r '.header.machine | tovalue' /usr/bin/fq)
+              [ "$got" = "$want" ] || {
+                echo "elf machine: got '$got', want '$want'" >&2; exit 1; }
+            "%
+          ],
+          # 4. The jq engine itself still works. Last, because on its own it
+          #    proves the least.
+          ["/bin/bash", "-c", "test \"$(fq -n '1+1')\" = 2"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/fq/build.sh
+++ b/packages/fq/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+export GOROOT=/usr/go
+
+# CGO_ENABLED=0 is upstream's own build setting (see fq's Makefile) and is what
+# makes the result a pure-Go static binary with no DT_NEEDED — hence the empty
+# runtime_deps in build.ncl. Flipping this back on would silently add a libc
+# dependency that nothing here declares.
+export CGO_ENABLED=0
+
+# Reproducibility (see AGENTS.md): -trimpath strips the build directory out of
+# recorded paths and -buildid= clears the non-deterministic build ID. -s -w
+# drop the symbol and DWARF tables, matching the other Go packages here.
+#
+# No -X version stamping: fq keeps its version as a plain const in fq.go, so
+# `fq --version` already reports 0.17.0 from the source tree. A -ldflags -X
+# aimed at a const would be silently ignored — the linker only rewrites vars.
+go build -trimpath -ldflags "-buildid= -s -w" -o fq .
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+install -m 755 fq "$OUTPUT_DIR/usr/bin/fq"

--- a/packages/upx/build.ncl
+++ b/packages/upx/build.ncl
@@ -1,0 +1,129 @@
+let { standaloneTest, subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let ninja = import "../ninja/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let version = "5.2.0" in
+{
+  name = "upx",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    cmake,
+    ninja,
+    toolchain,
+    glibc,
+    {
+      # The `-src` release asset, not the git tag: it ships the vendored
+      # subprojects (ucl, lzma-sdk, zlib, zstd, bzip2, doctest) that are git
+      # submodules in the repo and would otherwise be empty directories.
+      #
+      # NOT `extract = true`: upstream compresses this with an xz SHA-256
+      # integrity check (`xz --list` reports `Check: SHA-256`, not the usual
+      # CRC64), and the fetcher's decoder rejects it outright —
+      #   compression error: Unsupported SHA-256 checksum (not yet implemented)
+      # build.sh unpacks it with the system tar instead, which handles it.
+      url = "https://github.com/upx/upx/releases/download/v%{version}/upx-%{version}-src.tar.xz",
+      sha256 = "af99e526d5759de94412aea1104d5e4ca406cb725295f8633ecc9e843dc1ce1c",
+    } | Source,
+  ],
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    upx = { glob = "usr/bin/upx" } | OutputBin,
+    mans = { glob = "usr/share/man/**" } | OutputData,
+    docs = { glob = "usr/share/doc/**" } | OutputData,
+  },
+  # upx is C++, so it carries libstdc++/libgcc beyond glibc. Caught by the
+  # `missing runtime_deps` checker rather than guessed: with only glibc here,
+  # even `upx --version-short` died with
+  #   error while loading shared libraries: libstdc++.so.6
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc", "libstdcpp"],
+  ],
+  attrs =
+    {
+      upstream_version = version,
+      source_provenance = { category = 'GithubRepo, owner = "upx", repo = "upx" },
+      # GPL-2.0-or-later: COPYING is the GPLv2 text and LICENSE says "either
+      # version 2 of the License, or (at your option) any later version".
+      #
+      # UPX additionally grants a special exception so that compressing a
+      # program does not impose the GPL on that program. That exception has no
+      # SPDX identifier, so it cannot be expressed in this field — recorded
+      # here instead, because the bare GPL value overstates the obligations on
+      # anything this tool merely packs.
+      license_spdx = "GPL-2.0-or-later",
+    } | Attrs,
+  tests = {
+    smoketest = standaloneTest "/bin/upx --version-short",
+
+    # PACK, RUN, UNPACK, COMPARE — the only test that proves this package works.
+    #
+    # Everything cheaper is satisfied by a broken build. `upx --version` runs
+    # without touching a single compressor. `upx --best foo` can produce a
+    # file that is smaller and completely unrunnable, because the part that
+    # has to be right is the decompression STUB that upx welds onto the front
+    # of the output — per-architecture machine code, selected at pack time.
+    # A stub that is missing or wrong for aarch64 yields an executable that
+    # dies on exec, and nothing upstream of actually running it notices.
+    #
+    # So: pack a real binary, EXECUTE the packed copy and compare its output
+    # to the original's, then unpack and compare bytes. This is upstream's own
+    # self-pack test with the round-trip assertion made explicit.
+    pack_run_unpack =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+              set -eu
+              cp /usr/bin/upx /build/upx.orig
+
+              # 1. It compresses at all.
+              upx -q --best -o /build/upx.packed /build/upx.orig >/dev/null
+              test -s /build/upx.packed
+
+              # 2. ...and the result is genuinely smaller. A "packed" file that
+              #    is the same size means upx fell back to storing.
+              orig=$(stat -c%s /build/upx.orig)
+              packed=$(stat -c%s /build/upx.packed)
+              [ "$packed" -lt "$orig" ] || {
+                echo "not compressed: $orig -> $packed" >&2; exit 1; }
+
+              # 3. upx's own integrity check on the packed file.
+              upx -q -t /build/upx.packed >/dev/null
+
+              # 4. THE ONE THAT MATTERS: the packed binary still executes on
+              #    this architecture, and behaves identically. This is what
+              #    proves the decompression stub is right.
+              a=$(/build/upx.orig --version-short)
+              b=$(/build/upx.packed --version-short)
+              [ "$a" = "$b" ] || {
+                echo "packed binary misbehaved: '$a' vs '$b'" >&2; exit 1; }
+
+              # 5. Unpacking restores the input BYTE FOR BYTE. Lossy
+              #    decompression is the failure that would quietly corrupt a
+              #    sample under analysis.
+              upx -q -d -o /build/upx.unpacked /build/upx.packed >/dev/null
+              cmp /build/upx.orig /build/upx.unpacked
+
+              echo "PACK_RUN_UNPACK_OK $orig -> $packed" > /build/upx.result
+              cat /build/upx.result
+            "%
+          ],
+          # The marker must exist, so a script that dies early — or is
+          # truncated — cannot pass by simply producing no output.
+          ["/bin/bash", "-c", "grep -q '^PACK_RUN_UNPACK_OK ' /build/upx.result"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/upx/build.ncl
+++ b/packages/upx/build.ncl
@@ -50,15 +50,24 @@ let version = "5.2.0" in
     {
       upstream_version = version,
       source_provenance = { category = 'GithubRepo, owner = "upx", repo = "upx" },
-      # GPL-2.0-or-later: COPYING is the GPLv2 text and LICENSE says "either
-      # version 2 of the License, or (at your option) any later version".
+      # The aggregate of what is actually LINKED INTO the shipped binary, which
+      # is not the same as what sits in vendor/ — see build.sh for how that was
+      # established:
+      #   GPL-2.0-or-later  upx's own code, plus the vendored UCL
+      #   Zlib              the vendored zlib
+      #   MIT               doctest, compiled in via src/check/dt_impl.cpp
+      # The vendored LZMA SDK is also compiled in (compress_lzma.cpp #includes
+      # its .cpp files directly) but is placed in the PUBLIC DOMAIN by its
+      # author, so it adds no conditions and has no SPDX identifier to add.
+      # bzip2 and zstd are present in vendor/ but upstream hard-disables both
+      # (CMakeLists.txt:269-270), so their licences are deliberately absent.
       #
       # UPX additionally grants a special exception so that compressing a
       # program does not impose the GPL on that program. That exception has no
       # SPDX identifier, so it cannot be expressed in this field — recorded
       # here instead, because the bare GPL value overstates the obligations on
       # anything this tool merely packs.
-      license_spdx = "GPL-2.0-or-later",
+      license_spdx = "(GPL-2.0-or-later AND Zlib AND MIT)",
     } | Attrs,
   tests = {
     smoketest = standaloneTest "/bin/upx --version-short",

--- a/packages/upx/build.sh
+++ b/packages/upx/build.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+# Unpacked here rather than by the fetcher: upstream's .tar.xz carries an xz
+# SHA-256 integrity check, which the fetcher's decoder does not implement
+# ("compression error: Unsupported SHA-256 checksum"). The system tar handles
+# it, so the Source stays un-extracted and this does the work.
+tar -xof "upx-${MINIMAL_ARG_VERSION}-src.tar.xz"
+cd "upx-${MINIMAL_ARG_VERSION}-src"
+
+# Reproducibility flags (see AGENTS.md).
+export CFLAGS="${CFLAGS:-} -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="${LDFLAGS:-} -Wl,--build-id=none"
+export ARFLAGS=Drc
+
+# UPX BUNDLES ITS COMPRESSORS AND THAT IS NOT A CONFIGURATION CHOICE.
+#
+# vendor/ carries ucl, lzma-sdk, zlib, zstd, bzip2 (plus doctest and valgrind
+# headers), and the CMake build offers no `find_package(ZLIB)` or system-lib
+# option of any kind — unlike rizin, where seven `use_sys_*` flags exist and
+# flipping them was the whole job. Here there is nothing to flip.
+#
+# It is also not an oversight: the compressed data written by `upx` is read
+# back by a decompression STUB that upx welds onto the packed executable, so
+# the compressor and the stub must agree bit-for-bit. Swapping in a system
+# zlib would produce files this upx's own stubs could not unpack.
+#
+# The consequence still has to be stated rather than discovered: those five
+# libraries are INVISIBLE to pkgscan here. A CVE in the bundled zlib or zstd
+# will not appear against this package, because nothing in the tree names
+# them. Called out in the PR body too — this is a real, permanent blind spot
+# on this package, not a TODO someone can close.
+#
+# UPX_CONFIG_DISABLE_GITREV=ON: without it the build stamps a git revision
+# into the binary. There is no .git here (we build from the -src tarball), so
+# it would stamp an empty/unknown value — but making it explicit keeps the
+# output independent of whether a .git ever appears in the build tree, which
+# is a reproducibility property, not a cosmetic one.
+#
+# GNUInstallDirs is included by upstream only when CMAKE_INSTALL_PREFIX is
+# set, and the whole install() block is guarded on CMAKE_INSTALL_BINDIR being
+# DEFINED — so the prefix below is what makes `cmake --install` do anything at
+# all. Drop it and the build succeeds and installs nothing.
+cmake -S . -B build -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUPX_CONFIG_DISABLE_GITREV=ON
+
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build

--- a/packages/upx/build.sh
+++ b/packages/upx/build.sh
@@ -16,21 +16,38 @@ export ARFLAGS=Drc
 
 # UPX BUNDLES ITS COMPRESSORS AND THAT IS NOT A CONFIGURATION CHOICE.
 #
-# vendor/ carries ucl, lzma-sdk, zlib, zstd, bzip2 (plus doctest and valgrind
-# headers), and the CMake build offers no `find_package(ZLIB)` or system-lib
-# option of any kind — unlike rizin, where seven `use_sys_*` flags exist and
-# flipping them was the whole job. Here there is nothing to flip.
+# The CMake build offers no `find_package(ZLIB)` or system-lib option of any
+# kind — unlike rizin, where seventeen `use_sys_*` flags exist and flipping
+# them was the whole job. Here there is nothing to flip.
 #
 # It is also not an oversight: the compressed data written by `upx` is read
 # back by a decompression STUB that upx welds onto the packed executable, so
 # the compressor and the stub must agree bit-for-bit. Swapping in a system
 # zlib would produce files this upx's own stubs could not unpack.
 #
-# The consequence still has to be stated rather than discovered: those five
-# libraries are INVISIBLE to pkgscan here. A CVE in the bundled zlib or zstd
-# will not appear against this package, because nothing in the tree names
-# them. Called out in the PR body too — this is a real, permanent blind spot
-# on this package, not a TODO someone can close.
+# WHAT IS ACTUALLY LINKED IN is narrower than what sits in vendor/, and the
+# difference matters because it is what license_spdx has to name. Established
+# from the build rather than assumed — the ninja log compiles exactly two
+# vendor targets, upx_vendor_ucl and upx_vendor_zlib:
+#
+#   ucl        GPL-2.0-or-later. Linked.
+#   zlib       Zlib licence. Linked.
+#   lzma-sdk   Public domain. Linked, but invisibly: it has no CMake target
+#              because src/compress/compress_lzma.cpp `#include`s its .cpp
+#              files DIRECTLY (lines 273+), so it never appears as its own
+#              objects in the build log.
+#   doctest    MIT. Linked via src/check/dt_impl.cpp, which does the same
+#              trick with doctest.cpp — this is a release binary that carries
+#              its test framework.
+#   bzip2      NOT linked. CMakeLists.txt:269 `set(UPX_CONFIG_DISABLE_BZIP2 ON)`
+#   zstd       NOT linked. CMakeLists.txt:270 `set(UPX_CONFIG_DISABLE_ZSTD ON)`
+#              ("currently not used; maybe in UPX version 6")
+#
+# The consequence still has to be stated rather than discovered: the three
+# libraries that ARE linked are INVISIBLE to pkgscan here. A CVE in the
+# bundled zlib will not appear against this package, because nothing in the
+# tree names it. A real, permanent blind spot on this package — not a TODO
+# someone can close.
 #
 # UPX_CONFIG_DISABLE_GITREV=ON: without it the build stamps a git revision
 # into the binary. There is no .git here (we build from the -src tarball), so


### PR DESCRIPTION
The last three of the reverse-engineering workbench: the disassembler engine, the unpacker, and the binary-format query tool. Independent of #545 (ghidra) and #547 (gef + rizin) — nothing here references them, so this can land in any order.

Each package's interesting decision is in its commit message; the short version:

## capstone 5.0.9 — the default is static, and static is invisible

`BUILD_SHARED_LIBS` defaults to **OFF** upstream (`BUILD_STATIC_LIBS` to ON), so a stock build ships `libcapstone.a` only. Anything linking that absorbs capstone statically, which puts a capstone CVE beyond pkgscan's reach entirely — nothing in the consumer's tree would name capstone at all. Shared on, static off, and a test pins the outcome rather than trusting the flag.

5.0.9 rather than 6.0.0-Alpha10: the 6.0.0 alphas are tagged `prerelease=false` on GitHub but are alphas by name. **rizin (#547) does not consume this** — it pins capstone `next`, the unreleased v6, and vendors it; that's recorded in the rizin package and is unchanged by this PR.

Licence is `(BSD-3-Clause AND NCSA)`: the tree ships `LICENSE.TXT` (BSD-3-Clause) **and** `LICENSE_LLVM.TXT` for the decoders generated from LLVM's tables. That second file is the *old* LLVM Release License — University of Illinois/NCSA — because capstone 5.x predates LLVM's relicensing. An earlier revision of this PR called it "Apache-2.0 WITH LLVM-exception" and declared BSD-3-Clause alone; both were wrong.

## upx 5.2.0 — vendored compressors that cannot be unbundled

The CMake build offers **no `find_package()` or system-lib option at all** — unlike rizin, where seventeen `use_sys_*` flags existed and flipping them was the whole job. It isn't an oversight: upx's output is read back by a decompression stub welded onto the packed executable, so compressor and stub must agree bit-for-bit; a system zlib would produce files this upx's own stubs could not unpack.

**What is actually linked in is narrower than `vendor/` suggests**, and reading the directory listing gets it wrong in both directions:

| | licence | in the binary? |
|---|---|---|
| ucl | GPL-2.0-or-later | yes, own CMake target |
| zlib | Zlib | yes, own CMake target |
| lzma-sdk | public domain | yes — but **invisibly**: `compress_lzma.cpp` `#include`s its `.cpp` files directly, so it never appears as its own objects in the ninja log |
| doctest | MIT | yes, same trick via `src/check/dt_impl.cpp` — this release binary carries its test framework |
| bzip2 | — | **no** — `CMakeLists.txt:269` hard-disables it |
| zstd | — | **no** — `CMakeLists.txt:270`, "currently not used; maybe in UPX version 6" |

So `license_spdx` is `(GPL-2.0-or-later AND Zlib AND MIT)` — the LZMA SDK is public domain, adding no conditions and no SPDX identifier.

The consequence is stated rather than left to be discovered: **the three libraries that are linked are invisible to pkgscan on this package, permanently.** A CVE in the bundled zlib will not appear against it. Not a TODO anyone can close — flagging it since it's the exact blind spot this distro exists to avoid.

Two more things a reviewer would otherwise trip on:

- The source is **not** `extract = true`. Upstream compresses the `-src` tarball with an xz SHA-256 integrity check (`xz --list` → `Check: SHA-256`, not the usual CRC64) and the fetcher's decoder rejects it outright: `compression error: Unsupported SHA-256 checksum (not yet implemented)`. build.sh unpacks with the system tar.
- `runtime_deps` needs libstdc++/libgcc. Found by the checker, not guessed — with glibc alone, even `upx --version-short` died with `error while loading shared libraries: libstdc++.so.6`.

## fq 0.17.0 — jq for binaries

~120 format decoders behind a jq expression language. `CGO_ENABLED=0` (upstream's own setting) makes it a pure-Go static binary with no `DT_NEEDED`, hence empty `runtime_deps` — same shape as `helm`.

No `-X` version stamping: fq keeps its version as a plain **const** in `fq.go`, and the Go linker only rewrites vars, so a `-ldflags -X` aimed at it would be silently ignored. That's the kind of line that looks maintained and does nothing, so it's absent and commented.

## Tests target each package's actual silent failure

| package | what fails quietly | what the test asserts |
|---|---|---|
| capstone | `CAPSTONE_ARCHITECTURE_DEFAULT` gates every per-arch option at once — cstool still builds, runs, and reports the same version with whole architectures gone | real instructions on real bytes across 5 arches incl. two fringe (riscv64, ppc64be), plus a no-such-arch **control** so the greps can't pass on an error message |
| upx | `upx --best` will produce a file that is smaller and completely unrunnable if the per-arch stub is wrong | pack → **execute the packed copy** and compare its output to the original → unpack → `cmp` byte-for-byte |
| fq | the jq engine and the format decoders are separate packages; `fq -n '1+1'` passes with every decoder broken | a gzip's **inflated payload** equals the input (not just the header field), plus ELF decoding of a second format |

**All mutation-tested.** Broke one load-bearing assertion in each package simultaneously and confirmed `min check` failed all three, each naming the exact assertion — then restored and re-verified green. Worth doing: `StandaloneTestCheck` maps a cache miss on any `test_dep` to `Skip`, and `check` only errors on `Fail`, so a green suite does not by itself prove the tests ran.

Two bugs in my own tests, both caught by running them: `cstool ppc64` is `CS_MODE_LITTLE_ENDIAN` in capstone 5 (`ppc64be` is the big-endian one) and my vector was the BE encoding; and the fq ELF assertion derives the expected machine from `uname` rather than hardcoding it, after an earlier package in this loadout pinned an arch literal and only failed once it reached amd64 CI.

## Verified

Built and checked entirely through the min-native path — no `minimal package` anywhere:

```
min session activate . --loadout pkgbuild --name build
min session attach build --command "min package build --rebuild --verbose capstone upx fq"
min session attach build --command "min check --packages capstone --packages upx --packages fq"
```

```
build                       exit 0 (capstone 102 ninja steps, upx 96, fq go build)
min check                   45/45 Pass, 0 Fail  (15 checks × 3 packages)
mutation test               3/3 assertions confirmed load-bearing
reproducibility             byte-identical across a genuine --rebuild:
                              libcapstone.so.5.0.9  d73cab95…
                              cstool                bcc3e710…
                              upx                   6e70030b…
                              fq                    ca2e70ff…
pkgmgr check                all three up_to_date, skipped=0
```

Reproducibility was measured from inside the build sandbox: a `min package build` writes to the daemon's store inside the VM and populates neither host cache, so the old "hash the tree under `~/.cache/minimal/built`" method no longer applies. Hashes above are of the installed artifacts, before and after a forced rebuild.

Arch note: built and verified on **arm64 only** — the amd64 path is exercised by CI, and unlike the ghidra PR nothing here compiles per-architecture natives, so the risk is ordinary rather than structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Packages**
  - Added Capstone 5.0.9 with shared libraries, headers, command-line tools, and development metadata.
  - Added `fq` 0.17.0, a standalone data query and processing tool.
  - Added UPX 5.2.0, including executable packing tools, documentation, and man pages.

- **Quality Assurance**
  - Added tests for multi-architecture disassembly, package discovery, and shared-library outputs.
  - Added smoke tests for compression, decompression, executable integrity, archive restoration, and query evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->