### PR TITLE
Add pi 0.84.2

### DIFF
--- a/packages/pi/build.ncl
+++ b/packages/pi/build.ncl
@@ -1,0 +1,52 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let node = import "../node/build.ncl" in
+
+# pi is the Pi coding agent (pi.dev), published to npm as
+# @earendil-works/pi-coding-agent. Like the other open-source npm CLI packages
+# here (typescript-language-server, bash-language-server), it is installed from
+# the registry by name@version into a package-private prefix rather than built
+# from the GitHub monorepo (whose build needs the tsgo native TS compiler and a
+# multi-package workspace, neither of which is warranted for an npm artifact).
+# The `#!/usr/bin/env node` shebang of the installed bin is served by
+# coreutils(env) + node.
+let version = "0.84.2" in
+{
+  name = "pi",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    node,
+  ],
+  runtime_deps = [
+    coreutils,
+    node,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    pi = { glob = "usr/bin/pi" } | OutputBin,
+    libexec = { glob = "usr/libexec/pi/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "earendil-works",
+        repo = "pi",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/pi/build.ncl
+++ b/packages/pi/build.ncl
@@ -1,21 +1,25 @@
-let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let node = import "../node/build.ncl" in
 
 # pi is the Pi coding agent (pi.dev), published to npm as
-# @earendil-works/pi-coding-agent. Like the other open-source npm CLI packages
-# here (typescript-language-server, bash-language-server), it is installed from
-# the registry by name@version into a package-private prefix rather than built
-# from the GitHub monorepo (whose build needs the tsgo native TS compiler and a
-# multi-package workspace, neither of which is warranted for an npm artifact).
-# The `#!/usr/bin/env node` shebang of the installed bin is served by
-# coreutils(env) + node.
+# @earendil-works/pi-coding-agent. It is installed from the sha256-pinned
+# registry tarball (the Source below) rather than built from the GitHub
+# monorepo, whose build needs the tsgo native TS compiler and a multi-package
+# workspace, neither of which is warranted for an npm artifact. The tarball
+# ships an npm-shrinkwrap.json, so installing it locks the transitive
+# dependency tree and keeps the build reproducible. The `#!/usr/bin/env node`
+# shebang of the installed bin is served by coreutils(env) + node.
 let version = "0.84.2" in
 {
   name = "pi",
   build_deps = [
     { file = "build.sh" } | Local,
+    {
+      url = "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-%{version}.tgz",
+      sha256 = "95b899cd7b1a0c1f0174c7bf33ab427435e3553a7d1f4756661aa9c7f1a68ffa",
+    } | Source,
     base,
     node,
   ],

--- a/packages/pi/build.sh
+++ b/packages/pi/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -ex
+
+# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules,
+# which the node runtime owns) so the tool can't collide with it; expose thin
+# symlinks on PATH. The inner `#!/usr/bin/env node` shebang is served by
+# coreutils(env)+node, so no shell is needed.
+npm install -g --prefix="$OUTPUT_DIR/usr/libexec/pi" \
+  "@earendil-works/pi-coding-agent@$MINIMAL_ARG_VERSION"
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for _bin in "$OUTPUT_DIR/usr/libexec/pi/bin/"*; do
+  [ -e "$_bin" ] || continue
+  _tool=${_bin##*/}
+  ln -s "../libexec/pi/bin/$_tool" "$OUTPUT_DIR/usr/bin/$_tool"
+done

--- a/packages/pi/build.sh
+++ b/packages/pi/build.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
 set -ex
 
-# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules,
-# which the node runtime owns) so the tool can't collide with it; expose thin
-# symlinks on PATH. The inner `#!/usr/bin/env node` shebang is served by
-# coreutils(env)+node, so no shell is needed.
+# Install the sha256-pinned registry tarball fetched as a Source (not the live
+# name@version tag), so the exact audited artifact is what ships. The tarball's
+# bundled npm-shrinkwrap.json locks the transitive dependency tree, keeping the
+# build reproducible. Install into a package-PRIVATE prefix (NOT the shared
+# usr/lib/node_modules, which the node runtime owns) so the tool can't collide
+# with it; expose thin symlinks on PATH. The inner `#!/usr/bin/env node`
+# shebang is served by coreutils(env)+node, so no shell is needed.
 npm install -g --prefix="$OUTPUT_DIR/usr/libexec/pi" \
-  "@earendil-works/pi-coding-agent@$MINIMAL_ARG_VERSION"
+  "pi-coding-agent-$MINIMAL_ARG_VERSION.tgz"
 
 mkdir -p "$OUTPUT_DIR/usr/bin"
 for _bin in "$OUTPUT_DIR/usr/libexec/pi/bin/"*; do


### PR DESCRIPTION
Add the `pi` package, the Pi coding agent from pi.dev (npm `@earendil-works/pi-coding-agent`), version 0.84.2.

Pi is a minimal terminal coding harness. It is an npm package, so it is installed from the registry rather than built from the GitHub monorepo, whose build needs the `tsgo` native TypeScript compiler and a multi-package workspace. This matches the existing npm CLI packages here, with one difference: the tarball is pinned as a `Source` by sha256 (like `cf`), and the tarball ships an `npm-shrinkwrap.json` that locks the transitive dependency tree. The build is reproducible: two `--no-cache` builds produce identical content-addressed output.

| File | Purpose |
| --- | --- |
| `packages/pi/build.ncl` | Build spec: sha256-pinned registry tarball Source, `node` + `coreutils` runtime deps, `dns`/`internet` needs, `source_provenance` = `earendil-works/pi` |
| `packages/pi/build.sh` | Installs the pinned tarball into `usr/libexec/pi`, symlinks `usr/bin/pi` |

Verification:
- `mip check --packages pi` passes
- `mip package build pi` builds successfully; two `--no-cache` builds give byte-identical output