### PR TITLE
charon-ml, aeneas: declare GithubRepo provenance — both were UNSCANNED

### DIFF
--- a/packages/aeneas/build.ncl
+++ b/packages/aeneas/build.ncl
@@ -68,6 +68,11 @@ let version = "20260713" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "AeneasVerif",
+        repo = "aeneas",
+      },
       license_spdx = "Apache-2.0",
     } | Attrs,
   tests = {

--- a/packages/charon-ml/build.ncl
+++ b/packages/charon-ml/build.ncl
@@ -66,6 +66,11 @@ let version = "0.1.223" in
   attrs =
     {
       upstream_version = version,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "AeneasVerif",
+        repo = "charon",
+      },
       license_spdx = "Apache-2.0",
     } | Attrs,
   tests = {


### PR DESCRIPTION
The nightly scan's *second* warning line — the one below the CPE-coverage line I've been chasing — reports:

> ⚠ **35 package(s) emitted NO vuln query** (no OSV ecosystem, no GitHub repo, not GnuProject/Sourceforge) — **UNSCANNED**, reported as 0 findings

That's a strictly worse class than *"queried, found nothing"*: these were never asked. `charon-ml` and `aeneas` are on that list, and both have a plain GitHub upstream that simply was never declared.

| package | upstream | license |
|---|---|---|
| charon-ml | `AeneasVerif/charon` | Apache-2.0 (confirmed via API) |
| aeneas | `AeneasVerif/aeneas` | Apache-2.0 (confirmed via API) |

Both sources are gs://-mirrored, and `Provenance::from_url` deliberately declines `gs://` — so nothing could infer these; they had to be declared.

Neither resolves any advisory today (OSV GIT query returns 0 for both repos, checked). **That's the point** — a queried zero is an answer, an unqueried zero is not. From here they ride the OSV GIT / GHSA path like every other GithubRepo package.

**Verified** with `pkgmgr check-onboarding` against this branch: **80 gaps → 78**, and neither package appears in the output any more.

---

## The other three couldn't be fixed, and the reason is the interesting part

`menhir`, `visitors` and `unionfind` are also on the unscanned list. All three are fpottier projects on `gitlab.inria.fr`, and each build.ncl header already says so:

> *"no `Gitlab` provenance category yet — minimal-supply-chain#347"*

That category **has** since shipped on the tooling side (sc#347/#348 + pm#511): `Provenance::Gitlab { host, owner, repo }` exists in the Rust parser and `scan.rs` routes it. But the minimal **stdlib contract** never got it. From `attr_classes.ncl` in the stdlib actually in use, the accepted set is exactly:

```
'GithubRepo   'GnuProject   'Sourceforge   'Website
```

Declaring `'Gitlab` under `| Attrs` fails the contract outright — and not gracefully. `minimal dump` aborts with `failed to validate source_provenance` and the **whole package set** fails to evaluate, not just that package. I hit exactly this and it silently turned a `check-onboarding` run into "0 packages evaluated successfully", which reads as a pass.

### `psmisc` looks like a counter-example. It isn't.

`psmisc` ships `category = 'Gitlab` on main today — but its attrs block carries **no `| Attrs` annotation**, so it is never contract-checked. That's an accident rather than a pattern to copy, and it means we currently have one package whose provenance the contract has never validated.

### So the pkgs half wasn't forgotten — it wasn't expressible

Raising the stdlib gap is a minimal-side decision, so this PR stops at the two packages that can land today rather than working around a contract. Flagging it here so the next person doesn't rediscover it the same way.

Remaining on the unscanned list after this: **33**, including the X11 stack (libdrm, xorgproto, xtrans, xcb-proto, libxau, libx*, atk, at-spi2-core), ghc/ghc-bootstrap, and several vendor CLIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added source repository metadata for Aeneas.
  * Added source repository metadata for Charon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->