### PR TITLE
Update chromium to 152.0.7977.8 (security update)

### DIFF
--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -48,6 +48,14 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # this case. The bare `chromium` name is intentionally left available
 # for a future source-built pkg.
 #
+# ⚠ CHANNEL: pre-stable BY DESIGN (pkgmgr-rs#646). This pair tracks
+# Playwright's pinned Chromium, which rides ahead of the stable channel
+# (the arm64 legs exist only for Playwright's revisions). CVEs are
+# published only against stable, so a 0/0/0 scan here means "ahead of
+# the published feed", NOT "audited clean" — and a held pin ages into
+# known-vulnerable as its major reaches stable. pkgmgr's nightly sweep
+# bumps the pair and alerts from the day that happens.
+#
 # Source mix — both legs are true open-source Chromium (BSD-3-Clause),
 # deliberately NOT Chrome for Testing: CfT is a *branded Google Chrome*
 # build governed by the Chrome ToS, which does not permit redistribution

--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -63,7 +63,7 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 #     (Google publishes no linux-arm64; Playwright still builds arm64).
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1234 ↔ Chrome 151.0.7922.34
+# packages/playwright-core/browsers.json. Revision 1237 ↔ Chrome 152.0.7977.8
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with
 # chromium-headless-shell-bin.
@@ -78,9 +78,9 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # If it doesn't, pass `executablePath: '/bin/chromium'` (or
 # '/bin/chromium-headless-shell' from the headless-shell pkg) to
 # bypass the registry lookup. See packages/chromium-bin/README.md.
-let revision = "1234" in
-let browser_version = "151.0.7922.34" in
-let snapshot_position = "1654408" in
+let revision = "1237" in
+let browser_version = "152.0.7977.8" in
+let snapshot_position = "1669021" in
 {
   name = "chromium-bin",
   build_deps = [
@@ -89,12 +89,12 @@ let snapshot_position = "1654408" in
       { arch = 'Amd64, .. } =>
         {
           url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
-          sha256 = "c094b77ad8d462bacd54769c5aa1fcd2e9d61f9b146796bbcded9276cdc40a5e",
+          sha256 = "89a52b393189c7ab7ee0f1ebdaf8279c2c97d0c0e83708abe84292b57337da19",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-linux-arm64.zip",
-          sha256 = "b5ad7d8fe70f230b34198ddb5626d717c016db2f627cb44b922babbcaf3479b9",
+          sha256 = "a188a0c13a944da8eb9b327dd473bf0378a10e170b2729d75b7be4520a9cfa1a",
         } | Source,
     } target,
     base,

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -46,6 +46,12 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # rendering (mermaid-cli, e.g.) depend on this pkg alone to avoid
 # pulling the full browser.
 #
+# ⚠ CHANNEL: pre-stable BY DESIGN (pkgmgr-rs#646) — mirrors chromium-bin:
+# this pair tracks Playwright's pinned Chromium, ahead of the stable
+# channel. CVEs publish only against stable, so a 0/0/0 scan here means
+# "ahead of the published feed", NOT "audited clean". pkgmgr's nightly
+# sweep bumps the pair and alerts when the shipped major reaches stable.
+#
 # Source mix mirrors chromium-bin (see its header for the full
 # rationale): both legs are true open-source Chromium, deliberately NOT
 # Chrome for Testing (a branded Google Chrome build whose ToS does not

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -55,12 +55,12 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # branched from); arm64 from Playwright's own arm64 build.
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1234 ↔ Chrome 151.0.7922.34
+# packages/playwright-core/browsers.json. Revision 1237 ↔ Chrome 152.0.7977.8
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with chromium-bin.
-let revision = "1234" in
-let browser_version = "151.0.7922.34" in
-let snapshot_position = "1654408" in
+let revision = "1237" in
+let browser_version = "152.0.7977.8" in
+let snapshot_position = "1669021" in
 {
   name = "chromium-headless-shell-bin",
   build_deps =
@@ -70,12 +70,12 @@ let snapshot_position = "1654408" in
         { arch = 'Amd64, .. } =>
           {
             url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
-            sha256 = "4cd2324a9343cf01fa192902c203250f73a14b6e60f4a775f84a2b26314c5cfa",
+            sha256 = "efd7bdeac429d8728e39eeb70b5de3355b276f134b159db61ffc7f6980e2b76c",
           } | Source,
         { arch = 'Arm64, .. } =>
           {
             url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-            sha256 = "b03443e1e1a60d06e07b6cdfe650b8c2bfcbb3db497d2b652f73dc6912f4ae15",
+            sha256 = "b3daa6584a2fcf8349d096e4b6c0706652ef1f87afd209455de509f17e7094d8",
           } | Source,
       } target,
       base,
@@ -91,7 +91,7 @@ let snapshot_position = "1654408" in
           [
             {
               url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
-              sha256 = "c094b77ad8d462bacd54769c5aa1fcd2e9d61f9b146796bbcded9276cdc40a5e",
+              sha256 = "89a52b393189c7ab7ee0f1ebdaf8279c2c97d0c0e83708abe84292b57337da19",
             } | Source,
             # headless_command_resources.pak (the pak implementing --dump-dom &
             # friends in standalone headless) ships in NO snapshot artifact —
@@ -101,7 +101,7 @@ let snapshot_position = "1654408" in
             # artifact, same pin).
             {
               url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-              sha256 = "b03443e1e1a60d06e07b6cdfe650b8c2bfcbb3db497d2b652f73dc6912f4ae15",
+              sha256 = "b3daa6584a2fcf8349d096e4b6c0706652ef1f87afd209455de509f17e7094d8",
             } | Source,
           ],
         # Playwright's arm64 bundle is already complete.


### PR DESCRIPTION
Updates **chromium-bin + chromium-headless-shell-bin** from **151.0.7922.34** to **152.0.7977.8** — a Chromium security update (each Chrome major carries Critical fixes).

**Channel context (#646):** `chromium-bin` tracks Playwright's pin, which is pre-stable by design; 152.0.7977.8 is ahead of current Linux stable (151.0.7922.108). CVEs publish only against stable, so a 0/0/0 scan for this package means "ahead of the published feed", not "audited clean".

chromium pins three interlocked identifiers, resolved from three sources:

| identifier | value | source |
|---|---|---|
| `browser_version` | 152.0.7977.8 | Playwright browsers.json |
| `revision` | 1237 | Playwright browsers.json (arm64 legs are Playwright-gated) |
| `snapshot_position` | 1669021 | chromiumdash branch position → nearest available amd64 snapshot |

Four artifacts fetched + `sha256`'d fresh (amd64 `chrome-linux.zip` + `headless-shell.zip` from the snapshot bucket; arm64 `chromium` / `headless-shell` builds at the Playwright revision). Resolved + rewritten by `pkgmgr` (gominimal/pkgmgr-rs#515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled Chromium browser to a newer pre-stable release.
  * Refreshed the headless browser package with the latest matching browser build.
  * Updated platform-specific packages for amd64 and arm64 systems.
  * Refreshed download integrity checks to ensure the updated browser artifacts are validated correctly.
  * Added clearer documentation indicating the pre-stable status of these browser builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->