### PR TITLE
feat: added odin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ stack {
 Stacks were previously called "harnesses". The stdlib still exports `harness` as an alias for `stack`, but new
 stacks should use `stack` and live at `stacks/<name>/stack.ncl`.
 
-Current stacks cover: aeneas, bun, cabal, cmake, deno, go, gradle, make, maven, meson, npm, ocaml, pip, pnpm, pulumi-go, pulumi-nodejs, rust, shell, stack, uv, zig.
+Current stacks cover: aeneas, bun, cabal, cmake, deno, go, gradle, make, maven, meson, npm, ocaml, odin, pip, pnpm, pulumi-go, pulumi-nodejs, rust, shell, stack, uv, zig.
 
 
 

--- a/packages/binaryen/build.ncl
+++ b/packages/binaryen/build.ncl
@@ -1,0 +1,80 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# Binaryen tags its releases version_<N>; the directory and the tag both use
+# that form, so the bare number is kept separate from the tag it builds.
+let version = "124" in
+{
+  name = "binaryen",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/WebAssembly/binaryen/archive/refs/tags/version_%{version}.tar.gz",
+      sha256 = "b8d06af81a8c2bb27c34d1f9e3cf7c621f93fc901f896809e0490f3586a63ca4",
+      extract = true,
+      strip_prefix = "binaryen-version_%{version}",
+    } | Source,
+    base,
+    cmake,
+    make,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc", "libstdcpp"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/*" } | OutputBin,
+    libs = { glob = "usr/lib/libbinaryen.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "WebAssembly",
+        repo = "binaryen",
+      },
+    } | Attrs,
+
+  tests = {
+    # The six tools emscripten drives directly -- see emscripten's
+    # docs/packaging.md. If a future bump drops or renames one, this catches it
+    # here rather than part-way through an emcc run.
+    emscripten_tools =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "set -eu; for t in wasm-opt wasm-emscripten-finalize wasm-dis wasm-as wasm2js wasm-metadce; do command -v $t >/dev/null; done"],
+        ],
+      } | Test,
+
+    roundtrip =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "printf '(module (func $$f (result i32) (i32.const 42)) (export \"f\" (func $$f)))' > m.wat"],
+          ["/bin/bash", "-c", "wasm-as m.wat -o m.wasm && wasm-opt -O3 m.wasm -o m.opt.wasm && wasm-dis m.opt.wasm | grep -q 'i32.const 42'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/binaryen/build.sh
+++ b/packages/binaryen/build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -ex
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+export CFLAGS="$MARCH -O3 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--build-id=none"
+export ARFLAGS=Drc
+
+# ENABLE_WERROR is on by default upstream, which turns any new warning from a
+# newer gcc into a build failure. BUILD_TESTS pulls in a googletest checkout
+# that the release tarball does not carry.
+# CMake defaults LIBDIR to lib64 on this platform; everything else in the
+# registry installs libraries to usr/lib.
+cmake -B build \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_TESTS=OFF \
+  -DENABLE_WERROR=OFF
+
+cmake --build build -j"$(nproc)"
+DESTDIR="$OUTPUT_DIR" cmake --install build

--- a/packages/emscripten/build.ncl
+++ b/packages/emscripten/build.ncl
@@ -1,0 +1,139 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let binaryen = import "../binaryen/build.ncl" in
+let llvm = import "../llvm/build.ncl" in
+let node = import "../node/build.ncl" in
+let python = import "../python/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+
+# Emscripten does not support stable LLVM releases in general -- it tracks
+# LLVM top-of-tree -- so the version is pinned to the last release whose
+# EXPECTED_LLVM_VERSION is 21, matching the llvm package. Bumping emscripten
+# means bumping llvm in lockstep; tools/shared.py holds the expected major.
+#
+# LIMITATION -- no JavaScript optimizer. This package ships without the npm
+# dependencies emscripten's own installer would fetch (see build.sh), so the
+# JS-side toolchain is absent: `acorn`, which tools/acorn-optimizer.mjs drives
+# at -O2 and above, and the closure compiler, which is a prebuilt jar. Emitting
+# JavaScript works -- `emcc foo.c -o foo.js` is covered by link_run -- but
+# `-O2`/`-O3`/`--closure 1` on a link that produces .js will fail resolving
+# those modules. Compiling and archiving, which is what vendor:raylib's wasm
+# libraries need, is unaffected. Restoring it means vendoring or mirroring the
+# npm tree rather than stubbing the install.
+let version = "4.0.11" in
+{
+  name = "emscripten",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/emscripten-core/emscripten/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "aecfc5df27141d5fb6dd2d4853d8cff0f7719fac4edea34ea7786a6a86d6ecf5",
+      extract = true,
+      strip_prefix = "emscripten-%{version}",
+    } | Source,
+    base,
+  ],
+
+  # Emscripten ships no compiled binaries of its own: it is Python and JS
+  # driving clang, wasm-ld and binaryen, so everything it calls is a runtime
+  # dependency rather than a build one.
+  runtime_deps = [
+    binaryen,
+    glibc,
+    node,
+    python,
+    subsetOf llvm ["bins", "libllvm", "libs_clang", "liblld", "libclang"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    bins = { glob = "usr/bin/em*" } | OutputBin,
+    emscripten = { glob = "usr/share/emscripten/**", allow_executable = true } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT AND NCSA",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "emscripten-core",
+        repo = "emscripten",
+      },
+    } | Attrs,
+
+  tests = {
+    version_check =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [["/bin/emcc", "--version"]],
+      } | Test,
+
+    # install.py copies the source tree wholesale, which by then also contains
+    # whatever the sandbox dropped in beside it -- our own build.sh included.
+    # Assert it stays out rather than trusting a local install to be current.
+    no_build_scaffolding =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "test ! -e /usr/share/emscripten/build.sh"],
+          ["/bin/bash", "-c", "test ! -e /usr/share/emscripten/output"],
+          ["/bin/bash", "-c", "test -z \"$(find /usr/share/emscripten -maxdepth 1 -name 'repro_*')\""],
+        ],
+      } | Test,
+
+    # This package fetches nothing but its own source tarball, and the two
+    # things that used to reach the network leave evidence when they run:
+    # `npm ci` creates node_modules, and a built port lands in cache/ports.
+    # Either reappearing means the build started downloading again -- and since
+    # the spec no longer declares dns/internet, it would fail late and obscurely
+    # rather than here.
+    fetches_nothing =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "test ! -e /usr/share/emscripten/node_modules"],
+          ["/bin/bash", "-c", "test ! -e /usr/share/emscripten/cache/ports"],
+        ],
+      } | Test,
+
+    # Compiles and archives, which is the path a C library build takes. Also
+    # proves the prebuilt sysroot cache is complete: with a read-only install
+    # emcc cannot build its own libc on first use.
+    compile_archive =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <stdio.h>\\nint answer(void){ return 42; }\\n' > a.c"],
+          ["/bin/bash", "-c", "emcc -c a.c -o a.o && emar rcs liba.a a.o"],
+          ["/bin/bash", "-c", "test -s liba.a"],
+        ],
+      } | Test,
+
+    # Full link through wasm-ld plus binaryen, run under node.
+    link_run =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <stdio.h>\\nint main(void){ printf(\"ok\\\\n\"); return 0; }\\n' > m.c"],
+          # No EM_CACHE set: this also covers the wrapper seeding a writable
+          # cache, without which linking against the read-only install fails.
+          ["/bin/bash", "-c", "emcc m.c -o m.js"],
+          ["/bin/bash", "-c", "test -f m.js && test -f m.wasm"],
+          ["/bin/bash", "-c", "node m.js > out.txt 2>&1"],
+          ["/bin/bash", "-c", "grep -q ok out.txt"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/emscripten/build.sh
+++ b/packages/emscripten/build.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -ex
+
+EM_ROOT="$OUTPUT_DIR/usr/share/emscripten"
+
+# install.py unconditionally runs `npm ci`, pulling ~110 packages from
+# registry.npmjs.org and executing their lifecycle scripts. Those drive the
+# JS-side tooling only -- optimising and minifying generated glue -- and nothing
+# on the compile-and-archive path this package exists for touches them. Feeding
+# it a no-op `npm` on PATH keeps the whole npm registry out of the build.
+# The stub lives outside the source tree: install.py copies that tree wholesale,
+# so anything left beside it gets shipped.
+NPM_STUB=/tmp/npm-stub
+mkdir -p "$NPM_STUB"
+printf '#!/bin/sh\nexit 0\n' > "$NPM_STUB/npm"
+chmod 0755 "$NPM_STUB/npm"
+
+# Emscripten's own packaging entry point: like `make dist`, but it drops the
+# test corpus, git metadata and other things end users never need.
+PATH="$NPM_STUB:$PATH" python3 tools/install.py "$EM_ROOT"
+
+rm -rf "$NPM_STUB"
+
+# Emscripten looks for a config beside its own root before falling back to
+# $HOME, so the packaged config lives inside the install tree and needs no
+# environment set up by the caller. LLVM_ROOT is a directory of binaries;
+# BINARYEN_ROOT is a prefix with bin/ underneath it.
+cat > "$EM_ROOT/.emscripten" <<'EOF'
+LLVM_ROOT = '/usr/bin'
+BINARYEN_ROOT = '/usr'
+NODE_JS = '/usr/bin/node'
+EOF
+
+# install.py copies the source tree, which by then also holds whatever the
+# sandbox and the build have put beside it: our own build.sh, and $OUTPUT_DIR
+# itself -- its EXCLUDES list covers `out`, not `output`. Neither is ours to
+# ship. Harmless on a clean build (output is still empty when install.py runs)
+# but it is copy-what-is-there, so drop both rather than rely on ordering.
+rm -f "$EM_ROOT/build.sh"
+rm -rf "$EM_ROOT/output"
+
+# Each entry point is a shell stub that runs "$0.py", so it has to see its own
+# path inside the emscripten tree -- a symlink from /usr/bin would send it
+# looking for /usr/bin/emcc.py. Hence wrappers rather than links.
+mkdir -p "$OUTPUT_DIR/usr/bin"
+for t in em++ em-config emar embuilder emcc emcmake emconfigure emdwp emmake \
+         emnm emprofile emranlib emrun emscan-deps emscons emsize emstrip \
+         emsymbolizer; do
+  cat > "$OUTPUT_DIR/usr/bin/$t" <<EOF
+#!/bin/sh
+# emcc writes to its cache while linking even when every entry is already
+# built. Seed a per-user copy on first use so linking works out of the box,
+# offline, with the prebuilt sysroot intact. Set EM_CACHE yourself to override.
+#
+# Keyed on EM_CACHE alone, deliberately: testing the packaged cache for
+# writability would say "writable" for root (test -w only checks the mode
+# bits, and the directory is 0755), and this package is content-addressed --
+# writing into it corrupts the store rather than merely being untidy. It is
+# never the right target, whatever the permissions say.
+if [ -z "\$EM_CACHE" ]; then
+  EM_CACHE="\${XDG_CACHE_HOME:-\${HOME:-/tmp}/.cache}/emscripten-$MINIMAL_ARG_VERSION"
+  if [ ! -d "\$EM_CACHE" ]; then
+    # Populate a scratch copy and claim it with a single rename, so a
+    # concurrent emcc or an interrupted copy can never leave a half-populated
+    # sysroot that every later run would reuse. mv -T fails rather than
+    # nesting if another process won the race.
+    mkdir -p "\$(dirname "\$EM_CACHE")"
+    _emtmp=\$(mktemp -d "\$EM_CACHE.tmp.XXXXXX") || exit 1
+    cp -a /usr/share/emscripten/cache/. "\$_emtmp"/
+    mv -T "\$_emtmp" "\$EM_CACHE" 2>/dev/null || rm -rf "\$_emtmp"
+  fi
+  export EM_CACHE
+fi
+exec /usr/share/emscripten/$t "\$@"
+EOF
+  chmod 0755 "$OUTPUT_DIR/usr/bin/$t"
+done
+
+# emcc compiles its own sysroot (musl libc, compiler-rt, libc++) on first use
+# and caches it inside the install tree. That tree is read-only once packaged,
+# so build the cache here instead of failing at the first invocation.
+#
+# SYSTEM, not ALL: ALL additionally builds every optional PORT (SDL, ICU,
+# harfbuzz, sqlite, ...), and each port is downloaded from its own upstream at
+# build time -- ~26 projects across 7 hosts, none of them mirrored. Nothing here
+# uses one: raylib's web build is compile-and-archive, and its -sUSE_GLFW=3 is a
+# built-in JS library, not a port. A consumer who does want a port can point
+# EM_CACHE at a writable directory, which the wrappers above already arrange.
+export EM_CACHE="$EM_ROOT/cache"
+"$EM_ROOT/embuilder" build SYSTEM
+
+# cache/build holds intermediate objects kept only to rebuild, which a read-only
+# install cannot do. Only cache/sysroot is consulted at link time.
+rm -rf "$EM_ROOT/cache/build"
+
+find "$EM_ROOT" -name '__pycache__' -type d -prune -exec rm -rf {} +
+

--- a/packages/libxcursor/build.ncl
+++ b/packages/libxcursor/build.ncl
@@ -1,0 +1,50 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let xorgproto = import "../xorgproto/build.ncl" in
+
+let libxrender = import "../libxrender/build.ncl" in
+let libxfixes = import "../libxfixes/build.ncl" in
+let libx11 = import "../libx11/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.2.3" in
+{
+  name = "libxcursor",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/libXcursor-%{version}.tar.xz",
+      sha256 = "fde9402dd4cfe79da71e2d96bb980afc5e6ff4f8a7d74c159e1966afb2b2c2c0",
+      extract = true,
+      strip_prefix = "libXcursor-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+    pkgconf,
+    xorgproto,
+  ],
+  runtime_deps = [
+    libxrender,
+    libxfixes,
+    libx11,
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    libs = { glob = "usr/lib/libXcursor.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfigs = { glob = "usr/lib/pkgconfig/*.pc" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/libxcursor/build.sh
+++ b/packages/libxcursor/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr --disable-static
+
+make -j$(nproc)
+make DESTDIR="$OUTPUT_DIR" install
+
+find "$OUTPUT_DIR" -name '*.la' -delete

--- a/packages/libxinerama/build.ncl
+++ b/packages/libxinerama/build.ncl
@@ -1,0 +1,48 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let xorgproto = import "../xorgproto/build.ncl" in
+
+let libxext = import "../libxext/build.ncl" in
+let libx11 = import "../libx11/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "1.1.6" in
+{
+  name = "libxinerama",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/libXinerama-%{version}.tar.xz",
+      sha256 = "d00fc1599c303dc5cbc122b8068bdc7405d6fcb19060f4597fc51bd3a8be51d7",
+      extract = true,
+      strip_prefix = "libXinerama-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+    pkgconf,
+    xorgproto,
+  ],
+  runtime_deps = [
+    libxext,
+    libx11,
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    libs = { glob = "usr/lib/libXinerama.so*" } | OutputLib,
+    includes = { glob = "usr/include/**" } | OutputData,
+    pkgconfigs = { glob = "usr/lib/pkgconfig/*.pc" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/libxinerama/build.sh
+++ b/packages/libxinerama/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+export CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+export LDFLAGS="-Wl,--build-id=none"
+export CXXFLAGS="${CFLAGS}"
+
+./configure --prefix=/usr --disable-static
+
+make -j$(nproc)
+make DESTDIR="$OUTPUT_DIR" install
+
+find "$OUTPUT_DIR" -name '*.la' -delete

--- a/packages/lua51/build.ncl
+++ b/packages/lua51/build.ncl
@@ -1,0 +1,82 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+
+# Lua's series is its MINOR component, and the series are separate, mutually
+# incompatible libraries that install side by side -- hence one package per
+# series rather than a single `lua`. 5.1, 5.2 and 5.3 are closed and the
+# versions here are their final releases; only 5.4 still receives them. A bump
+# must stay inside the series: 5.5 is a different library, not an upgrade.
+let version = "5.1.5" in
+let abi = "5.1" in
+{
+  name = "lua51",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/lua-%{version}.tar.gz",
+      sha256 = "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333",
+      extract = true,
+      strip_prefix = "lua-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include abi,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/liblua%{abi}.so*" } | OutputLib,
+    static = { glob = "usr/lib/liblua%{abi}.a" } | OutputLib,
+    includes = { glob = "usr/include/lua%{abi}/*.h*" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+
+  tests = {
+    link_static =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\n#include <lua%{abi}/lualib.h>\\nint main(void){ lua_State *L = luaL_newstate(); luaL_openlibs(L); int rc = luaL_dostring(L, \"x = 1 + 1\"); lua_close(L); return rc; }\\n' > t.c"],
+          # -l:liblua5.4.a, not -llua5.4: with both in the same directory ld
+          # picks the shared object, which would make this a duplicate of
+          # link_shared and leave the archive -- the artifact odin vendors --
+          # untested.
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.a -lm -ldl && ./t"],
+        ],
+      } | Test,
+
+    # `system:lua5.4` is what Odin's vendor bindings link against off amd64, so
+    # the plain -l name has to resolve to the shared library.
+    link_shared =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          # Deliberately only newstate/close: this has to compile against 5.1
+          # through 5.4, and lua_version arrived in 5.2.
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\nint main(void){ lua_State *L = luaL_newstate(); if (!L) return 1; lua_close(L); return 0; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.so -lm && ./t"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lua51/build.sh
+++ b/packages/lua51/build.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -ex
+
+ABI="$MINIMAL_ARG_ABI"
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+CFLAGS="$MARCH -O2 -pipe -fPIC -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+
+# LUA_USE_POSIX + LUA_USE_DLOPEN is what LUA_USE_LINUX expands to minus
+# readline, which only the standalone interpreter needs -- this package ships
+# the library, so it stays out of the dependency set. `ar -D` for a
+# deterministic archive.
+make -C src liblua.a \
+  CC=gcc \
+  AR="ar -D rc" \
+  MYCFLAGS="$CFLAGS -DLUA_USE_POSIX -DLUA_USE_DLOPEN"
+
+# Upstream ships no shared library and no rule to build one; every distro links
+# its own. The SONAME is the versioned name so `-llua5.4` records a series-
+# specific dependency and the four series coexist.
+gcc -shared -Wl,-soname,"liblua$ABI.so" -Wl,--build-id=none \
+  -o "liblua$ABI.so" src/*.o -lm -ldl
+
+install -D -m 0644 src/liblua.a     "$OUTPUT_DIR/usr/lib/liblua$ABI.a"
+install -D -m 0755 "liblua$ABI.so"  "$OUTPUT_DIR/usr/lib/liblua$ABI.so"
+
+# Headers go under a versioned directory so the series can be installed
+# together without fighting over usr/include/lua.h.
+mkdir -p "$OUTPUT_DIR/usr/include/lua$ABI"
+install -m 0644 src/lua.h src/luaconf.h src/lualib.h src/lauxlib.h \
+  "$OUTPUT_DIR/usr/include/lua$ABI/"
+
+# The C++ wrapper header arrived in 5.2; 5.1 has no lua.hpp to install.
+if [ -f src/lua.hpp ]; then
+  install -m 0644 src/lua.hpp "$OUTPUT_DIR/usr/include/lua$ABI/"
+fi

--- a/packages/lua52/build.ncl
+++ b/packages/lua52/build.ncl
@@ -1,0 +1,82 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+
+# Lua's series is its MINOR component, and the series are separate, mutually
+# incompatible libraries that install side by side -- hence one package per
+# series rather than a single `lua`. 5.1, 5.2 and 5.3 are closed and the
+# versions here are their final releases; only 5.4 still receives them. A bump
+# must stay inside the series: 5.5 is a different library, not an upgrade.
+let version = "5.2.4" in
+let abi = "5.2" in
+{
+  name = "lua52",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/lua-%{version}.tar.gz",
+      sha256 = "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b",
+      extract = true,
+      strip_prefix = "lua-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include abi,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/liblua%{abi}.so*" } | OutputLib,
+    static = { glob = "usr/lib/liblua%{abi}.a" } | OutputLib,
+    includes = { glob = "usr/include/lua%{abi}/*.h*" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+
+  tests = {
+    link_static =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\n#include <lua%{abi}/lualib.h>\\nint main(void){ lua_State *L = luaL_newstate(); luaL_openlibs(L); int rc = luaL_dostring(L, \"x = 1 + 1\"); lua_close(L); return rc; }\\n' > t.c"],
+          # -l:liblua5.4.a, not -llua5.4: with both in the same directory ld
+          # picks the shared object, which would make this a duplicate of
+          # link_shared and leave the archive -- the artifact odin vendors --
+          # untested.
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.a -lm -ldl && ./t"],
+        ],
+      } | Test,
+
+    # `system:lua5.4` is what Odin's vendor bindings link against off amd64, so
+    # the plain -l name has to resolve to the shared library.
+    link_shared =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          # Deliberately only newstate/close: this has to compile against 5.1
+          # through 5.4, and lua_version arrived in 5.2.
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\nint main(void){ lua_State *L = luaL_newstate(); if (!L) return 1; lua_close(L); return 0; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.so -lm && ./t"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lua52/build.sh
+++ b/packages/lua52/build.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -ex
+
+ABI="$MINIMAL_ARG_ABI"
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+CFLAGS="$MARCH -O2 -pipe -fPIC -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+
+# LUA_USE_POSIX + LUA_USE_DLOPEN is what LUA_USE_LINUX expands to minus
+# readline, which only the standalone interpreter needs -- this package ships
+# the library, so it stays out of the dependency set. `ar -D` for a
+# deterministic archive.
+make -C src liblua.a \
+  CC=gcc \
+  AR="ar -D rc" \
+  MYCFLAGS="$CFLAGS -DLUA_USE_POSIX -DLUA_USE_DLOPEN"
+
+# Upstream ships no shared library and no rule to build one; every distro links
+# its own. The SONAME is the versioned name so `-llua5.4` records a series-
+# specific dependency and the four series coexist.
+gcc -shared -Wl,-soname,"liblua$ABI.so" -Wl,--build-id=none \
+  -o "liblua$ABI.so" src/*.o -lm -ldl
+
+install -D -m 0644 src/liblua.a     "$OUTPUT_DIR/usr/lib/liblua$ABI.a"
+install -D -m 0755 "liblua$ABI.so"  "$OUTPUT_DIR/usr/lib/liblua$ABI.so"
+
+# Headers go under a versioned directory so the series can be installed
+# together without fighting over usr/include/lua.h.
+mkdir -p "$OUTPUT_DIR/usr/include/lua$ABI"
+install -m 0644 src/lua.h src/luaconf.h src/lualib.h src/lauxlib.h \
+  "$OUTPUT_DIR/usr/include/lua$ABI/"
+
+# The C++ wrapper header arrived in 5.2; 5.1 has no lua.hpp to install.
+if [ -f src/lua.hpp ]; then
+  install -m 0644 src/lua.hpp "$OUTPUT_DIR/usr/include/lua$ABI/"
+fi

--- a/packages/lua53/build.ncl
+++ b/packages/lua53/build.ncl
@@ -1,0 +1,82 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+
+# Lua's series is its MINOR component, and the series are separate, mutually
+# incompatible libraries that install side by side -- hence one package per
+# series rather than a single `lua`. 5.1, 5.2 and 5.3 are closed and the
+# versions here are their final releases; only 5.4 still receives them. A bump
+# must stay inside the series: 5.5 is a different library, not an upgrade.
+let version = "5.3.6" in
+let abi = "5.3" in
+{
+  name = "lua53",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/lua-%{version}.tar.gz",
+      sha256 = "fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60",
+      extract = true,
+      strip_prefix = "lua-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include abi,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/liblua%{abi}.so*" } | OutputLib,
+    static = { glob = "usr/lib/liblua%{abi}.a" } | OutputLib,
+    includes = { glob = "usr/include/lua%{abi}/*.h*" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+
+  tests = {
+    link_static =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\n#include <lua%{abi}/lualib.h>\\nint main(void){ lua_State *L = luaL_newstate(); luaL_openlibs(L); int rc = luaL_dostring(L, \"x = 1 + 1\"); lua_close(L); return rc; }\\n' > t.c"],
+          # -l:liblua5.4.a, not -llua5.4: with both in the same directory ld
+          # picks the shared object, which would make this a duplicate of
+          # link_shared and leave the archive -- the artifact odin vendors --
+          # untested.
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.a -lm -ldl && ./t"],
+        ],
+      } | Test,
+
+    # `system:lua5.4` is what Odin's vendor bindings link against off amd64, so
+    # the plain -l name has to resolve to the shared library.
+    link_shared =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          # Deliberately only newstate/close: this has to compile against 5.1
+          # through 5.4, and lua_version arrived in 5.2.
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\nint main(void){ lua_State *L = luaL_newstate(); if (!L) return 1; lua_close(L); return 0; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.so -lm && ./t"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lua53/build.sh
+++ b/packages/lua53/build.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -ex
+
+ABI="$MINIMAL_ARG_ABI"
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+CFLAGS="$MARCH -O2 -pipe -fPIC -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+
+# LUA_USE_POSIX + LUA_USE_DLOPEN is what LUA_USE_LINUX expands to minus
+# readline, which only the standalone interpreter needs -- this package ships
+# the library, so it stays out of the dependency set. `ar -D` for a
+# deterministic archive.
+make -C src liblua.a \
+  CC=gcc \
+  AR="ar -D rc" \
+  MYCFLAGS="$CFLAGS -DLUA_USE_POSIX -DLUA_USE_DLOPEN"
+
+# Upstream ships no shared library and no rule to build one; every distro links
+# its own. The SONAME is the versioned name so `-llua5.4` records a series-
+# specific dependency and the four series coexist.
+gcc -shared -Wl,-soname,"liblua$ABI.so" -Wl,--build-id=none \
+  -o "liblua$ABI.so" src/*.o -lm -ldl
+
+install -D -m 0644 src/liblua.a     "$OUTPUT_DIR/usr/lib/liblua$ABI.a"
+install -D -m 0755 "liblua$ABI.so"  "$OUTPUT_DIR/usr/lib/liblua$ABI.so"
+
+# Headers go under a versioned directory so the series can be installed
+# together without fighting over usr/include/lua.h.
+mkdir -p "$OUTPUT_DIR/usr/include/lua$ABI"
+install -m 0644 src/lua.h src/luaconf.h src/lualib.h src/lauxlib.h \
+  "$OUTPUT_DIR/usr/include/lua$ABI/"
+
+# The C++ wrapper header arrived in 5.2; 5.1 has no lua.hpp to install.
+if [ -f src/lua.hpp ]; then
+  install -m 0644 src/lua.hpp "$OUTPUT_DIR/usr/include/lua$ABI/"
+fi

--- a/packages/lua54/build.ncl
+++ b/packages/lua54/build.ncl
@@ -1,0 +1,82 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+
+# Lua's series is its MINOR component, and the series are separate, mutually
+# incompatible libraries that install side by side -- hence one package per
+# series rather than a single `lua`. 5.1, 5.2 and 5.3 are closed and the
+# versions here are their final releases; only 5.4 still receives them. A bump
+# must stay inside the series: 5.5 is a different library, not an upgrade.
+let version = "5.4.8" in
+let abi = "5.4" in
+{
+  name = "lua54",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "gs://minimal-staging-archives/lua-%{version}.tar.gz",
+      sha256 = "4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae",
+      extract = true,
+      strip_prefix = "lua-%{version}",
+    } | Source,
+    base,
+    make,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include abi,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/liblua%{abi}.so*" } | OutputLib,
+    static = { glob = "usr/lib/liblua%{abi}.a" } | OutputLib,
+    includes = { glob = "usr/include/lua%{abi}/*.h*" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+    } | Attrs,
+
+  tests = {
+    link_static =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\n#include <lua%{abi}/lualib.h>\\nint main(void){ lua_State *L = luaL_newstate(); luaL_openlibs(L); int rc = luaL_dostring(L, \"x = 1 + 1\"); lua_close(L); return rc; }\\n' > t.c"],
+          # -l:liblua5.4.a, not -llua5.4: with both in the same directory ld
+          # picks the shared object, which would make this a duplicate of
+          # link_shared and leave the archive -- the artifact odin vendors --
+          # untested.
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.a -lm -ldl && ./t"],
+        ],
+      } | Test,
+
+    # `system:lua5.4` is what Odin's vendor bindings link against off amd64, so
+    # the plain -l name has to resolve to the shared library.
+    link_shared =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc],
+        cmds = [
+          # Deliberately only newstate/close: this has to compile against 5.1
+          # through 5.4, and lua_version arrived in 5.2.
+          ["/bin/bash", "-c", "printf '#include <lua%{abi}/lua.h>\\n#include <lua%{abi}/lauxlib.h>\\nint main(void){ lua_State *L = luaL_newstate(); if (!L) return 1; lua_close(L); return 0; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -l:liblua%{abi}.so -lm && ./t"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/lua54/build.sh
+++ b/packages/lua54/build.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -ex
+
+ABI="$MINIMAL_ARG_ABI"
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+CFLAGS="$MARCH -O2 -pipe -fPIC -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+
+# LUA_USE_POSIX + LUA_USE_DLOPEN is what LUA_USE_LINUX expands to minus
+# readline, which only the standalone interpreter needs -- this package ships
+# the library, so it stays out of the dependency set. `ar -D` for a
+# deterministic archive.
+make -C src liblua.a \
+  CC=gcc \
+  AR="ar -D rc" \
+  MYCFLAGS="$CFLAGS -DLUA_USE_POSIX -DLUA_USE_DLOPEN"
+
+# Upstream ships no shared library and no rule to build one; every distro links
+# its own. The SONAME is the versioned name so `-llua5.4` records a series-
+# specific dependency and the four series coexist.
+gcc -shared -Wl,-soname,"liblua$ABI.so" -Wl,--build-id=none \
+  -o "liblua$ABI.so" src/*.o -lm -ldl
+
+install -D -m 0644 src/liblua.a     "$OUTPUT_DIR/usr/lib/liblua$ABI.a"
+install -D -m 0755 "liblua$ABI.so"  "$OUTPUT_DIR/usr/lib/liblua$ABI.so"
+
+# Headers go under a versioned directory so the series can be installed
+# together without fighting over usr/include/lua.h.
+mkdir -p "$OUTPUT_DIR/usr/include/lua$ABI"
+install -m 0644 src/lua.h src/luaconf.h src/lualib.h src/lauxlib.h \
+  "$OUTPUT_DIR/usr/include/lua$ABI/"
+
+# The C++ wrapper header arrived in 5.2; 5.1 has no lua.hpp to install.
+if [ -f src/lua.hpp ]; then
+  install -m 0644 src/lua.hpp "$OUTPUT_DIR/usr/include/lua$ABI/"
+fi

--- a/packages/odin/build.ncl
+++ b/packages/odin/build.ncl
@@ -1,0 +1,200 @@
+let { standaloneTest, subsetOf, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let cmake = import "../cmake/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let libglvnd = import "../libglvnd/build.ncl" in
+let libx11 = import "../libx11/build.ncl" in
+let llvm = import "../llvm/build.ncl" in
+let lua51 = import "../lua51/build.ncl" in
+let lua52 = import "../lua52/build.ncl" in
+let lua53 = import "../lua53/build.ncl" in
+let lua54 = import "../lua54/build.ncl" in
+let make = import "../make/build.ncl" in
+let raygui = import "../raygui/build.ncl" in
+let raylib = import "../raylib/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "dev-2026-07a" in
+# Odin stamps its own `ODIN_VERSION` from the month of the release commit.
+# Pinned here so the build does not read the wall clock (see build.sh).
+let version_date = "2026-07" in
+# Matches the version upstream's vendor/box2d/build_box2d.sh pins.
+let box2d_version = "3.1.1" in
+{
+  name = "odin",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/odin-lang/Odin/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "8f4f02fd9a3426b441cd0dfbe0aca1b95fd93c95d86940fcb4417ef6044c83cd",
+      extract = true,
+      strip_prefix = "Odin-%{version}",
+    } | Source,
+    # vendor/box2d carries bindings but no Linux library, and no C source to
+    # build one from -- upstream's build_box2d.sh downloads this same tarball.
+    {
+      url = "https://github.com/erincatto/box2d/archive/refs/tags/v%{box2d_version}.tar.gz",
+      sha256 = "fb6ef914b50f4312d7d921a600eabc12318bb3c55a0b8c0b90608fa4488ef2e4",
+      extract = true,
+    } | Source,
+    base,
+    cmake, # box2d
+    llvm,
+    make, # vendor/{stb,cgltf}/src ship Makefiles we build the bindings' C libs with
+    # vendor/raylib carries bindings and checked-in binaries but no C source at
+    # all, so unlike the other vendor libraries there is nothing to compile in
+    # place -- the libraries come from these packages instead.
+    raygui,
+    raylib,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    # `odin build` shells out to `clang` to link every program it compiles, and
+    # clang in turn needs binutils' `ld` plus gcc's crt objects and libgcc — so
+    # the whole C toolchain is needed wherever odin runs, not just to build it.
+    toolchain,
+    # libllvm: the compiler itself links against the shared libLLVM.
+    # bins/libs_clang: the `clang` driver above, and `ld.lld` for `-linker:lld`.
+    subsetOf llvm ["bins", "libllvm", "libs_clang", "liblld", "libclang"],
+    # vendor:lua links the bundled library only on Linux/amd64; every other
+    # target falls back to `system:lua<ver>`, which needs liblua5.N.so present
+    # wherever odin runs. Runtime rather than build deps so that fallback
+    # resolves -- and since runtime_deps are injected into the build too, this
+    # is also what supplies the libraries copied into the vendor tree on amd64.
+    lua51,
+    lua52,
+    lua53,
+    lua54,
+    # vendor:raylib's bindings declare `system:X11`, and the static libraylib.a
+    # we ship pulls in libGL, so `odin build` on anything importing it needs
+    # both present -- the same reasoning as the lua fallback above. Only the
+    # `libs` output of each: the headers and pkgconfig files are build-time
+    # concerns, and taking libglvnd whole would drag mesa's drivers in behind it
+    # for a linkage that only needs libGL.so.1.
+    subsetOf libglvnd ["libs"],
+    subsetOf libx11 ["libs"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include version_date,
+    include box2d_version,
+  },
+
+  outputs = {
+    # Symlink into the collection tree below: `odin` finds its ODIN_ROOT by
+    # reading /proc/self/exe, which resolves symlinks.
+    odin = { glob = "usr/bin/odin" } | OutputBin,
+    odin_bin = { glob = "usr/lib/odin/odin" } | OutputBin,
+
+    base_collection = { glob = "usr/lib/odin/base/**" } | OutputData,
+    core_collection = { glob = "usr/lib/odin/core/**" } | OutputData,
+    # vendor ships prebuilt static/shared libraries for the bindings it wraps.
+    vendor_collection = { glob = "usr/lib/odin/vendor/**", allow_executable = true } | OutputData,
+    examples = { glob = "usr/lib/odin/examples/**" } | OutputData,
+    license = { glob = "usr/lib/odin/LICENSE" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "BSD-3-Clause",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "odin-lang",
+        repo = "Odin",
+      },
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/odin version",
+
+    compile_run =
+      {
+        class = 'Standalone,
+        test_deps = [base, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf 'package main\\nimport \"core:fmt\"\\nmain :: proc() { fmt.println(\"ok\") }\\n' > hellope.odin"],
+          ["/bin/odin", "run", "hellope.odin", "-file"],
+        ],
+      } | Test,
+
+    # Links against the vendor C libraries this package builds from source.
+    # Upstream ships no Linux build of stb or cgltf, so against upstream's own
+    # tree this fails at compile time with "Could not find the compiled STB
+    # libraries" -- it guards the vendor build, not just the bindings.
+    vendor_link =
+      {
+        class = 'Standalone,
+        test_deps = [base, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf 'package main\\nimport stbi \"vendor:stb/image\"\\nimport \"vendor:cgltf\"\\nimport b3 \"vendor:box3d\"\\nimport b2 \"vendor:box2d\"\\nmain :: proc() {\\n_ = stbi.failure_reason()\\ncgltf.free(nil)\\n_ = b3.GetVersion()\\n_ = b2.GetByteCount()\\n}\\n' > vendor.odin"],
+          ["/bin/odin", "build", "vendor.odin", "-file"],
+        ],
+      } | Test,
+
+    # vendor:raylib is the one binding whose link needs libraries from outside
+    # the vendor tree (system:X11 plus libGL, via the static archive), so it is
+    # the only one that can regress on runtime_deps alone. vendor_link covers
+    # stb/cgltf/box2d/box3d, which link nothing external; without this, dropping
+    # the X11/GL entries above would break every raylib user silently. Links but
+    # does not run -- there is no display in the sandbox.
+    vendor_link_raylib =
+      {
+        class = 'Standalone,
+        test_deps = [base, glibc],
+        cmds = [
+          ["/bin/bash", "-c", "printf 'package main\\nimport rl \"vendor:raylib\"\\nmain :: proc() { _ = rl.GetRandomValue(1, 1) }\\n' > rl.odin"],
+          ["/bin/odin", "build", "rl.odin", "-file"],
+        ],
+      } | Test,
+
+    # Existence checks cannot tell our libraries from upstream's, since both
+    # land at the same paths. This compares the vendor copies byte-for-byte
+    # against what the source-built packages emit, so reintroducing a checked-in
+    # blob fails here instead of shipping.
+    vendor_provenance =
+      {
+        class = 'Standalone,
+        test_deps = [base, lua51, lua52, lua53, lua54, raygui, raylib],
+        cmds = [
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; case $(uname -m) in x86_64) RL=linux;; *) RL=linux-arm64;; esac; cmp $V/raylib/$RL/libraylib.a /usr/lib/libraylib.a; cmp $V/raylib/$RL/libraylib.so.600 /usr/lib/libraylib.so.6.0.0; cmp $V/raylib/linux/libraygui.a /usr/lib/libraygui.a; cmp $V/raylib/linux/libraygui.so /usr/lib/libraygui.so"],
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; cmp $V/raylib/wasm/libraylib.web.a /usr/lib/emscripten/libraylib.web.a; cmp $V/raylib/wasm/libraygui.a /usr/lib/emscripten/libraygui.a"],
+          # lua is bundled on amd64 only; elsewhere the bindings use system:lua.
+          ["/bin/bash", "-c", "set -eu; [ $(uname -m) = x86_64 ] || exit 0; V=$(/bin/odin root)/vendor; for s in 5.1:5.1 5.2:52 5.3:53 5.4:54; do a=${s%:*}; b=${s#*:}; cmp $V/lua/$a/linux/liblua$b.a /usr/lib/liblua$a.a; cmp $V/lua/$a/linux/liblua$b.so /usr/lib/liblua$a.so; done"],
+        ],
+      } | Test,
+
+    # Asserts the shape of the vendor tree: every library we ship is one we built
+    # from source, and every artifact we deliberately drop (Windows, macOS, the
+    # other Linux arch) is gone. Pins the de-blobbing so a future version bump
+    # that reintroduces upstream's prebuilts fails here rather than shipping
+    # silently.
+    vendor_tree =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Native libraries built from the vendored C source.
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; case $(uname -m) in x86_64) A=linux-amd64; B2=box2d_other_amd64_avx2.a;; *) A=linux-arm64; B2=box2d_other.a;; esac; test -f $V/box3d/lib/$A/libbox3d.a; test -f $V/stb/lib/stb_image.a; test -f $V/cgltf/lib/cgltf.a; test -f $V/box2d/lib/$B2"],
+
+          # raylib and raygui, which upstream ships only as binaries.
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; case $(uname -m) in x86_64) RL=linux; test ! -e $V/raylib/linux-arm64;; *) RL=linux-arm64; test ! -e $V/raylib/linux/libraylib.a;; esac; test -f $V/raylib/$RL/libraylib.a; test -f $V/raylib/$RL/libraylib.so.600; test -f $V/raylib/linux/libraygui.a; test -f $V/raylib/linux/libraygui.so"],
+
+          # Every wasm artifact is rebuilt from source as well -- the objects
+          # from plain clang, the two raylib archives through emscripten.
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; test -f $V/box2d/lib/box2d_wasm.o; test -f $V/box2d/lib/box2d_wasm_simd.o; test -f $V/cgltf/lib/cgltf_wasm.o; for o in image image_resize image_write rect_pack sprintf truetype vorbis; do test -f $V/stb/lib/stb_${o}_wasm.o; done; test -f $V/raylib/wasm/libraylib.web.a; test -f $V/raylib/wasm/libraygui.a"],
+
+          # lua only has a bundled library to build on amd64; elsewhere the
+          # bindings fall back to system:lua<ver>.
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; if [ $(uname -m) = x86_64 ]; then test -f $V/lua/5.4/linux/liblua54.a; else test ! -e $V/lua/5.4/linux; fi"],
+
+          # Everything we deliberately drop.
+          ["/bin/bash", "-c", "set -eu; V=$(/bin/odin root)/vendor; case $(uname -m) in x86_64) OTHER=linux-arm64;; *) OTHER=linux-amd64;; esac; test ! -e $V/box3d/lib/$OTHER; test ! -e $V/raylib/macos; test -z \"$(find $V -type d -name darwin)\"; test -z \"$(find $V -type f \\( -name '*.dll' -o -name '*.lib' -o -name '*.exe' -o -name '*.pdb' \\))\""],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/odin/build.sh
+++ b/packages/odin/build.sh
@@ -1,0 +1,196 @@
+#!/bin/sh
+set -ex
+
+BUILD_ROOT="$PWD"
+
+# build_odin.sh bakes ODIN_VERSION into the compiler. Without a .git directory
+# it falls back to `date +%Y-%m`, which reads the wall clock and would make the
+# build non-reproducible; pin it to the month of the release instead. Fail loudly
+# if upstream stops stamping the version this way.
+grep -q 'date +"%Y-%m"' build_odin.sh
+sed -i "s|^\([[:space:]]*\)GIT_DATE=.*|\1GIT_DATE=\"${MINIMAL_ARG_VERSION_DATE}\"|" build_odin.sh
+
+# sed exits 0 whether or not it matched anything, so the grep above only proves
+# the wall-clock fallback still exists -- not that we neutralised it. If upstream
+# renames GIT_DATE while keeping that fallback, the substitution silently does
+# nothing and the build month gets baked into the binary: a non-reproducible
+# package that passes every check until the month rolls over. Assert the pin.
+grep -q "GIT_DATE=\"${MINIMAL_ARG_VERSION_DATE}\"" build_odin.sh
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+export CXX=clang++
+export LLVM_CONFIG=llvm-config
+export CPPFLAGS="-ffile-prefix-map=$(pwd)=/builddir"
+export CXXFLAGS="$MARCH -pipe -gno-record-gcc-switches"
+export LDFLAGS="-Wl,--build-id=none"
+
+# `release` compiles with -O3; `release-native` would add -march=native, which
+# is not reproducible across builders.
+./build_odin.sh release
+
+ODIN_ROOT="$OUTPUT_DIR/usr/lib/odin"
+
+install -D -m 0755 odin "$ODIN_ROOT/odin"
+install -D -m 0644 LICENSE "$ODIN_ROOT/LICENSE"
+cp -r base core vendor examples "$ODIN_ROOT/"
+
+# --- vendor collection ------------------------------------------------------
+# Upstream checks prebuilt libraries into vendor/. Everything we can build from
+# source, we build; everything that cannot run on this platform, we drop. What
+# remains prebuilt is called out explicitly at the bottom of this section.
+VENDOR="$ODIN_ROOT/vendor"
+
+case $(uname -m) in
+  x86_64)  VENDOR_ARCH=linux-amd64; VENDOR_ARCH_OTHER=linux-arm64 ;;
+  aarch64) VENDOR_ARCH=linux-arm64; VENDOR_ARCH_OTHER=linux-amd64 ;;
+  # Without this, VENDOR_ARCH_OTHER would be empty and the rm below would take
+  # out the whole box3d/lib directory rather than one arch's subdirectory.
+  *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Windows artifacts — upstream's own Linux release tarball drops these too
+# (~140MB of .lib/.dll/.exe/.pdb).
+sh ci/remove_windows_binaries.sh "$VENDOR"
+
+# macOS artifacts: this package is Linux-only and cannot produce Mach-O.
+find "$VENDOR" -type d -name darwin -prune -exec rm -rf {} +
+rm -rf "$VENDOR/raylib/macos"
+rm -f "$VENDOR"/box2d/lib/box2d_darwin_*.a
+
+# The other Linux arch: we build per-arch, so it is dead weight.
+rm -rf "$VENDOR/box3d/lib/$VENDOR_ARCH_OTHER"
+
+# Reproducibility: the vendor Makefiles hardcode their own -O flags and never
+# reference $(CFLAGS), so -ffile-prefix-map has to ride in on $(CC). stb and
+# cgltf use assert(), which bakes __FILE__ into the objects without it.
+VENDOR_CC="gcc -ffile-prefix-map=$VENDOR=/builddir"
+
+# box3d, stb and cgltf ship their full C source in-tree, so these need no
+# network access and no dependency beyond the C toolchain we already have.
+# Upstream ships no Linux build of stb or cgltf at all — it expects users to run
+# these same Makefiles by hand — so building them here is net-new coverage.
+(
+  cd "$VENDOR/box3d/src"
+  rm -rf ../lib/linux-*
+  # Upstream's build.sh calls `cc`, which the sandbox does not provide.
+  $VENDOR_CC -c -O2 -std=c17 -fPIC -Iinclude src/*.c
+  mkdir -p "../lib/$VENDOR_ARCH"
+  ar -D rcs "../lib/$VENDOR_ARCH/libbox3d.a" ./*.o
+  rm -f ./*.o
+)
+make -C "$VENDOR/stb/src"   CC="$VENDOR_CC" AR="ar -D" unix
+make -C "$VENDOR/cgltf/src" CC="$VENDOR_CC" AR="ar -D" unix
+
+# box2d ships bindings but no Linux library and no in-tree C source, so its
+# tarball is a Source above rather than something we compile in place. Build it
+# outside the vendor tree so no cmake scratch lands in the package output.
+# On amd64 the bindings pick the AVX2 or SSE2 archive from the target's feature
+# set at compile time, so both have to exist.
+build_box2d() {
+  rm -rf "$BUILD_ROOT/box2d-build"
+  cmake -S "$BUILD_ROOT/box2d-$MINIMAL_ARG_BOX2D_VERSION" -B "$BUILD_ROOT/box2d-build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBOX2D_SAMPLES=OFF -DBOX2D_VALIDATE=OFF -DBOX2D_UNIT_TESTS=OFF \
+    -DCMAKE_C_FLAGS="-ffile-prefix-map=$BUILD_ROOT=/builddir" \
+    -DBOX2D_AVX2="$1"
+  cmake --build "$BUILD_ROOT/box2d-build" -j"$(nproc)"
+  cp "$BUILD_ROOT/box2d-build/src/libbox2d.a" "$VENDOR/box2d/lib/$2"
+}
+case "$VENDOR_ARCH" in
+  linux-amd64)
+    build_box2d ON  box2d_other_amd64_avx2.a
+    build_box2d OFF box2d_other_amd64_sse2.a
+    ;;
+  linux-arm64)
+    build_box2d OFF box2d_other.a
+    ;;
+esac
+rm -rf "$BUILD_ROOT/box2d-build"
+
+# lua: the libraries come from the lua51..lua54 packages. The bindings reach for
+# a bundled library only on amd64 and fall back to `system:lua<ver>` elsewhere,
+# so there is nothing to install for arm64 -- but the checked-in amd64 blobs are
+# still dead weight there, hence the unconditional rm. The vendor filenames are
+# upstream's and are not consistent (liblua5.1 but liblua52), so the series and
+# the suffix are passed separately.
+install_lua() { # $1 = series (5.1), $2 = vendor library suffix (5.1, 52, ...)
+  dest="$VENDOR/lua/$1/linux"
+  mkdir -p "$dest"
+  install -m 0644 "/usr/lib/liblua$1.a"  "$dest/liblua$2.a"
+  install -m 0755 "/usr/lib/liblua$1.so" "$dest/liblua$2.so"
+}
+rm -rf "$VENDOR"/lua/*/linux
+if [ "$VENDOR_ARCH" = linux-amd64 ]; then
+  install_lua 5.1 5.1
+  install_lua 5.2 52
+  install_lua 5.3 53
+  install_lua 5.4 54
+fi
+
+# raylib and raygui are the one part of vendor/ with no C source in-tree at all
+# -- upstream checks in binaries only. Drop every one of them and install the
+# libraries the `raylib` and `raygui` packages built from source.
+rm -rf "$VENDOR"/raylib/linux "$VENDOR"/raylib/linux-arm64
+
+case "$VENDOR_ARCH" in
+  linux-amd64) RAYLIB_DIR="$VENDOR/raylib/linux" ;;
+  linux-arm64) RAYLIB_DIR="$VENDOR/raylib/linux-arm64" ;;
+esac
+mkdir -p "$RAYLIB_DIR"
+install -m 0644 /usr/lib/libraylib.a         "$RAYLIB_DIR/libraylib.a"
+install -m 0755 /usr/lib/libraylib.so.6.0.0  "$RAYLIB_DIR/libraylib.so.600"
+
+# The arm64 static path in the bindings points at a linux-arm/ directory that
+# has never existed -- the shared path two lines below it says linux-arm64. Fix
+# it so the static library above is actually linkable, and fail loudly if a
+# version bump fixes it upstream and makes this sed a silent no-op.
+if [ "$VENDOR_ARCH" = linux-arm64 ]; then
+  grep -q '"linux-arm/libraylib.a"' "$VENDOR/raylib/raylib.odin"
+  sed -i 's|"linux-arm/libraylib.a"|"linux-arm64/libraylib.a"|' "$VENDOR/raylib/raylib.odin"
+fi
+
+# raygui's bindings look in linux/ on every arch, so it does not follow the
+# per-arch layout raylib uses.
+mkdir -p "$VENDOR/raylib/linux"
+install -m 0644 /usr/lib/libraygui.a  "$VENDOR/raylib/linux/libraygui.a"
+install -m 0755 /usr/lib/libraygui.so "$VENDOR/raylib/linux/libraygui.so"
+
+# The wasm archives upstream ships are emscripten output; ours come from the
+# same source through the emscripten package.
+rm -rf "$VENDOR/raylib/wasm"
+mkdir -p "$VENDOR/raylib/wasm"
+install -m 0644 /usr/lib/emscripten/libraylib.web.a "$VENDOR/raylib/wasm/libraylib.web.a"
+install -m 0644 /usr/lib/emscripten/libraygui.a     "$VENDOR/raylib/wasm/libraygui.a"
+
+# --- wasm objects -----------------------------------------------------------
+# Upstream checks in prebuilt .o files for the wasm targets too. stb, cgltf and
+# box2d all build theirs with plain clang -- box2d's wasm.Makefile says outright
+# that it only pretends to be emscripten -- so these are rebuilt from source.
+# The vendor Makefiles locate their sysroot with `odin root`; putting the
+# compiler we just built on PATH resolves that to the source tree, whose
+# libc-shim is the same one we install.
+export PATH="$BUILD_ROOT:$PATH"
+WASM_CC="clang -ffile-prefix-map=$BUILD_ROOT=/builddir -ffile-prefix-map=$VENDOR=/builddir"
+
+rm -f "$VENDOR"/stb/lib/*_wasm.o "$VENDOR"/cgltf/lib/cgltf_wasm.o
+make -C "$VENDOR/stb/src"   CC="$WASM_CC" wasm
+make -C "$VENDOR/cgltf/src" CC="$WASM_CC" wasm
+
+# box2d's wasm.Makefile expects to run beside an unpacked box2d source tree and
+# writes into ./lib, so it runs out of the build root rather than the vendor dir.
+rm -f "$VENDOR"/box2d/lib/box2d_wasm.o "$VENDOR"/box2d/lib/box2d_wasm_simd.o
+mkdir -p "$BUILD_ROOT/lib"
+make -C "$BUILD_ROOT" -f "$VENDOR/box2d/wasm.Makefile" \
+  VERSION="$MINIMAL_ARG_BOX2D_VERSION" CC="$WASM_CC" LD=wasm-ld
+cp "$BUILD_ROOT/lib/box2d_wasm.o" "$BUILD_ROOT/lib/box2d_wasm_simd.o" "$VENDOR/box2d/lib/"
+rm -rf "$BUILD_ROOT/lib"
+
+# odin resolves ODIN_ROOT from /proc/self/exe, which follows symlinks, so this
+# lands it on the collection tree installed above.
+mkdir -p "$OUTPUT_DIR/usr/bin"
+ln -s ../lib/odin/odin "$OUTPUT_DIR/usr/bin/odin"

--- a/packages/raygui/build.ncl
+++ b/packages/raygui/build.ncl
@@ -1,0 +1,71 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let emscripten = import "../emscripten/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+let libglvnd = import "../libglvnd/build.ncl" in
+let libx11 = import "../libx11/build.ncl" in
+let raylib = import "../raylib/build.ncl" in
+
+let version = "4.0" in
+{
+  name = "raygui",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/raysan5/raygui/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "299c8fcabda68309a60dc858741b76c32d7d0fc533cdc2539a55988cee236812",
+      extract = true,
+      strip_prefix = "raygui-%{version}",
+    } | Source,
+    base,
+    emscripten, # wasm32 build of the same header, for vendor:raylib on wasm
+    toolchain,
+  ],
+
+  # raygui is a single header compiled against raylib's; every consumer links
+  # both, so raylib rides along wherever raygui goes.
+  runtime_deps = [
+    glibc,
+    raylib,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/libraygui.so*" } | OutputLib,
+    static = { glob = "usr/lib/libraygui.a" } | OutputLib,
+    web = { glob = "usr/lib/emscripten/libraygui.a" } | OutputLib,
+    includes = { glob = "usr/include/raygui.h" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Zlib",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "raysan5",
+        repo = "raygui",
+      },
+    } | Attrs,
+
+  tests = {
+    # Links rather than runs -- raygui's entry points need a GL context, and
+    # there is no display in the sandbox.
+    link_static =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc, libglvnd, libx11, raylib],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <raylib.h>\\n#include <raygui.h>\\nint main(void){ return GuiGetStyle(DEFAULT, TEXT_SIZE) >= 0 ? 0 : 1; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -lraygui -lraylib -lGL -lX11 -lm -lpthread -ldl -lrt && ./t"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/raygui/build.sh
+++ b/packages/raygui/build.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -ex
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+CFLAGS="$MARCH -O2 -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+LDFLAGS="-Wl,--build-id=none"
+
+# raygui ships as a single header; the library is that header compiled once with
+# RAYGUI_IMPLEMENTATION. -x c because the file is named .h.
+gcc -c -x c src/raygui.h -o raygui.o -DRAYGUI_IMPLEMENTATION -fPIC $CFLAGS
+
+mkdir -p "$OUTPUT_DIR/usr/lib" "$OUTPUT_DIR/usr/include"
+
+ar -D rcs "$OUTPUT_DIR/usr/lib/libraygui.a" raygui.o
+
+# raygui has no versioned-soname convention upstream, so the SONAME matches the
+# plain filename the Odin bindings and everyone else link against.
+gcc -shared -Wl,-soname,libraygui.so -o "$OUTPUT_DIR/usr/lib/libraygui.so" \
+  raygui.o $LDFLAGS -lraylib -lm
+
+install -m 0644 src/raygui.h "$OUTPUT_DIR/usr/include/raygui.h"
+
+# --- wasm -------------------------------------------------------------------
+# Same single header, compiled for wasm32 against raylib's headers. emcc wants a
+# writable cache even when every entry is present, and the installed one is
+# read-only.
+export EM_CACHE="$(pwd)/.emcache"
+cp -r /usr/share/emscripten/cache "$EM_CACHE"
+
+# emcc searches emscripten's own sysroot, not /usr/include, so raylib.h has to
+# be put where raygui.h's quoted include will find it -- beside the source.
+# Copying beats -I/usr/include, which would also shadow musl's stdio.h and
+# stdlib.h with the native glibc ones.
+cp /usr/include/raylib.h src/
+
+emcc -c -x c src/raygui.h -o raygui_wasm.o -DRAYGUI_IMPLEMENTATION \
+  -Os -ffile-prefix-map="$(pwd)"=/builddir
+mkdir -p "$OUTPUT_DIR/usr/lib/emscripten"
+emar rcs "$OUTPUT_DIR/usr/lib/emscripten/libraygui.a" raygui_wasm.o
+
+rm -rf "$EM_CACHE"

--- a/packages/raylib/build.ncl
+++ b/packages/raylib/build.ncl
@@ -1,0 +1,104 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let emscripten = import "../emscripten/build.ncl" in
+let make = import "../make/build.ncl" in
+let pkgconf = import "../pkgconf/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let glibc = import "../glibc/build.ncl" in
+let libglvnd = import "../libglvnd/build.ncl" in
+let libx11 = import "../libx11/build.ncl" in
+let libxcursor = import "../libxcursor/build.ncl" in
+let libxext = import "../libxext/build.ncl" in
+let libxfixes = import "../libxfixes/build.ncl" in
+let libxi = import "../libxi/build.ncl" in
+let libxinerama = import "../libxinerama/build.ncl" in
+let libxrandr = import "../libxrandr/build.ncl" in
+let libxrender = import "../libxrender/build.ncl" in
+let xorgproto = import "../xorgproto/build.ncl" in
+
+let version = "6.0" in
+{
+  name = "raylib",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/raysan5/raylib/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "2b3ee1e2120c7a0796b33062c7e9a694dd8a8caa56a96319ac8c8ecf54a90d0b",
+      extract = true,
+      strip_prefix = "raylib-%{version}",
+    } | Source,
+    base,
+    emscripten, # wasm32 build of the same source, for vendor:raylib on wasm
+    make,
+    pkgconf,
+    toolchain,
+    xorgproto,
+  ],
+
+  # raylib bundles every library it needs (GLFW, glad, miniaudio, stb) under
+  # src/external, so the only external surface is X11 and GL. GLFW dlopens the
+  # Xrandr/Xinerama/Xcursor/Xi extensions at runtime but includes their headers
+  # at compile time, so they are needed on both sides.
+  runtime_deps = [
+    glibc,
+    libglvnd,
+    libx11,
+    libxcursor,
+    libxext,
+    libxfixes,
+    libxi,
+    libxinerama,
+    libxrandr,
+    libxrender,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    libs = { glob = "usr/lib/libraylib.so*" } | OutputLib,
+    static = { glob = "usr/lib/libraylib.a" } | OutputLib,
+    web = { glob = "usr/lib/emscripten/libraylib.web.a" } | OutputLib,
+    includes = { glob = "usr/include/*.h" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Zlib",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "raysan5",
+        repo = "raylib",
+      },
+    } | Attrs,
+
+  tests = {
+    # No display in the sandbox, so this links rather than runs: it proves the
+    # static archive and every system library raylib expects resolve.
+    link_static =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc, libglvnd, libx11],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <raylib.h>\\nint main(void){ SetTraceLogLevel(LOG_NONE); return GetRandomValue(1,1) == 1 ? 0 : 1; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -lraylib -lGL -lX11 -lm -lpthread -ldl -lrt"],
+          ["/bin/bash", "-c", "./t"],
+        ],
+      } | Test,
+
+    link_shared =
+      {
+        class = 'Standalone,
+        test_deps = [base, toolchain, glibc, libglvnd, libx11],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#include <raylib.h>\\nint main(void){ return GetRandomValue(1,1) == 1 ? 0 : 1; }\\n' > t.c"],
+          ["/bin/bash", "-c", "gcc t.c -o t -l:libraylib.so.600 -lm && ./t"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/raylib/build.sh
+++ b/packages/raylib/build.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -ex
+
+case $(uname -m) in
+  x86_64)  MARCH="-march=x86-64-v3" ;;
+  aarch64) MARCH="-march=armv8-a" ;;
+  *)       MARCH="" ;;
+esac
+
+# raylib's Makefile owns -O and the platform defines, so determinism flags ride
+# in through its CUSTOM_* hooks rather than CFLAGS/LDFLAGS. rglfw.c uses
+# assert(), which bakes __FILE__ into the objects without -ffile-prefix-map.
+CUSTOM_CFLAGS="$MARCH -pipe -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+
+# PLATFORM_DESKTOP resolves to PLATFORM_DESKTOP_GLFW, the X11 backend the Odin
+# bindings (and every other consumer) expect. `ar -D` for deterministic archives.
+build() { # $1 = STATIC | SHARED, $2 = extra LDFLAGS
+  make -C src clean
+  make -C src -j"$(nproc)" \
+    PLATFORM=PLATFORM_DESKTOP \
+    RAYLIB_LIBTYPE="$1" \
+    RAYLIB_BUILD_MODE=RELEASE \
+    CC=gcc \
+    AR="ar -D" \
+    CUSTOM_CFLAGS="$CUSTOM_CFLAGS" \
+    CUSTOM_LDFLAGS="-Wl,--build-id=none $2"
+}
+
+mkdir -p "$OUTPUT_DIR/usr/lib" "$OUTPUT_DIR/usr/include"
+
+build STATIC
+install -m 0644 src/libraylib.a "$OUTPUT_DIR/usr/lib/libraylib.a"
+
+# Upstream links the shared library without a SONAME, so anything linking
+# -lraylib records a bare "libraylib.so". Set the versioned one instead.
+build SHARED -Wl,-soname,libraylib.so.600
+install -m 0755 src/libraylib.so.6.0.0 "$OUTPUT_DIR/usr/lib/libraylib.so.6.0.0"
+ln -sf libraylib.so.6.0.0 "$OUTPUT_DIR/usr/lib/libraylib.so.600"
+ln -sf libraylib.so.600 "$OUTPUT_DIR/usr/lib/libraylib.so"
+
+install -m 0644 src/raylib.h src/raymath.h src/rlgl.h "$OUTPUT_DIR/usr/include/"
+
+# --- wasm -------------------------------------------------------------------
+# PLATFORM_WEB switches the Makefile to CC=emcc / AR=emar and to the GLES2
+# backend emscripten maps onto WebGL. No -march here: the target is wasm32.
+# emcc wants to write to its cache even when every entry is already present, and
+# the installed cache is read-only, so it gets a writable copy for this build.
+export EM_CACHE="$(pwd)/.emcache"
+cp -r /usr/share/emscripten/cache "$EM_CACHE"
+
+make -C src clean
+make -C src -j"$(nproc)" \
+  PLATFORM=PLATFORM_WEB \
+  RAYLIB_BUILD_MODE=RELEASE \
+  CUSTOM_CFLAGS="-ffile-prefix-map=$(pwd)=/builddir"
+
+install -D -m 0644 src/libraylib.web.a "$OUTPUT_DIR/usr/lib/emscripten/libraylib.web.a"
+
+rm -rf "$EM_CACHE"

--- a/stacks/odin/stack.ncl
+++ b/stacks/odin/stack.ncl
@@ -1,0 +1,30 @@
+let { stack, .. } = import "minimal.ncl" in
+stack {
+  name = "odin",
+  build_packages = ["odin", "base", "glibc", "linux_headers"],
+
+  # `odin build <dir>` treats the directory as a package and compiles every
+  # .odin file in it. Odin's default is -o:minimal; -o:speed is the closer
+  # analogue of what the other compiled-language stacks build by default.
+  build_cmd = "odin build . -o:speed",
+
+  # Odin has no manifest file -- no go.mod, no Cargo.toml, no build.zig -- so a
+  # source tree is identified by the presence of .odin files themselves. ols.json
+  # (Odin Language Server config) is a common but not universal companion.
+  #
+  # `*.odin`, not a regex: despite the field name every other stack writes these
+  # as literal names or globs (cabal's `*.cabal` is not valid regex at all), so
+  # the matching is glob-shaped and `.*\.odin` would match nothing real.
+  matches_project_if_any = [
+    {
+      file_regexes = {
+        "*.odin" = "*",
+      },
+    },
+    {
+      file_regexes = {
+        "ols.json" = "*",
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Adds the `odin` package and stack. Odin can't be packaged on its own: upstream's
`vendor/` tree ships checked-in binaries rather than source — raylib and raygui as
prebuilt `.a`/`.so`, four Lua libraries, and ten prebuilt wasm objects. This builds
all of them from source instead, which is what pulls in the other ten packages.

The result ships **zero binaries it did not build**, enforced by a test rather than
by inspection.

## Changes

- **`odin`** dev-2026-07a — https://github.com/odin-lang/Odin (+ box2d 3.1.1)
- **`raylib`** 6.0, **`raygui`** 4.0 — https://github.com/raysan5/{raylib,raygui};
  static, shared and wasm. Replace upstream's checked-in `vendor/raylib` binaries.
- **`lua51`/`lua52`/`lua53`/`lua54`** 5.1.5 / 5.2.4 / 5.3.6 / 5.4.8 — lua.org.
  One package per minor series: 5.1–5.4 are mutually incompatible libraries that
  install side by side, so a single `lua` cannot express it.
- **`emscripten`** 4.0.11, **`binaryen`** version_124 — needed to build
  `libraylib.web.a` and the wasm `libraygui.a` from source. emscripten is pinned to
  the last release whose `EXPECTED_LLVM_VERSION` is 21, matching our `llvm`.
- **`libxinerama`** 1.1.6, **`libxcursor`** 1.2.3 — x.org; the two X.Org headers
  GLFW needs that weren't packaged yet.
- **`stacks/odin`** — `odin build . -o:speed`, matches on `*.odin` / `ols.json`.
- `AGENTS.md` — adds odin to the stack list.

All six non-GitHub sources are mirrored to `gs://minimal-staging-archives/`.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [x] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

**Where to focus.** `packages/odin/build.sh` is the substantive file — it de-blobs
the vendor tree and installs the source-built replacements. `vendor_provenance`
`cmp`s every vendored library byte-for-byte against the producing package's output,
so a reintroduced blob fails the tests rather than shipping quietly.

**Upstream bug fixed.** `vendor/raylib/raylib.odin`'s arm64 static path names a
`linux-arm/` directory that has never existed (the shared path beside it says
`linux-arm64`), so static raylib linking was simply broken on arm64. The build
patches it, guarded by a `grep` that fails loudly if upstream fixes it first.

**Only aarch64 was verified locally.** The amd64 paths — raylib/raygui in `linux/`,
box2d's AVX2 *and* SSE2 archives, the four Lua installs — run for the first time in
CI here. No local cross-arch build exists (`patched-build` has no `--arch`) and
emulation isn't available, so CI on `ubuntu-latest` is the check.

**Known limitations.**
- `emscripten` ships without its JS optimizer: `npm ci` is stubbed out to keep ~110
  unmirrored registry packages out of the build, so `emcc -o foo.js -O2` and
  `--closure` fail. Compile-and-archive — all the wasm libraries need — is
  unaffected. Documented in `packages/emscripten/build.ncl`.
- `embuilder build SYSTEM` rather than `ALL`, which drops ~26 optional ports and
  their downloads from 7 hosts. A consumer wanting `-sUSE_SDL=2` sets `EM_CACHE`;
  the wrappers already seed a writable per-user copy.
- `lua54` is 5.4.8, not the 5.4.2 upstream Odin's README documents — ABI-compatible
  within 5.4, and the old pin only existed to byte-match blobs we no longer ship.

**Reproducibility.** `lua54`, `raylib`, `binaryen`, `emscripten` and `odin` were each
built twice and confirmed byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Odin stack support, including project detection and optimized builds.
  - Added Odin compiler packaging with collections, examples, vendor libraries, and WebAssembly support.
  - Added Binaryen and Emscripten packages for WebAssembly development.
  - Added Lua 5.1–5.4 packages with static and shared libraries.
  - Added raylib and raygui packages with native, WebAssembly, and development outputs.
  - Added libxcursor and libxinerama packages.
  - Updated the documented stack list to include Odin.
- **Tests**
  - Added validation for compilation, linking, execution, and WebAssembly workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->