### PR TITLE
Update actions-runner to 2.336.0 (hand-mirrored)

### DIFF
--- a/packages/actions-runner/build.ncl
+++ b/packages/actions-runner/build.ncl
@@ -7,11 +7,11 @@ let icu = import "../icu/build.ncl" in
 let openssl = import "../openssl/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "2.332.0" in
+let version = "2.336.0" in
 
 let { amd64_sha256, arm64_sha256 } = {
-  amd64_sha256 = "f2094522a6b9afeab07ffb586d1eb3f190b6457074282796c497ce7dce9e0f2a",
-  arm64_sha256 = "b72f0599cdbd99dd9513ab64fcb59e424fc7359c93b849e8f5efdd5a72f743a6",
+  amd64_sha256 = "04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d",
+  arm64_sha256 = "58b758e420b87093fbd4bfddd368074960053e2f1388f01848c82624b90f27d1",
 }
 in
 


### PR DESCRIPTION
The 2026-08-10 stacked run dropped this member: per-arch gs://-mirrored sources are the one combination the updater cannot mirror (it early-returns before the scan-before-mirror gate — an upload added naively would publish unscanned bytes). Done by hand instead, **with** the gate's diligence:

- Both 2.336.0 artifacts fetched from the `actions/runner` GitHub release and verified **byte-for-byte against the sha256 values upstream publishes in the release notes** (x64 `04cf0be1…`, arm64 `58b758e4…`).
- `pkgscan diff` old→new run for each arch: every finding is the changed-ELF class (`bin/*.so`, dotnet runtime, bundled node) — definitional for a prebuilt bundle bump and the same shape as the already-published 2.332.0 mirror. No new signal class.
- Artifacts mirrored to `gs://minimal-staging-archives/actions/runner/`; sha256 literals updated in lockstep.

Updater support for scan-gated multi-arch mirroring remains the real fix (the refusal message documents the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)