### PR TITLE
lean: ship the module roots — `lean` cannot compile anything without them

### DIFF
--- a/packages/lean/build.ncl
+++ b/packages/lean/build.ncl
@@ -55,6 +55,21 @@ let version = "4.33.0" in
     libs = { glob = "usr/lib/lean/*.{a,so*}" } | OutputLib,
     includes = { glob = "usr/include/**" } | OutputData,
     data = { glob = "usr/lib/lean/**/*.olean" } | OutputData,
+    # The MODULE ROOTS — `Init.olean`, `Std.olean`, `Lean.olean`, `Lake.olean`
+    # — sit directly in `usr/lib/lean/`, and `**/` requires at least one
+    # directory level, so the glob above matches `.../Init/Core.olean` but
+    # never `.../Init.olean`. Those roots are exactly what `import Init`
+    # resolves, so without them lean cannot compile ANY file, including
+    # `#eval 1+1`:
+    #
+    #   error: object file '/usr/lib/lean/Init.olean' of module Init does
+    #   not exist
+    #
+    # Everything else looked right, which is what made it hard to see: 586
+    # oleans ship under Init/ and Std/, and the root-level `.a`/`.so` arrive
+    # via the `libs` glob above — the only absent class is the one file per
+    # module that makes the rest reachable.
+    module_roots = { glob = "usr/lib/lean/*.olean" } | OutputData,
   },
   attrs =
     {

--- a/packages/lean/build.sh
+++ b/packages/lean/build.sh
@@ -48,6 +48,21 @@ cp -a "$STAGE/lib/lean/"*.so* "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 # rest reachable.
 cp -a "$STAGE/lib/lean/"*.olean "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 
+# Then ASSERT they arrived. The copy above swallows errors (the `|| true` is
+# there so a layout change upstream doesn't hard-fail the copy), and a glob
+# happily matches the remaining files if one is absent — which is precisely how
+# this package shipped a lean that could not compile anything, for however long
+# it has been broken, with a green build the whole time. Turn a silent
+# incomplete publish into a loud build failure. (CR on #605.)
+for m in Init Std Lean Lake; do
+  if [ ! -f "$OUTPUT_DIR/usr/lib/lean/$m.olean" ]; then
+    echo "lean: module root $m.olean is MISSING from the install tree." >&2
+    echo "  Without it, 'import $m' cannot resolve and lean compiles nothing." >&2
+    echo "  Check whether upstream moved lib/lean/*.olean in this release." >&2
+    exit 1
+  fi
+done
+
 # Copy olean files and other lean lib data
 for d in "$STAGE/lib/lean/"*/; do
   [ -d "$d" ] && cp -r "$d" "$OUTPUT_DIR/usr/lib/lean/"

--- a/packages/lean/build.sh
+++ b/packages/lean/build.sh
@@ -35,6 +35,19 @@ fi
 mkdir -p "$OUTPUT_DIR/usr/lib/lean"
 cp -a "$STAGE/lib/lean/"*.a "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 cp -a "$STAGE/lib/lean/"*.so* "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
+# The MODULE ROOTS: Init.olean, Std.olean, Lean.olean, Lake.olean sit directly
+# in lib/lean/, NOT in a subdirectory, so the per-directory loop below skips
+# them entirely. They are what `import Init` resolves, so without them lean
+# cannot compile ANY file — not even `#eval 1+1`:
+#
+#   error: object file '/usr/lib/lean/Init.olean' of module Init does not exist
+#
+# Hard to spot because everything else looked right: 586 oleans landed under
+# Init/ and Std/, and the root-level .a/.so came across in the two copies
+# above. The only missing class was the one file per module that makes all the
+# rest reachable.
+cp -a "$STAGE/lib/lean/"*.olean "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
+
 # Copy olean files and other lean lib data
 for d in "$STAGE/lib/lean/"*/; do
   [ -d "$d" ] && cp -r "$d" "$OUTPUT_DIR/usr/lib/lean/"


### PR DESCRIPTION
The `lean` package is currently non-functional. Not "degraded on some inputs" — it cannot compile `#eval 1+1`:

```
$ lean /tmp/t.lean
error: object file '/usr/lib/lean/Init.olean' of module Init does not exist
```

## Cause

Lean's module **roots** — `Init.olean`, `Std.olean`, `Lean.olean`, `Lake.olean` — sit directly in `lib/lean/`, not inside a subdirectory. Two independent places drop them:

- **`build.sh`** copies `lib/lean/*.a` and `lib/lean/*.so*`, then loops over `lib/lean/*/` — **directories only**. The root-level `.olean` files never reach `$OUTPUT_DIR`.
- **the output glob** `usr/lib/lean/**/*.olean` requires at least one directory level, so it wouldn't capture them even if they were there.

Both are fixed here. **Either alone is a no-op** — I wrote the glob fix first, and it would have shipped as a change that did nothing until I read `build.sh`.

## Why it hid

Everything else looked right. 586 oleans land under `Init/` and `Std/`, the binaries run, `lean --version` answers, and `mip check` passes. The only absent class is the one file per module that makes all the rest reachable.

## How it surfaced

Building an aeneas verification bench (a session loadout for the `aeneas` stack). The first two steps of the documented pipeline work end to end on a trivial crate:

```
charon cargo --preset=aeneas --dest-file vlab.llbc   → vlab.llbc (12,614 bytes)
aeneas -backend lean vlab.llbc                       → Generated: ./Vlab.lean
```

and the model is faithful — `fn add(a: u32, b: u32) -> u32` comes out as `Result Std.U32`, modelling the overflow rather than pretending the addition is total. Then nothing could **check** it.

Worth noting: `stacks/aeneas/stack.ncl` says Lean is there "so the loop actually closes (emit AND check)". That claim isn't true today; this PR is what makes it true.

## Verification status — please read

**Not locally build-verified.** `mip package build` refuses on macOS (`sandbox execution is only supported on Linux`), so this leans on CI to do the real build. `mip check --packages lean` is green, but its build-dependent checks Skip on an unbuilt package, so that's weak evidence by itself.

The two checks to make against a built tree:

```
ls usr/lib/lean/Init.olean     # should now exist
lean /tmp/t.lean               # `#eval 1+1` should no longer error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Packaged Lean installations now include root-level compiled modules, including core modules such as `Init`, `Std`, `Lean`, and `Lake`.
  * Improved availability of these modules when using the packaged Lean library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->