### PR TITLE
tamarin-prover: use the packaged alex/happy instead of cabal's own (intermittent amd64 failure)

### DIFF
--- a/packages/tamarin-prover/build.ncl
+++ b/packages/tamarin-prover/build.ncl
@@ -10,6 +10,12 @@ let ghc = import "../ghc/build.ncl" in
 let cabal = import "../cabal/build.ncl" in
 let gmp = import "../gmp/build.ncl" in
 let patch = import "../patch/build.ncl" in
+# alex + happy: the lexer/parser generators `language-javascript` (a tamarin
+# dependency) needs at CONFIGURE time. Both are packaged, so build them ONCE
+# from the fleet rather than letting cabal provision its own from Hackage into
+# `.cabal-home/store` — see build.sh for why that mattered on amd64.
+let alex = import "../alex/build.ncl" in
+let happy = import "../happy/build.ncl" in
 let graphviz = import "../graphviz/build.ncl" in
 let maude = import "../maude/build.ncl" in
 let version = "1.12.0" in
@@ -39,6 +45,8 @@ let version = "1.12.0" in
     cabal,
     gmp,
     patch,
+    alex,
+    happy,
   ],
   runtime_deps = [
     gmp,

--- a/packages/tamarin-prover/build.sh
+++ b/packages/tamarin-prover/build.sh
@@ -102,12 +102,48 @@ if grep -q 'getCurrentTime' "$stamp_file"; then
     exit 1
 fi
 
+# ── amd64: use the PACKAGED alex/happy, not cabal's own ──────────────────────
+#
+# tamarin built on arm64 and failed on amd64 (pkgs#606's run, 2026-08-14) with:
+#
+#   Error: [Cabal-1008]
+#   The program 'alex' version >=3.1.4 is required but the version of
+#   /build/.cabal-home/store/ghc-9.10.3-inplace/alex-3.5.4.2-.../bin/alex
+#   could not be determined.
+#
+# NOT a compile error: cabal BUILT alex fine ("Completed alex-3.5.4.2 (exe:alex)")
+# and then could not get a version out of it when `language-javascript`
+# configured. So the binary exists and will not answer — which is what you get
+# from a partially-installed store entry under `--jobs=$(nproc)`, or from an
+# invocation killed for memory. Either way it is cabal provisioning its own copy
+# that fails, and both alex and happy are already packaged for both arches.
+#
+# Point cabal at those instead. `--with-PROG` is Cabal's documented override for
+# a known program, and alex/happy are known programs.
+#
+# The assertions below are deliberate: if the packaged tools are the problem
+# rather than the fix, this fails HERE with the version printed, instead of 40
+# minutes later inside a dependency's configure step with no way to tell which
+# alex cabal used. Amd64 could not be reproduced locally (this fleet develops on
+# arm64), so the next run's log is the experiment.
+ALEX_BIN="$(command -v alex)"
+HAPPY_BIN="$(command -v happy)"
+echo "tamarin: packaged alex  = ${ALEX_BIN:-<not on PATH>}"
+echo "tamarin: packaged happy = ${HAPPY_BIN:-<not on PATH>}"
+[ -n "$ALEX_BIN" ]  || { echo "ERROR: alex not on PATH — build_deps regression" >&2; exit 1; }
+[ -n "$HAPPY_BIN" ] || { echo "ERROR: happy not on PATH — build_deps regression" >&2; exit 1; }
+# Prove they RUN and report a version — the exact thing cabal could not do.
+"$ALEX_BIN" --version  || { echo "ERROR: packaged alex cannot report a version"  >&2; exit 1; }
+"$HAPPY_BIN" --version || { echo "ERROR: packaged happy cannot report a version" >&2; exit 1; }
+
 # Build + install the executable (STATIC — a normal Haskell static link; the link
 # was never the problem). The sandbox hides build detail, so on failure dump the
 # real error (compile OR link) rather than a silent "Failed to build".
 set +e
 cabal build exe:tamarin-prover \
     --with-compiler="$(command -v ghc)" \
+    --with-alex="$ALEX_BIN" \
+    --with-happy="$HAPPY_BIN" \
     --jobs="$(nproc)" -v1 2>&1 | tee /tmp/tam-build.log
 rc=${PIPESTATUS[0]}
 set -e

--- a/packages/tamarin-prover/build.sh
+++ b/packages/tamarin-prover/build.sh
@@ -104,7 +104,7 @@ fi
 
 # ── amd64: use the PACKAGED alex/happy, not cabal's own ──────────────────────
 #
-# tamarin built on arm64 and failed on amd64 (pkgs#606's run, 2026-08-14) with:
+# tamarin fails INTERMITTENTLY on amd64 (pkgs#606's run, 2026-08-14) with:
 #
 #   Error: [Cabal-1008]
 #   The program 'alex' version >=3.1.4 is required but the version of
@@ -117,6 +117,15 @@ fi
 # from a partially-installed store entry under `--jobs=$(nproc)`, or from an
 # invocation killed for memory. Either way it is cabal provisioning its own copy
 # that fails, and both alex and happy are already packaged for both arches.
+#
+# INTERMITTENT is established, not assumed: pkgs#607 and #608 built the same
+# tamarin source on the same amd64 builder and PASSED (merged 20:28 and 20:30
+# the same day) hours after #606 failed at 12:33. So this is not a miscompile
+# and not a missing dependency — it is a race, and #606 drew the short straw.
+#
+# That is the worse shape for a queue: the natural response to a flake is to
+# re-run it, which usually works, which is how one survives for weeks without
+# anyone fixing it.
 #
 # Point cabal at those instead. `--with-PROG` is Cabal's documented override for
 # a known program, and alex/happy are known programs.


### PR DESCRIPTION
tamarin fails **intermittently** on amd64. Seen in pkgs#606's run — note tamarin is *not in that PR*; the buildbot builds the whole graph, so it failed as collateral.

```
Error: [Cabal-1008]
The program 'alex' version >=3.1.4 is required but the version of
/build/.cabal-home/store/ghc-9.10.3-inplace/alex-3.5.4.2-.../bin/alex
could not be determined.
```

## Intermittent is established, not assumed

**pkgs#607 and #608 built the same tamarin source on the same amd64 builder and passed** — merged 20:28 and 20:30 on 2026-08-14, hours after #606 failed at 12:33.

So amd64 works most of the time. This is **not** a miscompile, **not** a missing dependency, and **not** something #606 introduced. It is a race, and #606 drew the short straw.

*(An earlier revision of this PR said "builds on arm64 and fails on amd64" and framed it as the onboarding's amd64-unverified flag coming due. That was wrong; the second commit corrects the diagnosis in the build.sh comment, which is what outlives this PR.)*

## This is not a compile error

Cabal **built alex successfully** (`Completed alex-3.5.4.2 (exe:alex)`) and then could not get a version out of it when `language-javascript` configured. The binary exists and will not answer — the shape you get from a partially-installed store entry under `--jobs=$(nproc)`, or an invocation killed for memory.

## The fix

Both `alex` and `happy` are **already packaged** for both arches, and tamarin was not using them — cabal was provisioning its own from Hackage. Add them to `build_deps` and point cabal at them via `--with-alex` / `--with-happy`.

That removes the racy step rather than tuning around it, and drops a from-Hackage build out of a pioneering GHC-9.10 port that already carries four source patches.

## Cannot be reproduced locally

No amd64 here, and Haskell will not build on macOS at all (`sandbox execution is only supported on Linux`). So the build **asserts** the packaged tools exist and can report a version, printing both paths first:

```
tamarin: packaged alex  = /usr/bin/alex
tamarin: packaged happy = /usr/bin/happy
```

If the packaged tools turn out to be the problem rather than the fix, it fails at that assertion with the evidence in hand — instead of 40 minutes later inside a dependency's configure step with no way to tell which alex cabal used.

## If this does not settle it

The next suspect is **`--jobs=$(nproc)`** itself rather than alex specifically, since the same race can bite any build tool. I have deliberately not capped parallelism here: it would slow an already-long build and muddy the signal from this change.

Worth naming the risk in a flake: the natural response is to re-run it, which usually works, which is exactly how one survives for weeks without anyone fixing it.

`bash -n` clean; `mip check --packages tamarin-prover` all Pass (build-dependent checks Skip on an unbuilt package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
