### PR TITLE
Add maki 0.4.7

### DIFF
--- a/packages/maki/build.ncl
+++ b/packages/maki/build.ncl
@@ -1,0 +1,67 @@
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+# isahc (static-ssl) vendors and builds OpenSSL from source (perl Configure + make)
+let make = import "../make/build.ncl" in
+let perl = import "../perl/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "0.4.7" in
+{
+  name = "maki",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/tontinton/maki/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "6337b40f5c1db69e780873dfd249d88b03943b0ff16d6eb0e9c752b691db1939",
+      extract = true,
+      strip_prefix = "maki-%{version}",
+    } | Source,
+    base,
+    make,
+    perl,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = { include version },
+
+  outputs = {
+    maki = { glob = "usr/bin/maki" } | OutputBin,
+  },
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [],
+        cmds = [["maki", "--version"]],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "tontinton",
+        repo = "maki",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/maki/build.sh
+++ b/packages/maki/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Source unpacks into cwd via `extract = true` + `strip_prefix` in
+# build.ncl — no explicit `cd` needed.
+
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+export CFLAGS="-O2 -pipe -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+
+cargo build --release --locked --bin maki
+
+mkdir -p $OUTPUT_DIR/usr/bin
+install -m 755 target/release/maki $OUTPUT_DIR/usr/bin/maki

--- a/packages/pi/build.ncl
+++ b/packages/pi/build.ncl
@@ -1,0 +1,52 @@
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let coreutils = import "../coreutils/build.ncl" in
+let node = import "../node/build.ncl" in
+
+# pi is the Pi coding agent (pi.dev), published to npm as
+# @earendil-works/pi-coding-agent. Like the other open-source npm CLI packages
+# here (typescript-language-server, bash-language-server), it is installed from
+# the registry by name@version into a package-private prefix rather than built
+# from the GitHub monorepo (whose build needs the tsgo native TS compiler and a
+# multi-package workspace, neither of which is warranted for an npm artifact).
+# The `#!/usr/bin/env node` shebang of the installed bin is served by
+# coreutils(env) + node.
+let version = "0.84.2" in
+{
+  name = "pi",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    node,
+  ],
+  runtime_deps = [
+    coreutils,
+    node,
+  ],
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    pi = { glob = "usr/bin/pi" } | OutputBin,
+    libexec = { glob = "usr/libexec/pi/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "earendil-works",
+        repo = "pi",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/pi/build.ncl
+++ b/packages/pi/build.ncl
@@ -1,21 +1,25 @@
-let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let node = import "../node/build.ncl" in
 
 # pi is the Pi coding agent (pi.dev), published to npm as
-# @earendil-works/pi-coding-agent. Like the other open-source npm CLI packages
-# here (typescript-language-server, bash-language-server), it is installed from
-# the registry by name@version into a package-private prefix rather than built
-# from the GitHub monorepo (whose build needs the tsgo native TS compiler and a
-# multi-package workspace, neither of which is warranted for an npm artifact).
-# The `#!/usr/bin/env node` shebang of the installed bin is served by
-# coreutils(env) + node.
+# @earendil-works/pi-coding-agent. It is installed from the sha256-pinned
+# registry tarball (the Source below) rather than built from the GitHub
+# monorepo, whose build needs the tsgo native TS compiler and a multi-package
+# workspace, neither of which is warranted for an npm artifact. The tarball
+# ships an npm-shrinkwrap.json, so installing it locks the transitive
+# dependency tree and keeps the build reproducible. The `#!/usr/bin/env node`
+# shebang of the installed bin is served by coreutils(env) + node.
 let version = "0.84.2" in
 {
   name = "pi",
   build_deps = [
     { file = "build.sh" } | Local,
+    {
+      url = "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-%{version}.tgz",
+      sha256 = "95b899cd7b1a0c1f0174c7bf33ab427435e3553a7d1f4756661aa9c7f1a68ffa",
+    } | Source,
     base,
     node,
   ],

--- a/packages/pi/build.sh
+++ b/packages/pi/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -ex
+
+# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules,
+# which the node runtime owns) so the tool can't collide with it; expose thin
+# symlinks on PATH. The inner `#!/usr/bin/env node` shebang is served by
+# coreutils(env)+node, so no shell is needed.
+npm install -g --prefix="$OUTPUT_DIR/usr/libexec/pi" \
+  "@earendil-works/pi-coding-agent@$MINIMAL_ARG_VERSION"
+
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for _bin in "$OUTPUT_DIR/usr/libexec/pi/bin/"*; do
+  [ -e "$_bin" ] || continue
+  _tool=${_bin##*/}
+  ln -s "../libexec/pi/bin/$_tool" "$OUTPUT_DIR/usr/bin/$_tool"
+done

--- a/packages/pi/build.sh
+++ b/packages/pi/build.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
 set -ex
 
-# Install into a package-PRIVATE prefix (NOT the shared usr/lib/node_modules,
-# which the node runtime owns) so the tool can't collide with it; expose thin
-# symlinks on PATH. The inner `#!/usr/bin/env node` shebang is served by
-# coreutils(env)+node, so no shell is needed.
+# Install the sha256-pinned registry tarball fetched as a Source (not the live
+# name@version tag), so the exact audited artifact is what ships. The tarball's
+# bundled npm-shrinkwrap.json locks the transitive dependency tree, keeping the
+# build reproducible. Install into a package-PRIVATE prefix (NOT the shared
+# usr/lib/node_modules, which the node runtime owns) so the tool can't collide
+# with it; expose thin symlinks on PATH. The inner `#!/usr/bin/env node`
+# shebang is served by coreutils(env)+node, so no shell is needed.
 npm install -g --prefix="$OUTPUT_DIR/usr/libexec/pi" \
-  "@earendil-works/pi-coding-agent@$MINIMAL_ARG_VERSION"
+  "pi-coding-agent-$MINIMAL_ARG_VERSION.tgz"
 
 mkdir -p "$OUTPUT_DIR/usr/bin"
 for _bin in "$OUTPUT_DIR/usr/libexec/pi/bin/"*; do


### PR DESCRIPTION
Add a package for maki 0.4.7, a Rust TUI AI coding agent (github.com/tontinton/maki).

## Changes

| File | Purpose |
| --- | --- |
| `packages/maki/build.ncl` | BuildSpec for maki 0.4.7: GitHub source tarball, rust + toolchain + make + perl build deps, glibc + libgcc runtime deps, standalone `maki --version` test |
| `packages/maki/build.sh` | `cargo build --release --locked --bin maki` with Rust and C determinism flags (path remaps, prefix map) |

Notes:

- `make` and `perl` are required because isahc builds vendored OpenSSL from source (static-ssl). `toolchain` ships neither.
- Built-in Lua plugins are embedded at compile time via `include_dir!`, so the package ships only the binary.
- `needs = { dns, internet }` for cargo fetches; `Cargo.lock` is committed, so the build uses `--locked`.

## Verification

- `mip check --packages maki`: all 15 checks pass, including `missing runtime_deps` and the standalone test
- Two clean-room builds (`mip package build` and `mip package build --rebuild`) produce byte-identical output (same content-addressed hash; `diff -r` clean)
- `maki --version` prints `maki 0.4.7`