### PR TITLE
util-linux: drop setuid on mount/umount (defense-in-depth, low practical severity)

### DIFF
--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -32,6 +32,7 @@ export CXXFLAGS="${CFLAGS}"
             ADJTIME_PATH=/var/lib/hwclock/adjtime \
             --docdir=/usr/share/doc/util-linux    \
             --disable-makeinstall-chown \
+            --disable-makeinstall-setuid \
             --disable-use-tty-group     \
 
 make -j$(nproc)


### PR DESCRIPTION
## What this does

`build.sh` passes `--disable-makeinstall-chown` but not `--disable-makeinstall-setuid`, so `make install` does `chmod 4755` on mount/umount and we ship them **setuid root**. This adds `--disable-makeinstall-setuid` so they install as `755`.

## Severity — low in our model, and this is defense-in-depth, not a live-exploit fix

Two scanner-flagged CVEs sit behind the setuid bit:

| CVE | | |
|---|---|---|
| CVE-2026-53614 | HIGH | LPE via `LIBMOUNT_FORCE_MOUNT2` — nosuid/noexec bypass in **SUID** mount(8) |
| CVE-2026-53613 | HIGH | LPE via TOCTOU target-path redirection in mount(8) |

Both are **local privilege escalations** — they require an *unprivileged user* to invoke setuid mount and escalate to root. **Our images run as root by default, so in the common case there is no unprivileged principal to trigger them** — the setuid bit is a no-op for a root caller (the mount battery below confirms every operation behaves identically with it removed). So the scanner's "2 HIGH" reflects a multi-user threat model that doesn't match root-by-default; the *practical* exposure is low.

**Why still do it:** it's free defense-in-depth. Non-root containers are a security best practice, and if any image is ever run as non-root (or grows an unprivileged process), the setuid bit is a genuine escalation path. Removing it eliminates that surface at **zero functional cost** for the root case, and there's no upstream fix to wait for (2.42.2 is latest, `patched_versions` empty). It's a cleaner, permanent version of a VEX `not_affected` — the vulnerable SUID path simply no longer exists.

## Verified in a session (24/26 mount workloads pass)

Built with the flag, mount/umount install as `755 -rwxr-xr-x` (was `4755`), `mount --version` runs, and a ~20-operation battery passes: tmpfs, bind (dir + file), read-only, `nosuid,noexec,nodev`, mount propagation, recursive bind + `umount -R`, `mount --move`, overlayfs, devpts, `X-mount.mkdir`, `mount -a`, `umount -l`, remount rw↔ro, rootless `unshare -rm`. The 2 that fail (proc, sysfs) fail on a rootless-userns kernel limit identical with or without setuid — which *is* the point: these run as root, and the setuid bit does nothing for a root caller.

## Context

Most distros keep mount setuid (Alpine, Wolfi, Debian, Fedora — verified for Alpine/Wolfi). Dropping it is a hardening choice appropriate for a container/microVM base OS, not the mainstream default. Only 4 packages depend on util-linux, so the rebuild cascade is small; any *build-time* reliance on mount would surface on buildbot.
