### PR TITLE
Update vlt to 1.0.2

### DIFF
--- a/packages/vlt/build.ncl
+++ b/packages/vlt/build.ncl
@@ -51,7 +51,7 @@ let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Tes
 let base = import "../base/build.ncl" in
 let node-lts = import "../node-lts/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
-let version = "1.0.1" in
+let version = "1.0.2" in
 {
   name = "vlt",
   build_deps = [

--- a/packages/vlt/package-lock.json
+++ b/packages/vlt/package-lock.json
@@ -8,13 +8,13 @@
       "name": "pkgmgr-node-import",
       "version": "0.0.0",
       "dependencies": {
-        "vlt": "1.0.1"
+        "vlt": "1.0.2"
       }
     },
     "node_modules/vlt": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vlt/-/vlt-1.0.1.tgz",
-      "integrity": "sha512-+EVCj7/jfTsotOQjrOvteDQSLgTVYu005eslkaAypPYBUdZ+AN8Y3cHk6F100l9mFrvdN3d99ypmPYSv2++FLA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vlt/-/vlt-1.0.2.tgz",
+      "integrity": "sha512-ZbviHaqrZSqo+ofr48gJ7LzmaUYjTCcL9tUwGRUcKXvYoi1KhLF1fn78y43VdnbW6kxKwutfRE84RYs/QkjiqA==",
       "license": "BSD-2-Clause-Patent",
       "bin": {
         "vlr": "vlr.js",

--- a/packages/vlt/package.json
+++ b/packages/vlt/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "vlt": "1.0.1"
+    "vlt": "1.0.2"
   }
 }


### PR DESCRIPTION
Upstream shipped 1.0.2 on 2026-08-07 (npm `dist-tags.latest` and the GitHub release agree); we sat on 1.0.1 because vlt had **no version source of any kind** — `check` skipped it every run and `/pkgs upgrade` had nothing newer to offer. pkgmgr-rs#703 adds the npm dist-tags version check so the staleness can't silently recur.

- `build.ncl` version → 1.0.2 (the `version_is_exact` standalone test pins the built binary to it)
- `package.json` pin + `package-lock.json` regenerated via `npm install --package-lock-only`: version, resolved URL, and sha512 integrity move together
- Manual bump because the updater's version-only npm path parses `npm install <pkg>@$VERSION` scripts, not this package's committed-lockfile `npm ci` flavor (pkgmgr-rs follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vlt package to version 1.0.2.
  * Updated the associated dependency version to keep package metadata consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->