### PR TITLE
vlt: package the vlt package manager from npm (BSD-2-Clause-Patent)

### DIFF
--- a/packages/vlt/build.ncl
+++ b/packages/vlt/build.ncl
@@ -5,6 +5,17 @@
 # in the committed package-lock.json. No transitive tree, no native addons, no
 # compile step — the whole build is an extract.
 #
+# `node-lts`, not `node`, for both build and runtime. Two reasons, and the
+# private `usr/libexec/vlt` prefix below is the third leg of the same argument
+# (gominimal/pkgs#370: a global `usr/lib/node_modules` install collides with
+# whichever node variant the user actually has):
+#   - vlt's own CI tests Node 22.x only (`node-version: '^22.22.0'`, `[22.x]`)
+#     and `engines` says `>=22.22.0`. Our node-lts is 24.14.1, node is 25.8.2 —
+#     neither is 22.x, but LTS is two majors closer to what upstream tests.
+#   - pnpm, the closest analogue in this repo (also a package manager, also a
+#     node CLI), is on node-lts for exactly this reason — see #97/#98: the node
+#     most users and hosting providers run is whatever ships with current LTS.
+#
 # Deliberately NO `source_provenance`. vlt's vuln identity is its npm package
 # name, and minimal-supply-chain routes a node-flavored package with no
 # provenance to `pkg:npm/<name>` (scan.rs `npm_purl_for_node_package`) so the
@@ -14,7 +25,7 @@
 # correct here, not an oversight.
 let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
-let node = import "../node/build.ncl" in
+let node-lts = import "../node-lts/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let version = "1.0.1" in
 {
@@ -24,9 +35,9 @@ let version = "1.0.1" in
     { file = "package.json" } | Local,
     { file = "package-lock.json" } | Local,
     base,
-    node,
+    node-lts,
   ],
-  runtime_deps = [coreutils, node],
+  runtime_deps = [coreutils, node-lts],
   needs =
     {
       dns = {},

--- a/packages/vlt/build.ncl
+++ b/packages/vlt/build.ncl
@@ -1,0 +1,105 @@
+# Imported from npm `vlt` by `pkgmgr import npm` (node build).
+#
+# vlt is a package manager (vlt.sh), shipped as a single dependency-free npm
+# tarball: `npm ci` installs exactly ONE package, pinned by version + integrity
+# in the committed package-lock.json. No transitive tree, no native addons, no
+# compile step — the whole build is an extract.
+#
+# Deliberately NO `source_provenance`. vlt's vuln identity is its npm package
+# name, and minimal-supply-chain routes a node-flavored package with no
+# provenance to `pkg:npm/<name>` (scan.rs `npm_purl_for_node_package`) so the
+# OSV/GHSA npm advisories resolve. Declaring `GithubRepo vltpkg/vltpkg` would
+# take it OFF that arm onto the repo-purl arm, where GHSA's npm advisories —
+# which are keyed by package name, not repo — would no longer match. Absent is
+# correct here, not an oversight.
+let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let node = import "../node/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let version = "1.0.1" in
+{
+  name = "vlt",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    { file = "package.json" } | Local,
+    { file = "package-lock.json" } | Local,
+    base,
+    node,
+  ],
+  runtime_deps = [coreutils, node],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+  outputs = {
+    # Enumerated, not `usr/bin/*`: the checker wants each bin named, and the
+    # npm registry metadata already lists them exactly, so there is nothing to
+    # infer. `vlt` is the CLI; the others are the documented shorthands
+    # (`vlr` = `vlt run`, `vlx` = `vlt exec`, plus their variants).
+    vlt = { glob = "usr/bin/vlt" } | OutputBin,
+    vlr = { glob = "usr/bin/vlr" } | OutputBin,
+    vlrx = { glob = "usr/bin/vlrx" } | OutputBin,
+    vlx = { glob = "usr/bin/vlx" } | OutputBin,
+    vlxl = { glob = "usr/bin/vlxl" } | OutputBin,
+
+    libexec = { glob = "usr/libexec/vlt/**", allow_executable = true } | OutputData,
+  },
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "BSD-2-Clause-Patent",
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/vlt --version",
+
+    version_is_exact =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Exact equality, NOT `--version | grep '%{version}'`: vlt's usage
+          # banner also carries the version ("next-gen package management
+          # v1.0.1"), so a grep would pass on a build where `--version` itself
+          # is broken and only usage prints. This asserts the artifact's own
+          # version, independent of the build-time lockfile guard in build.sh.
+          ["/bin/bash", "-c", "test \"$(/bin/vlt --version)\" = \"%{version}\""],
+        ],
+      }
+        | Test,
+
+    companion_bins_work =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Five bins are declared as outputs; they are PATH symlinks into the
+          # private libexec prefix, so a broken relative link fails here and
+          # nowhere else. A test that only exercised `vlt` would ship four
+          # dead entries in usr/bin.
+          ["/bin/bash", "-c", "for b in vlr vlrx vlx vlxl; do test \"$(/bin/$b --version)\" = \"%{version}\" || { echo \"$b failed\" >&2; exit 1; }; done"],
+        ],
+      }
+        | Test,
+
+    reads_a_manifest =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Real work, offline: `vlt pkg get` parses a package.json and returns
+          # a field. This exercises the bundled JS beyond argv handling — a
+          # truncated or partially-installed tarball prints `--version` fine
+          # and fails here. vlt has NO default registry as of 1.0.1, so any
+          # network-touching command is not a candidate for a sandbox test.
+          ["/bin/bash", "-c", "d=/tmp/vlt-selftest; mkdir -p \"$d\"; cd \"$d\"; printf '{\"name\":\"vlt-selftest-fixture\",\"version\":\"9.9.9\"}' > package.json; test \"$(/bin/vlt pkg get name)\" = '\"vlt-selftest-fixture\"'"],
+        ],
+      }
+        | Test,
+  },
+} | BuildSpec

--- a/packages/vlt/build.ncl
+++ b/packages/vlt/build.ncl
@@ -5,6 +5,30 @@
 # in the committed package-lock.json. No transitive tree, no native addons, no
 # compile step — the whole build is an extract.
 #
+# WHY A REGISTRY ARTIFACT AND NOT A SOURCE BUILD — AGENTS.md requires this be
+# called out explicitly, and the reason is not "nobody tried". Source IS
+# published (codeload .../vltpkg/tar.gz/refs/tags/v1.0.1, 200, 7.4 MB, 48 real
+# TypeScript workspaces). It cannot be built with a toolchain we have:
+#
+#   - The only lockfile in the repo is `vlt-lock.json` — vlt's own format.
+#     There is no pnpm-lock.yaml and no package-lock.json.
+#   - Dependency specs use the `catalog:` protocol with the catalog declared in
+#     `vlt.json`. Measured against the extracted tarball:
+#         npm  → EUNSUPPORTEDPROTOCOL: Unsupported URL Type "catalog:"
+#         pnpm → ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC (pnpm supports
+#                catalogs, but reads pnpm-workspace.yaml, not vlt.json)
+#     `package.json` has no `workspaces` key at all, so neither tool can even
+#     see the monorepo layout.
+#   - Upstream CI agrees: `uses: vltpkg/setup-vlt@v1` then `vlt install`.
+#   - The published package (`infra/cli/package.json`) declares `bin: null`,
+#     `dependencies: {}`, and one script — `prepack: vlt-build-prepack`. The
+#     npm tarball is generated wholesale by their internal bundler.
+#
+# So building vlt from source requires vlt: a genuine bootstrap cycle, which is
+# the "required toolchain genuinely isn't packaged yet" case AGENTS.md carves
+# out. Breaking it would mean a two-stage `vlt-bootstrap` → `vlt` pair in the
+# gawk-bootstrap shape; worth doing if vlt becomes load-bearing, not before.
+#
 # `node-lts`, not `node`, for both build and runtime. Two reasons, and the
 # private `usr/libexec/vlt` prefix below is the third leg of the same argument
 # (gominimal/pkgs#370: a global `usr/lib/node_modules` install collides with

--- a/packages/vlt/build.sh
+++ b/packages/vlt/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Imported from npm `vlt` (1.0.1, node) by pkgmgr import npm.
+set -eu
+
+# Reproducible install: `npm ci` from the committed package-lock.json pins
+# the WHOLE transitive tree by version + integrity (a bare `npm install`
+# re-resolves it at build time). Install into a package-PRIVATE libexec
+# prefix (NOT the shared usr/lib/node_modules the node runtime owns) and
+# expose bins as PATH symlinks; the inner `#!/usr/bin/env node` shebang is
+# served by coreutils(env)+node, so no shell wrapper is needed.
+# Guard: the committed lock must pin the build.ncl version (the updater
+# regenerates it on a bump; this catches a hand-edited version drift).
+grep -qF "\"$MINIMAL_ARG_VERSION\"" package.json ||
+  { echo "package.json does not pin $MINIMAL_ARG_VERSION — regenerate the lockfile" >&2; exit 1; }
+prefix="$OUTPUT_DIR/usr/libexec/vlt"
+mkdir -p "$prefix"
+cp package.json package-lock.json "$prefix/"
+cd "$prefix"
+npm ci --omit=dev
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for _bin in node_modules/.bin/*; do
+  [ -e "$_bin" ] || continue
+  _tool=${_bin##*/}
+  ln -s "../libexec/vlt/node_modules/.bin/$_tool" "$OUTPUT_DIR/usr/bin/$_tool"
+done

--- a/packages/vlt/package-lock.json
+++ b/packages/vlt/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "pkgmgr-node-import",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pkgmgr-node-import",
+      "version": "0.0.0",
+      "dependencies": {
+        "vlt": "1.0.1"
+      }
+    },
+    "node_modules/vlt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlt/-/vlt-1.0.1.tgz",
+      "integrity": "sha512-+EVCj7/jfTsotOQjrOvteDQSLgTVYu005eslkaAypPYBUdZ+AN8Y3cHk6F100l9mFrvdN3d99ypmPYSv2++FLA==",
+      "license": "BSD-2-Clause-Patent",
+      "bin": {
+        "vlr": "vlr.js",
+        "vlrx": "vlrx.js",
+        "vlt": "vlt.js",
+        "vlx": "vlx.js",
+        "vlxl": "vlxl.js"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      }
+    }
+  }
+}

--- a/packages/vlt/package.json
+++ b/packages/vlt/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pkgmgr-node-import",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "vlt": "1.0.1"
+  }
+}


### PR DESCRIPTION
`vlt` 1.0.1 ([vltpkg/vltpkg](https://github.com/vltpkg/vltpkg)) shipped today. Seeded with `pkgmgr import npm vlt`, then refined by hand for the two things discovery mode can't know.

## Why this one is unusually clean

The published tarball has **zero dependencies**. `npm ci` against the committed lockfile installs exactly one package, pinned by version + integrity — no transitive tree, no native addons, no compile step. `npm audit` in-build reports 0 vulnerabilities across the whole 2-package graph. For a distro whose premise is supply-chain tracking, that is about as good as an npm-distributed tool gets.

License is **BSD-2-Clause-Patent** (OSI-approved), confirmed against the repo's own `LICENSE`, not just the npm field.

## What I changed on top of the generated files

**Bins enumerated, not globbed.** The importer emits `bins = { glob = "usr/bin/*" }`, which trips the `enumerate bins` checker for any package with a handful of bins — vlt has five (`vlt`, plus the documented shorthands `vlr`/`vlx` and their variants). The npm registry metadata lists them exactly, so nothing had to be inferred. Fixing that in the importer is pkgmgr-rs follow-up work, not a one-off.

**Real standalone tests.** The generated package had none — and `standalone tests...Pass` is what the checker reports for a package with *zero* tests, so the out-of-the-box green meant nothing. Added three that exercise the artifact rather than the build inputs:

| test | what it catches |
|---|---|
| `version_is_exact` | String equality against `%{version}`, **not** `--version \| grep`. vlt's usage banner also carries the version, so a grep would pass on a build where `--version` is broken and only usage prints. |
| `companion_bins_work` | All four shorthands. They're PATH symlinks into the private libexec prefix; a broken relative link fails here and nowhere else. |
| `reads_a_manifest` | `vlt pkg get name` against a fixture `package.json` — real offline work through the bundled JS. A truncated install still prints `--version` and fails this. |

**Mutation-tested**, because "the tests pass" was already established as meaningless here: flipping the expected version to `0.0.0-mutant` turns the suite red with `version_is_exact ... had exit code 1`. They can fail for the reason they exist.

## Why a registry artifact and not a source build

AGENTS.md requires a prebuilt fallback be called out explicitly. The reason here is not "nobody tried" — **source is published** (`codeload.../vltpkg/tar.gz/refs/tags/v1.0.1`, 200, 7.4 MB, 48 real TypeScript workspaces). It cannot be built with a toolchain we have. Measured against the extracted tarball:

```
npm  -> npm error code EUNSUPPORTEDPROTOCOL
        Unsupported URL Type "catalog:": catalog:
pnpm -> ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC
        No catalog entry '@eslint/js' was found for catalog 'default'
```

- The only lockfile in the repo is `vlt-lock.json` — vlt's own format. No `pnpm-lock.yaml`, no `package-lock.json`.
- Dependency specs use the `catalog:` protocol with the catalog declared in `vlt.json`. pnpm *does* support catalogs, but reads `pnpm-workspace.yaml`.
- `package.json` has no `workspaces` key at all, so neither tool can even see the 48-workspace layout.
- Upstream CI agrees: `uses: vltpkg/setup-vlt@v1` then `vlt install`.
- The published package (`infra/cli/package.json`) declares `bin: null`, `dependencies: {}`, and one script — `prepack: vlt-build-prepack`. The npm tarball is generated wholesale by their internal bundler.

**Building vlt from source requires vlt** — a genuine bootstrap cycle, which is the "required toolchain genuinely isn't packaged yet" case AGENTS.md carves out. Breaking it would mean a two-stage `vlt-bootstrap` → `vlt` pair in the `gawk-bootstrap` shape. Worth doing if vlt becomes load-bearing; not before.

## Verification

Built and checked on the min-native path against a clean-main worktree:

```
min session activate . --loadout pkgbuild --name vltfinal
min session attach vltfinal --command "min package build --rebuild --verbose vlt"
min session attach vltfinal --command "min check --packages vlt"
```

`npm ci` → `added 1 package, and audited 2 packages in 300ms`, `found 0 vulnerabilities`; then **15/15 Pass**, `check finished`.

## Not verified

- **Reproducibility.** AGENTS.md wants byte-identical rebuilds. `npm ci` from a pinned lockfile ought to be deterministic and there is no compiler involved, but I did not measure it — `min materialize` is not in the session `--command` allowlist, so getting the tree back to the host for a two-build hash comparison needs an interactive attach. Flagging rather than assuming.
- **arm64.** Built on this host's arch only. Pure JS with no native addons, so arch-independence is expected, not demonstrated.

## Reviewer notes

No `TODO:`/`FIXME` remain. The importer's generated TODO ("add any peer packages the tool needs") is *resolved*, not dropped: vlt declares no `dependencies`, `peerDependencies`, `optionalDependencies`, or `bundleDependencies`.

## Note on the sibling project

`vltpkg/vsr` (the registry) is **not** packageable on the same terms — it is FSL-1.1-MIT (source-available, competing-use restricted; converts to MIT on 2028-02-04), and it is a Cloudflare Workers app built via `wrangler deploy`. Details in the thread that prompted this.
