### PR TITLE
fx: add the vercel-labs/fx coding-agent harness (0.0.3)

### DIFF
--- a/packages/fx/build.ncl
+++ b/packages/fx/build.ncl
@@ -1,0 +1,62 @@
+let { Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let zig = import "../zig/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# fx — vercel-labs/fx, an experimental AI coding-agent harness written in Zig
+# (Apache-2.0). Source build via our zig toolchain, mirroring the opencode
+# harness. build.zig.zon declares NO dependencies and `minimum_zig_version =
+# "0.16.0"` (exactly our zig), so `zig build` is fully hermetic — no network,
+# and `readGitCommit` falls back to "unknown" without a .git dir.
+let version = "0.0.3" in
+{
+  name = "fx",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/vercel-labs/fx/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "eb0f9b8877db2764c083e0620b1f0fb60a90345367bc8a6fe81af3682facd337",
+      extract = true,
+      strip_prefix = "fx-%{version}",
+    } | Source,
+    base,
+    zig,
+  ],
+
+  runtime_deps = [
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    fx = { glob = "usr/bin/fx" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "Apache-2.0",
+      build_cost_multiple = 2,
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "vercel-labs",
+        repo = "fx",
+      },
+    } | Attrs,
+
+  tests = {
+    version =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # Proves the binary runs and the embedded app_version (read from
+          # src/main.zig at build time) is the release we packaged. Offline —
+          # help needs no gateway / API key. fx has no `version` subcommand; the
+          # banner rides the help output.
+          ["/bin/bash", "-c", "fx --help 2>&1 | grep -q 'v0.0.3'"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/fx/build.sh
+++ b/packages/fx/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# fx (0.0.3, Zig) — vercel-labs/fx AI coding-agent harness.
+set -eu
+
+# Keep zig's caches inside the build tree: hermetic (no $HOME dependency) and
+# reproducible. build.zig.zon has no dependencies, so nothing is fetched.
+export ZIG_GLOBAL_CACHE_DIR="$(pwd)/.zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="$(pwd)/.zig-cache"
+
+# Pin the glibc target to 2.43: zig 0.16 bundles glibc stubs only through 2.43,
+# so a bare `native` target against our glibc 2.44 fails ("cannot build new glibc
+# version 2.44.0"). A binary built against 2.43 is forward-compatible with the
+# 2.44 we ship at runtime (glibc keeps old symbol versions). fx's build.zig uses
+# standardTargetOptions, so -Dtarget flows through to the linked exe.
+case "$(uname -m)" in
+  x86_64)  ZTARGET="x86_64-linux-gnu.2.43" ;;
+  aarch64) ZTARGET="aarch64-linux-gnu.2.43" ;;
+  *)       echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# app_version is read from src/main.zig; git_commit falls back to "unknown"
+# without a .git dir (readGitCommit uses runAllowFail). ReleaseSafe is upstream's
+# documented release build.
+zig build -Doptimize=ReleaseSafe -Dtarget="$ZTARGET"
+
+install -Dm755 zig-out/bin/fx "$OUTPUT_DIR/usr/bin/fx"


### PR DESCRIPTION
**fx** — vercel-labs/fx, an experimental model-agnostic AI coding agent written in Zig (Apache-2.0). Founder request; packaged like our other agent harnesses (opencode) — a real **source build**, not a prebuilt vendor binary.

## Build
Source build via our **zig 0.16.0** toolchain. fx declares `minimum_zig_version = "0.16.0"` (exactly ours) and **no dependencies**, so `zig build` is fully hermetic — no network, and `readGitCommit` degrades to `"unknown"` without `.git` (app_version reads from `src/main.zig`, so the release version still embeds).

Two gotchas handled:
- **glibc**: zig 0.16 bundles glibc stubs only through 2.43; a bare `native` target against our glibc 2.44 fails. Pinned `-Dtarget=<arch>-linux-gnu.2.43` — a 2.43-linked binary is forward-compatible with the 2.44 runtime.
- zig caches pinned inside the build tree (hermetic, no `$HOME` dep).

## Verified in a session
Built + checked, including a smoke test: `fx --help` reports `v0.0.3` (binary runs, version embedded), **15/15 checks pass**, `missing runtime_deps` confirms the ELF links only glibc.

## Follow-up (not blocking)
State persistence via `env_dir_mappings` for fx's `~/.fx` dir (skills, config, usage log) like opencode maps `~/.local/share/opencode` — deferred because a `~/.fx` mapping tripped a `~`-resolution error in the materialize path. The binary works without it; fx creates `~/.fx` itself at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `fx` command-line package, version 0.0.3.
  * Provides architecture-specific builds with verified source retrieval.
  * Makes the `fx` executable available at `/usr/bin/fx`.
  * Added an offline validation check confirming the installed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->