### PR TITLE
Add biome 2.5.8

### DIFF
--- a/packages/biome/build.ncl
+++ b/packages/biome/build.ncl
@@ -1,0 +1,56 @@
+let { standaloneTest, subsetOf, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "2.5.8" in
+{
+  name = "biome",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/biomejs/biome/archive/refs/tags/@biomejs/biome@%{version}.tar.gz",
+      sha256 = "f380dead10231f4c2a26c16ad519553c3a4ae6a24e43faaab2cefafe41074577",
+      extract = true,
+      strip_prefix = "biome--biomejs-biome-%{version}",
+    } | Source,
+    base,
+    make,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    bins = { glob = "usr/bin/biome" } | OutputBin,
+  },
+
+  needs = {
+    internet = {},
+  },
+
+  attrs = {
+    upstream_version = version,
+    license_spdx = "MIT OR Apache-2.0",
+    source_provenance = {
+      category = 'GithubRepo,
+      owner = "biomejs",
+      repo = "biome",
+    },
+  },
+
+  tests = {
+    smoketest = standaloneTest "/usr/bin/biome --version",
+  },
+} | BuildSpec

--- a/packages/biome/build.sh
+++ b/packages/biome/build.sh
@@ -5,10 +5,6 @@ export CC=gcc
 export LD=gcc
 export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
 
-# Upstream's release profile uses fat LTO, which OOMs the build sandbox
-# linking the final binary; thin LTO fits in memory.
-export CARGO_PROFILE_RELEASE_LTO=thin
-
 cargo build --release -p biome_cli
 
 mkdir -p $OUTPUT_DIR/usr/bin

--- a/packages/biome/build.sh
+++ b/packages/biome/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -ex
+
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+# Upstream's release profile uses fat LTO, which OOMs the build sandbox
+# linking the final binary; thin LTO fits in memory.
+export CARGO_PROFILE_RELEASE_LTO=thin
+
+cargo build --release -p biome_cli
+
+mkdir -p $OUTPUT_DIR/usr/bin
+cp target/release/biome $OUTPUT_DIR/usr/bin/


### PR DESCRIPTION
Adds a package for [Biome](https://github.com/biomejs/biome) 2.5.8, the JS/TS/JSON/CSS formatter and linter.

- Built from the source tarball (tag `@biomejs/biome@2.5.8`) with the packaged Rust 1.97.1 toolchain (satisfies upstream's 1.96.1 requirement).
- `make` is in `build_deps` because `tikv-jemalloc-sys`'s build script shells out to it.
- Uses upstream's release profile as-is, including fat LTO. Note: the fat-LTO link of the final binary needs a lot of memory — it OOMed a smaller build sandbox before the sandbox memory was increased.
- `min package patched-build biome` succeeds and `min check --packages biome` passes all checkers, including the post-build ones (enumerate bins, missing runtime_deps, standalone `biome --version` smoketest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Biome version 2.5.8 to the available build packages.
  * Included the Biome command-line tool for formatting and linting workflows.
  * Added support for installing and running Biome through the packaged command-line executable.
  * Added version verification to help ensure the packaged tool runs correctly.
  * Included licensing and source information for the new package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->