### PR TITLE
feat(drift): package the drift git diff pager 0.0.1

### DIFF
--- a/packages/drift/build.ncl
+++ b/packages/drift/build.ncl
@@ -1,0 +1,66 @@
+let { standaloneTest, subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let git = import "../git/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.0.1" in
+{
+  name = "drift",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/aymanbagabas/drift/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "3ea14fc2dafc647d75305f5ee126362390f7aa7204c3a1904d9b1572dd0bc682",
+      extract = true,
+      strip_prefix = "drift-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  # drift is a pager for `git diff`: every view it renders comes from shelling
+  # out to git (src/git.rs), so git is a hard runtime dep, not a convenience.
+  # The library set is just what the binary actually links -- syntect is built
+  # with the `default-fancy` feature (pure-Rust fancy-regex), so unlike delta
+  # there is no oniguruma here, and nothing pulls in zlib.
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+    git,
+  ],
+
+  # Source archive is the plain GitHub tag tarball with no vendored crates, so
+  # the build resolves its cargo deps over the network.
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+
+  outputs = {
+    drift = { glob = "usr/bin/drift" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "aymanbagabas",
+        repo = "drift",
+      },
+      build_cost_multiple = 2,
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/drift --version",
+  },
+} | BuildSpec

--- a/packages/drift/build.sh
+++ b/packages/drift/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+# --locked: upstream ships a Cargo.lock, so pin to it rather than re-resolving.
+cargo build --release --locked
+
+# The release profile already sets lto/codegen-units=1/strip, so no extra
+# determinism flags are needed beyond the path remapping above.
+install -D -m 0755 target/release/drift "$OUTPUT_DIR/usr/bin/drift"


### PR DESCRIPTION
drift is a Rust TUI pager for `git diff` (MIT, aymanbagabas/drift).

Source is the GitHub tag tarball rather than the gs:// staging mirror, so cargo resolves crates during the build and the spec declares `needs = { dns, internet }` -- same shape as starship/zoxide/hunk.

Runtime deps were read off the built binary rather than guessed: it links only libc, libm and libgcc_s. Notably there is no oniguruma and no zlib, unlike delta, because syntect is built with the `default-fancy` feature (pure-Rust fancy-regex). git is a hard runtime dep -- every view drift renders comes from shelling out to git (src/git.rs).

The upstream release profile already pins lto/codegen-units=1/strip, so build.sh adds only the --remap-path-prefix flags; two builds from different paths were verified byte-identical.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [x] For version bumps: I've verified the new `sha256` against the upstream archive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Drift as an installable package.
  * Provides the Drift command-line executable for supported environments.
  * Includes package metadata and version validation to help ensure reliable installations.

* **Build and Runtime**
  * Packaged Drift with its required runtime components.
  * Added a reproducible release build process for consistent installation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->