### PR TITLE
gitleaks, act, dive: ship shell completions (cobra backfill)

### DIFF
--- a/packages/act/build.ncl
+++ b/packages/act/build.ncl
@@ -1,6 +1,6 @@
 # Imported from Wolfi `act` by `pkgmgr import-wolfi` (go build),
 # with outputs + runtime_deps refined from a verified `minimal package` build.
-let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
@@ -31,6 +31,9 @@ let version = "0.2.89" in
   },
   outputs = {
     act = { glob = "usr/bin/act" } | OutputBin,
+    bash_completion = { glob = "usr/share/bash-completion/completions/act" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_act" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/act.fish" } | OutputData,
   },
   runtime_deps = [glibc],
   attrs =

--- a/packages/act/build.sh
+++ b/packages/act/build.sh
@@ -7,3 +7,17 @@ export GOROOT=/usr/go
 go build -trimpath -ldflags "-buildid= -w -s -X main.version=${MINIMAL_ARG_VERSION}" -o act .
 mkdir -p "$OUTPUT_DIR/usr/bin"
 install -m 755 act "$OUTPUT_DIR/usr/bin/act"
+
+# Shell completions (cobra), generated from the built binary. Best-effort:
+# written only on success and non-empty output, so nothing ships if the command
+# is absent. `|| return 0` never breaks the build. (Backfill of the automatic
+# importer behaviour — pkgmgr-rs#745.)
+gen_completion() {
+  _out=$("$OUTPUT_DIR/usr/bin/act" completion "$1" 2>/dev/null) || return 0
+  [ -n "$_out" ] || return 0
+  install -d "$OUTPUT_DIR/$(dirname "$2")"
+  printf '%s\n' "$_out" > "$OUTPUT_DIR/$2"
+}
+gen_completion bash usr/share/bash-completion/completions/act
+gen_completion zsh  usr/share/zsh/site-functions/_act
+gen_completion fish usr/share/fish/vendor_completions.d/act.fish

--- a/packages/dive/build.ncl
+++ b/packages/dive/build.ncl
@@ -1,6 +1,6 @@
 # Imported from Wolfi `dive` by `pkgmgr import-wolfi` (go build),
 # with outputs + runtime_deps refined from a verified `minimal package` build.
-let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
@@ -31,6 +31,9 @@ let version = "0.13.1" in
   },
   outputs = {
     dive = { glob = "usr/bin/dive" } | OutputBin,
+    bash_completion = { glob = "usr/share/bash-completion/completions/dive" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_dive" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/dive.fish" } | OutputData,
   },
   runtime_deps = [glibc],
   attrs =

--- a/packages/dive/build.sh
+++ b/packages/dive/build.sh
@@ -4,3 +4,17 @@ set -eu
 export GOROOT=/usr/go
 mkdir -p "$OUTPUT_DIR/usr/bin"
 go build -trimpath -ldflags "-buildid= -w -s -X main.version=v${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/dive" .
+
+# Shell completions (cobra), generated from the built binary. Best-effort:
+# written only on success and non-empty output, so nothing ships if the command
+# is absent. `|| return 0` never breaks the build. (Backfill of the automatic
+# importer behaviour — pkgmgr-rs#745.)
+gen_completion() {
+  _out=$("$OUTPUT_DIR/usr/bin/dive" completion "$1" 2>/dev/null) || return 0
+  [ -n "$_out" ] || return 0
+  install -d "$OUTPUT_DIR/$(dirname "$2")"
+  printf '%s\n' "$_out" > "$OUTPUT_DIR/$2"
+}
+gen_completion bash usr/share/bash-completion/completions/dive
+gen_completion zsh  usr/share/zsh/site-functions/_dive
+gen_completion fish usr/share/fish/vendor_completions.d/dive.fish

--- a/packages/gitleaks/build.ncl
+++ b/packages/gitleaks/build.ncl
@@ -1,6 +1,6 @@
 # Imported from Wolfi `gitleaks` by `pkgmgr import-wolfi` (go build),
 # with outputs + runtime_deps refined from a verified `minimal package` build.
-let { Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let go = import "../go/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
@@ -31,6 +31,9 @@ let version = "8.30.1" in
   },
   outputs = {
     gitleaks = { glob = "usr/bin/gitleaks" } | OutputBin,
+    bash_completion = { glob = "usr/share/bash-completion/completions/gitleaks" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_gitleaks" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/gitleaks.fish" } | OutputData,
   },
   runtime_deps = [glibc],
   attrs =

--- a/packages/gitleaks/build.sh
+++ b/packages/gitleaks/build.sh
@@ -7,3 +7,20 @@ mkdir -p "$OUTPUT_DIR/usr/bin"
 # original `zricethezav` org (per upstream .goreleaser.yml) despite the GitHub
 # org rename to gitleaks/gitleaks — a wrong path is silently ignored by the linker.
 go build -trimpath -ldflags "-buildid= -w -s -X github.com/zricethezav/gitleaks/v8/version.Version=${MINIMAL_ARG_VERSION}" -o "$OUTPUT_DIR/usr/bin/gitleaks" .
+
+# Shell completions, generated from the just-built binary via cobra's standard
+# `completion <shell>` command. Best-effort: a file is written only when the
+# command succeeds AND its output is non-empty, so a tool that lacks the command
+# ships nothing rather than an empty (glob-matching, useless) file. Cobra's
+# completion output is generated from the command tree — deterministic, no
+# network or config — and the sandbox runs the binary on its native arch.
+gen_completion() {
+  # $1 = shell, $2 = dest path under $OUTPUT_DIR
+  _out=$("$OUTPUT_DIR/usr/bin/gitleaks" completion "$1" 2>/dev/null) || return 0
+  [ -n "$_out" ] || return 0
+  install -d "$OUTPUT_DIR/$(dirname "$2")"
+  printf '%s\n' "$_out" > "$OUTPUT_DIR/$2"
+}
+gen_completion bash usr/share/bash-completion/completions/gitleaks
+gen_completion zsh  usr/share/zsh/site-functions/_gitleaks
+gen_completion fish usr/share/fish/vendor_completions.d/gitleaks.fish


### PR DESCRIPTION
## Backfill: three pkgmgr-imported cobra CLIs that shipped no completions

gitleaks, act, and dive each ship a single binary and nothing else, despite being cobra tools that generate bash/zsh/fish completions for free. This adds them, backfilling the automatic importer behaviour in gominimal/minimal-supply-chain… (pkgmgr-rs#745).

Each `build.sh` generates completions from the built binary via `<bin> completion <shell>` (best-effort — writes only on success + non-empty output); each `build.ncl` captures the three files.

## Verified in a real build, not just a check

Built and **materialized in a min session** — all three produce all three shells:

| package | bash | zsh | fish |
|---|---|---|---|
| gitleaks | 426 | 212 | 235 |
| act | 426 | 212 | 235 |
| dive | 426 | 212 | 235 |

(Identical counts are cobra's fixed template with the tool name substituted.) `min check` passes for all three — `output types valid` confirms the globs matched real files.

The globs are safe to hard-code here because these three are *proven* to generate. A build **fails** on a glob matching no files — which is how the sibling **restic** was excluded: it depends on cobra but ships `restic generate --bash-completion` instead of a `completion` command, so it generates nothing via the block. (The importer PR handles that general case by leaving glob emission to `--from-build` refinement.)

Non-cobra pkgmgr tools (sops, croc, lazydocker, mkcert, lazygit) are untouched — their generators vary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
