### PR TITLE
virtio-linux-detonation: 6.18.36 -> 6.18.42 (six LTS releases of fixes)

### DIFF
--- a/packages/virtio-linux-detonation/build.ncl
+++ b/packages/virtio-linux-detonation/build.ncl
@@ -14,13 +14,14 @@ let python = import "../python/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
 # Detonation observability kernel. Intentionally diverged from virtio-linux's
-# 6.12.43 base to 6.18.36 (newest LTS) for the materially newer BPF verifier +
+# 6.12.43 base to the 6.18 LTS line (6.18 is longterm; no 7.x line is longterm
+# as of 2026-08) for the materially newer BPF verifier +
 # features the in-VM eBPF observer needs (the 6.12 verifier rejected the env-scan
 # tracepoint with E2BIG). Same BPF-LSM/BTF/AUDIT config delta (see build.sh) and
 # the dwarves build_dep that supplies `pahole` for CONFIG_DEBUG_INFO_BTF. Source
 # moved off the gs:// staging mirror (only 6.1/6.12 staged there) to cdn.kernel.org,
 # matching the libkrunfw package's accepted pattern.
-let version = "6.18.36" in
+let version = "6.18.42" in
 {
   name = "virtio-linux-detonation",
 
@@ -28,7 +29,7 @@ let version = "6.18.36" in
     { file = "build.sh" } | Local,
     {
       url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{version}.tar.xz",
-      sha256 = "fbab86c9f471c81075b280cca30bd85d790c060063a1245859b6344b07c9c44e",
+      sha256 = "35a8ef5e8fb44467e56a42b40c23c4c10a61d1e95ff8d738f285230e8bed63e7",
       extract = true,
       strip_prefix = "linux-%{version}",
     } | Source,


### PR DESCRIPTION
This package was **update-dark** until yesterday: no `source_provenance`, no `repology_project`, and missing from the kernel-LTS override arm — so `check` reported *"no upstream source found"* and skipped it. It could never be offered a bump and nothing said so. gominimal/minimal-supply-chain#391 routed it; this is the bump that was waiting behind it.

Six point releases behind — 6.18.42 shipped 2026-08-03.

## Not 7.x, deliberately

Moving to the newest series is a reasonable instinct and wrong here. kernel.org lists **7.1.6 as `stable`** and marks exactly six lines `longterm`: 6.18, 6.12, 6.6, 6.1, 5.15, 5.10.

**6.18 IS the newest longterm** — the line this package is already on. Moving to 7.1 would *leave* LTS for a line that dies when 7.2 ships (7.2-rc6 tagged 2026-08-02), buying a newer BPF verifier the observer has no demonstrated need for, in exchange for a two-arch config + boot revalidation every ~9 weeks. Revisit when a 7.x line is marked longterm — historically the last release of the calendar year.

## Risk read

sha256 read from kernel.org's **signed** `sha256sums.asc`. The currently-pinned 6.18.36 digest matches that same file exactly, which validates the read.

Diffed all six incremental patches (36→42, 141k lines) against what this build actually depends on:

- **The four files the build starts from are untouched** — `arch/x86/configs/{x86_64_,}defconfig`, `arch/arm64/configs/defconfig`, `kernel/configs/kvm_guest.config`
- **None of the 14 CONFIG_ symbols** the build sets or asserts was removed or renamed. This matters specifically because `scripts/config --enable` on an unknown symbol is a **silent no-op** — a rename would produce an observability-blind kernel that builds perfectly.
- **The LSM hook table did change — purely additively.** New `backing_file_alloc` / `backing_file_free` / `mmap_backing_file` hooks plus BTF plumbing in `kernel/bpf/bpf_lsm.c`. No removals or renames of `file_open` / `bprm_*` / `socket_*`, and no change to `BPF_MAP_TYPE_RINGBUF` — the surface the in-VM observer attaches through is intact.

build.ncl only. No build.sh change, no CONFIG_ change.

## Verification

Built in a clean session — arm64 produced `BTFIDS` + `Image.gz`, so pahole handled BTF against the new tree — and `min check`: **15/15 Pass**.

Worth being explicit: `standalone tests...Pass` is worth **nothing** here, because this package has **no tests**. The real gate is `build.sh:219`, which fails the build outright if any of `BPF_LSM` / `DEBUG_INFO_BTF` / `AUDIT` / `DYNAMIC_FTRACE_WITH_ARGS` / `FTRACE_SYSCALLS` fails to survive `olddefconfig`. That assertion passing is the actual evidence the observability config landed on 6.18.42.

## Deliberately left for separate PRs

- **Four dead CONFIG names in build.sh** — `VIRTIO_SCSI`/`VIRTIO_GPU` should be `SCSI_VIRTIO`/`DRM_VIRTIO_GPU`, so arm64 currently ships *without* virtio-scsi and virtio-gpu (x86 masks it because `x86_64_defconfig` sets both independently). Fixing that **changes the arm64 kernel's contents** and must not ride a version bump.
- **The missing tests.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the bundled Linux kernel to version 6.18.42.
  * Refreshed the source verification checksum for the new kernel release.
  * Updated release-line documentation to reflect the 6.18 long-term support status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->