### PR TITLE
ci(setup-minimal): route package-cache reads through the R2 mirror

### DIFF
--- a/.github/actions/setup-minimal/action.yml
+++ b/.github/actions/setup-minimal/action.yml
@@ -38,3 +38,14 @@ runs:
     - name: Enable unprivileged user namespaces
       shell: bash
       run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+    - name: Route package-cache reads through the R2 mirror
+      shell: bash
+      # Same move as webapp#380: CI runs on GitHub-hosted Azure runners, so
+      # cache reads from GCS are billed internet egress; cache.minimal.farm
+      # serves the identical immutable, sha256-verified artifacts from R2 at
+      # $0 egress. Measured before this change: the six advisory workflows
+      # cold-pull ~6.5 GB per fresh runner, ~370 GB/week across the fleet —
+      # the majority of remaining GCS egress spend. Written to $GITHUB_ENV so
+      # it reaches the calling job's later steps. Trailing slash required
+      # (Url::join). Rollback = delete this step.
+      run: echo "MINIMAL_REMOTE_CACHE_URL=https://cache.minimal.farm/" >> "$GITHUB_ENV"


### PR DESCRIPTION
Replaces #613 — that PR accidentally included unrelated working-tree files (my `git add -A` in a live checkout; the WIP has been restored to its owner untouched). This one is the intended single-file change.

One step added to the shared `setup-minimal` action, mirroring **webapp#380** — with the bill quantified.

**Why**: the six per-PR advisory workflows (smoke-test-coverage, corresponding-source, stable-closure-check, trivial-update, license-lint, version-age) each run on a fresh GitHub-hosted Azure runner and cold-pull **~6.5 GB** of toolchain artifacts from GCS in ~90 seconds. Across the fleet that's **~370 GB/week from ~174 runner IPs** — the majority of remaining billed GCS egress (~$250 CAD/mo at current pace). Attribution from GCS usage logs, timestamp-matched to this repo's workflow launch batches (runner IP active 21:22–21:24 ↔ workflows launched 21:22:13).

**Why it's safe**: `cache.minimal.farm` serves the identical immutable objects from R2 (verified byte-identical against authoritative GCS); the CLI sha256-verifies every artifact regardless of source; `MINIMAL_REMOTE_CACHE_URL` is honored by every build on the `unstable` channel (minimal#643) and continuously canaried by minimal's dogfood lane (minimal#667). webapp has run this way since July 8. Rollback = delete the step.

(Uses `.farm` for now — it flips to `cache.minimal.dev` for free when minimal#1234 makes that the client default, at which point this step becomes a harmless no-op that can be deleted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured package-cache reads to use the designated remote cache mirror in minimal setup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->