### PR TITLE
wget: backport the 4 CVEs fixed upstream after 1.25.0

### DIFF
--- a/packages/wget/CVE-2026-58469.patch
+++ b/packages/wget/CVE-2026-58469.patch
@@ -1,0 +1,50 @@
+From 37a40fcb450153f69537c7cbc2a7a4fb0b6f7826 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Mon, 29 Jun 2026 18:32:02 +0200
+Subject: [PATCH] * src/metalink.c (clean_metalink_string): Fix buffer
+ underflow
+
+Reported-by: TristanInSec@gmail.com
+---
+ src/metalink.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/src/metalink.c b/src/metalink.c
+index 9e355fd0..3acdc3a2 100644
+--- a/src/metalink.c
++++ b/src/metalink.c
+@@ -1041,7 +1041,6 @@ void
+ clean_metalink_string (char **str)
+ {
+   int c;
+-  size_t len;
+   char *new, *beg, *end;
+ 
+   if (!str || !*str)
+@@ -1049,7 +1048,7 @@ clean_metalink_string (char **str)
+ 
+   beg = *str;
+ 
+-  while ((c = *beg) && (c == '\n' || c == '\r' || c == '\t' || c == ' '))
++  while (isspace(*beg))
+     beg++;
+ 
+   end = beg;
+@@ -1062,12 +1061,10 @@ clean_metalink_string (char **str)
+   /* If we are at the end of the string, search the first legit
+      character going backward.  */
+   if (*end == '\0')
+-    while ((c = *(end - 1)) && (c == '\n' || c == '\r' || c == '\t' || c == ' '))
++    while (end > beg && !isspace(*(end - 1)))
+       end--;
+ 
+-  len = end - beg;
+-
+-  new = xmemdup0 (beg, len);
++  new = xmemdup0 (beg, end - beg);
+   xfree (*str);
+   *str = new;
+ }
+-- 
+GitLab
+

--- a/packages/wget/CVE-2026-58470.patch
+++ b/packages/wget/CVE-2026-58470.patch
@@ -1,0 +1,76 @@
+From 43d3ba9336bc94937e6fae2365c6ffd30c34ffcf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Mon, 29 Jun 2026 18:57:54 +0200
+Subject: [PATCH] * src/http.c (parse_content_range): Fix integer overflow
+
+Reported-by: TristanInSec@gmail.com
+---
+ src/http.c | 35 ++++++++++++++++++++++++-----------
+ 1 file changed, 24 insertions(+), 11 deletions(-)
+
+diff --git a/src/http.c b/src/http.c
+index 61d83df1..f447c7f7 100644
+--- a/src/http.c
++++ b/src/http.c
+@@ -914,6 +914,7 @@ parse_content_range (const char *hdr, wgint *first_byte_ptr,
+                      wgint *last_byte_ptr, wgint *entity_length_ptr)
+ {
+   wgint num;
++  char *end;
+ 
+   /* Ancient versions of Netscape proxy server, presumably predating
+      rfc2068, sent out `Content-Range' without the "bytes"
+@@ -932,27 +933,39 @@ parse_content_range (const char *hdr, wgint *first_byte_ptr,
+     }
+   if (!c_isdigit (*hdr))
+     return false;
+-  for (num = 0; c_isdigit (*hdr); hdr++)
+-    num = 10 * num + (*hdr - '0');
+-  if (*hdr != '-' || !c_isdigit (*(hdr + 1)))
++
++  errno = 0;
++  num = strtol(hdr, &end, 10);
++  if (errno == ERANGE)
++    return false;
++  hdr = end;
++
++  if (*hdr++ != '-' || !c_isdigit (*hdr))
+     return false;
+   *first_byte_ptr = num;
+-  ++hdr;
+-  for (num = 0; c_isdigit (*hdr); hdr++)
+-    num = 10 * num + (*hdr - '0');
+-  if (*hdr != '/')
++
++  errno = 0;
++  num = strtol(hdr, &end, 10);
++  if (errno == ERANGE)
++    return false;
++  hdr = end;
++
++  if (*hdr++ != '/')
+     return false;
+   *last_byte_ptr = num;
+-  if (!(c_isdigit (*(hdr + 1)) || *(hdr + 1) == '*'))
++  if (!(c_isdigit (*hdr) || *hdr == '*'))
+     return false;
+   if (*last_byte_ptr < *first_byte_ptr)
+     return false;
+-  ++hdr;
+   if (*hdr == '*')
+     num = -1;
+   else
+-    for (num = 0; c_isdigit (*hdr); hdr++)
+-      num = 10 * num + (*hdr - '0');
++    {
++      errno = 0;
++      num = strtol(hdr, NULL, 10);
++      if (errno == ERANGE)
++        return false;
++    }
+   *entity_length_ptr = num;
+   if ((*entity_length_ptr <= *last_byte_ptr) && *entity_length_ptr != -1)
+     return false;
+-- 
+GitLab
+

--- a/packages/wget/CVE-2026-58471.patch
+++ b/packages/wget/CVE-2026-58471.patch
@@ -1,0 +1,68 @@
+From c2640fe5171c59f87c58dc9fcb195b2d18b010ee Mon Sep 17 00:00:00 2001
+From: Arkadi Vainbrand <arkadva8@gmail.com>
+Date: Tue, 13 Jan 2026 12:22:04 +0200
+Subject: [PATCH] Fix buffer size handling in filename conversion
+
+* src/url.c (convert_fname): Fix buffer overflow.
+
+Copyright-paperwork-exempt: Yes
+Signed-off-by: Arkadi Vainbrand <arkadva8@gmail.com>
+---
+ src/url.c | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/src/url.c b/src/url.c
+index 7540e90f..f334456c 100644
+--- a/src/url.c
++++ b/src/url.c
+@@ -1614,7 +1614,7 @@ convert_fname (char *fname)
+   const char *from_encoding = opt.encoding_remote;
+   const char *to_encoding = opt.locale;
+   iconv_t cd;
+-  size_t len, done, inlen, outlen;
++  size_t len, inlen, outlen;
+   char *s;
+   const char *orig_fname;
+ 
+@@ -1636,7 +1636,6 @@ convert_fname (char *fname)
+   inlen = strlen (fname);
+   len = outlen = inlen * 2;
+   converted_fname = s = xmalloc (outlen + 1);
+-  done = 0;
+ 
+   for (;;)
+     {
+@@ -1644,7 +1643,7 @@ convert_fname (char *fname)
+       if (iconv (cd, (ICONV_CONST char **) &fname, &inlen, &s, &outlen) == 0
+           && iconv (cd, NULL, NULL, &s, &outlen) == 0)
+         {
+-          *(converted_fname + len - outlen - done) = '\0';
++          *s = '\0';
+           iconv_close (cd);
+           DEBUGP (("Converted file name '%s' (%s) -> '%s' (%s)\n",
+                    orig_fname, from_encoding, converted_fname, to_encoding));
+@@ -1667,10 +1666,17 @@ convert_fname (char *fname)
+         }
+       else if (errno == E2BIG) /* Output buffer full */
+         {
+-          done = len;
+-          len = outlen = done + inlen * 2;
+-          converted_fname = xrealloc (converted_fname, outlen + 1);
+-          s = converted_fname + done;
++          size_t used = s - converted_fname;
++          size_t newlen = used + inlen * 2 + 1;
++
++          /* Ensure we actually grow the buffer */
++          if (newlen <= len)
++            newlen = len * 2;
++
++          converted_fname = xrealloc (converted_fname, newlen + 1);
++          len = newlen;
++          s = converted_fname + used;
++          outlen = len - used;
+         }
+       else /* Weird, we got an unspecified error */
+         {
+-- 
+GitLab
+

--- a/packages/wget/CVE-2026-58472.patch
+++ b/packages/wget/CVE-2026-58472.patch
@@ -1,0 +1,71 @@
+From dd692d9cea5335b181d877ae917fe6e75587a812 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Mon, 29 Jun 2026 19:13:15 +0200
+Subject: [PATCH] * src/convert.c (html_quote_string): Fix integer+buffer
+ overflow
+
+Reported-by: TristanInSec@gmail.com
+---
+ src/convert.c | 31 ++++++++++++++++++++++++-------
+ 1 file changed, 24 insertions(+), 7 deletions(-)
+
+diff --git a/src/convert.c b/src/convert.c
+index feb90a35..3baec850 100644
+--- a/src/convert.c
++++ b/src/convert.c
+@@ -36,6 +36,7 @@ as that of the covered work.  */
+ #include <unistd.h>
+ #include <errno.h>
+ #include <assert.h>
++#include <intprops.h>
+ #include "convert.h"
+ #include "url.h"
+ #include "recur.h"
+@@ -1178,21 +1179,37 @@ html_quote_string (const char *s)
+ {
+   const char *b = s;
+   char *p, *res;
+-  int i;
++  size_t i;
++  int ok;
+ 
+   /* Pass through the string, and count the new size.  */
+-  for (i = 0; *s; s++, i++)
++  for (i = 0; *s; s++)
+     {
+       if (*s == '&')
+-        i += 4;                 /* `amp;' */
++        ok = INT_ADD_OK (i, 4, &i);     /* `amp;' */
+       else if (*s == '<' || *s == '>')
+-        i += 3;                 /* `lt;' and `gt;' */
++        ok = INT_ADD_OK (i, 3, &i);     /* `lt;' and `gt;' */
+       else if (*s == '\"')
+-        i += 5;                 /* `quot;' */
++        ok = INT_ADD_OK (i, 5, &i);     /* `quot;' */
+       else if (*s == ' ')
+-        i += 4;                 /* #32; */
++        ok = INT_ADD_OK (i, 4, &i);     /* #32; */
++      else
++        ok = INT_ADD_OK (i, 1, &i);
++
++      if (!ok)
++        {
++          DEBUGP (("Overflow detected in html_quote_string().\n"));
++          abort();
++        }
+     }
+-  res = xmalloc (i + 1);
++
++  if (!INT_ADD_OK (i, 1, &i))
++    {
++      DEBUGP (("Overflow detected in html_quote_string().\n"));
++      abort();
++    }
++
++  res = xmalloc (i);
+   s = b;
+   for (p = res; *s; s++)
+     {
+-- 
+GitLab
+

--- a/packages/wget/build.ncl
+++ b/packages/wget/build.ncl
@@ -2,6 +2,7 @@ let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = impo
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let make = import "../make/build.ncl" in
+let patch = import "../patch/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
 
 let glibc = import "../glibc/build.ncl" in
@@ -21,9 +22,19 @@ let version = "1.25.0" in
       extract = true,
       strip_prefix = "wget-%{version}",
     } | Source,
+    # Security backports for the four CVEs upstream fixed after 1.25.0 (the last
+    # release, 2024-11-11). Each is a self-contained fix touching one src/ file
+    # and a different file from the others, so they apply independently and in
+    # any order. Cherry-picked from gitlab.com/gnuwget/wget; verified to apply
+    # clean (`patch -Np1`) against the 1.25.0 tarball.
+    { file = "CVE-2026-58469.patch" } | Local,
+    { file = "CVE-2026-58470.patch" } | Local,
+    { file = "CVE-2026-58471.patch" } | Local,
+    { file = "CVE-2026-58472.patch" } | Local,
     base,
     toolchain,
     make,
+    patch,
     pkgconf,
   ],
   runtime_deps = [

--- a/packages/wget/build.sh
+++ b/packages/wget/build.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+# Security backports — CVEs fixed upstream after the 1.25.0 release (see
+# build.ncl for provenance). `set -e` plus patch's non-zero exit on a rejected
+# hunk means a stale patch ABORTS the build rather than silently shipping an
+# unpatched wget. Each touches a different src/ file, so order is immaterial.
+patch -Np1 -i "CVE-2026-58469.patch"   # metalink.c  clean_metalink_string buffer underflow
+patch -Np1 -i "CVE-2026-58470.patch"   # http.c      parse_content_range integer overflow
+patch -Np1 -i "CVE-2026-58471.patch"   # url.c       filename-conversion buffer size
+patch -Np1 -i "CVE-2026-58472.patch"   # convert.c   html_quote_string integer+buffer overflow
+
 case $(uname -m) in
   x86_64)  MARCH="-march=x86-64-v3" ;;
   aarch64) MARCH="-march=armv8-a" ;;


### PR DESCRIPTION
## What

Backports the four CVEs upstream fixed **after** wget's last release (1.25.0, 2024-11-11). All four are confirmed to affect 1.25.0 (the OSV records name "GNU Wget 1.25.0" explicitly) and each has a clean upstream fix commit on `gitlab.com/gnuwget/wget`:

| CVE | Sev | File | Fix |
|---|---|---|---|
| CVE-2026-58469 | **HIGH** | `src/metalink.c` | `clean_metalink_string` buffer underflow (`37a40fcb`) |
| CVE-2026-58470 | MED | `src/http.c` | `parse_content_range` integer overflow (`43d3ba93`) |
| CVE-2026-58471 | MED | `src/url.c` | filename-conversion buffer size (`c2640fe5`) |
| CVE-2026-58472 | MED | `src/convert.c` | `html_quote_string` integer+buffer overflow (`dd692d9c`) |

Each is a self-contained upstream maintainer commit touching a **single, distinct** `src/` file, so they apply independently in any order (no prerequisite chain like libssh2 needed).

## How

- Patches cherry-picked from upstream, committed as `CVE-*.patch`.
- Applied via `patch -Np1` in `build.sh` under `set -e` — a rejected hunk **aborts** the build rather than silently shipping an unpatched wget.
- `patch` added to `build_deps`.

## Verified locally

- All four apply clean (`patch -Np1`) to the 1.25.0 tarball — individually and in sequence.
- `min package build --rebuild wget` → exit 0 (patches applied under `set -e`, patched tree compiled).
- `min check --packages wget` → **every check passes**, including the build-dependent ones (enumerate-bins, missing-runtime_deps, standalone-tests) that only run against a built+cached package.

wget is on the highest-exposure end of the backport list (it parses untrusted server responses), and it's on upstream's latest release, so backporting is the only path short of waiting for 1.25.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added four Wget security fixes addressing malformed Metalink input, HTTP Content-Range parsing, filename conversion, and HTML string handling.
  * Improved protection against buffer underflows, integer overflows, and invalid numeric values.
* **Build**
  * Security patches are now applied automatically when building Wget 1.25.0.
  * Builds stop if any security patch cannot be applied successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->