### PR TITLE
varlock: re-onboard 0.2.3 → 1.17.0 (0.x→1.x repackaging)

### DIFF
--- a/packages/varlock/build.ncl
+++ b/packages/varlock/build.ncl
@@ -1,9 +1,22 @@
-let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
 let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
 
 # TODO: build rather than fetch
-let version = "0.2.3" in
+#
+# Re-onboarded 0.2.3 -> 1.17.0: the 0.x -> 1.x jump changed the packaging, so
+# this is not a plain version bump. Three things moved:
+#  - upstream dropped the version from the asset filename
+#    (varlock-linux-x64-0.2.3.tar.gz -> varlock-linux-x64.tar.gz);
+#  - the tarball now bundles a `varlock-local-encrypt` native helper next to the
+#    main binary (varlock invokes it by name for the local-encrypt feature);
+#  - `varlock` is now a ~104MB dynamically-linked node/bun single-executable, so
+#    it needs the glibc loader + libc/libm/libdl/libpthread at runtime (0.2.3
+#    declared no runtime_deps).
+# Source points at the upstream release asset directly (like ghidra) rather than
+# a gs:// mirror — acceptable for this low-churn, no-CVE package.
+let version = "1.17.0" in
 {
   name = "varlock",
   build_deps = [
@@ -11,16 +24,19 @@ let version = "0.2.3" in
     match {
       { arch = 'Amd64, .. } =>
         {
-          url = "gs://minimal-staging-archives/dmno-dev/varlock/varlock-linux-x64-%{version}.tar.gz",
-          sha256 = "b7a6cb07507105cac70e847adbf8fbe462f3a91f5376f564458e5c0d77bf0f96",
+          url = "https://github.com/dmno-dev/varlock/releases/download/varlock%40%{version}/varlock-linux-x64.tar.gz",
+          sha256 = "9b0ee1a7d42469c27dbfa284fa4337eb02c39c259198f36c5b127d5c3fb7a89d",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
-          url = "gs://minimal-staging-archives/dmno-dev/varlock/varlock-linux-arm64-%{version}.tar.gz",
-          sha256 = "0ec5d782dd0254f511aed3a2a7a3403a14d0bab4ed8947c35b29bc1d3543cbe9",
+          url = "https://github.com/dmno-dev/varlock/releases/download/varlock%40%{version}/varlock-linux-arm64.tar.gz",
+          sha256 = "08ea40fdca2ffeb7bb0afe6f47813bab43298c1ce897f07e013aae2649bfc01a",
         } | Source,
     } target,
     base,
+  ],
+  runtime_deps = [
+    glibc,
   ],
 
   cmd = "./build.sh",
@@ -30,6 +46,8 @@ let version = "0.2.3" in
 
   outputs = {
     varlock = { glob = "usr/bin/varlock" } | OutputBin,
+    # The bundled native helper varlock invokes (by name) for local-encrypt.
+    varlock-local-encrypt = { glob = "usr/bin/varlock-local-encrypt" } | OutputBin,
   },
 
   attrs =
@@ -43,5 +61,19 @@ let version = "0.2.3" in
       },
     } | Attrs,
 
-  tests.smoketest = standaloneTest "/bin/varlock --version",
+  tests = {
+    # `standaloneTest` runs the ELF directly with no loader in the sandbox, which
+    # ENOENTs for a dynamically-linked binary. Use base (bash + glibc loader) as
+    # a test dep and exercise real subcommands.
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "varlock --version | grep -q '1.17.0'"],
+          ["/bin/bash", "-c", "varlock --help"],
+        ],
+      }
+        | Test,
+  },
 } | BuildSpec

--- a/packages/varlock/build.sh
+++ b/packages/varlock/build.sh
@@ -7,6 +7,10 @@ case $(uname -m) in
   *)       echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
 esac
 
-tar -xzof "varlock-linux-${ARCH}-${MINIMAL_ARG_VERSION}.tar.gz"
+# 1.x dropped the version from the asset filename (varlock-linux-${ARCH}.tar.gz).
+tar -xzof "varlock-linux-${ARCH}.tar.gz"
 
 install -D -m 0755 varlock "$OUTPUT_DIR/usr/bin/varlock"
+# 1.x ships a bundled native helper alongside the main binary; varlock invokes
+# it by name for local-encrypt, so install it next to the CLI or that breaks.
+install -D -m 0755 varlock-local-encrypt "$OUTPUT_DIR/usr/bin/varlock-local-encrypt"


### PR DESCRIPTION
## What

Re-onboards **varlock 0.2.3 → 1.17.0**. We onboarded early at 0.2.3 and never bumped; upstream is now at 1.17.0 (real — `dmno-dev/varlock` tags `varlock@X.Y.Z`, npm `latest = 1.17.0`). The 0.x→1.x jump **changed the packaging**, so this is a manual re-onboard, not a version bump — a naive version+sha bump would have 404'd on the download and, if forced, shipped a binary that can't start.

## Why it's not a plain bump

Three things moved between 0.2.3 and 1.x:

1. **Asset naming lost the version** — `varlock-linux-x64-0.2.3.tar.gz` → `varlock-linux-x64.tar.gz`. Updated the source URL and build.sh's untar. Source now points at the upstream release asset directly (like ghidra) instead of a gs:// mirror — acceptable for this low-churn, no-CVE package.
2. **New bundled native helper** — the tarball now ships `varlock-local-encrypt` next to the main binary; `varlock` invokes it by name for the local-encrypt feature. build.sh installs it and it's declared as an output.
3. **New runtime linkage** — `varlock` is now a ~104MB dynamically-linked node/bun single-executable needing the glibc loader + `libc/libm/libdl/libpthread`. 0.2.3 declared **no** runtime_deps; added `glibc`. The smoke test moved off bare `standaloneTest` (runs the ELF with no loader → `ENOENT`) to a `Standalone` `Test` with `base` as a test dep, asserting `--version == 1.17.0` and `--help`.

## Verified locally

- `min package build --rebuild varlock` → exit 0 (both binaries installed).
- `min check --packages varlock` → **every check passes**, including `missing runtime_deps`, `standalone tests` (real `varlock --version`/`--help`), and `enumerate bins`.

## Note

No security urgency — varlock 0.2.3 has no known advisories; this just brings us current. This is also a live example for a **POTD guard on 0.x→1.x major jumps** (the POTD offered this as a routine bump; it's really a re-onboarding) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Varlock to version 1.17.0.
  * Added the bundled local encryption helper alongside the main command-line tool.
  * Added support for AMD64 and ARM64 release assets.

* **Bug Fixes**
  * Improved runtime compatibility for systems using glibc.
  * Updated verification checks to confirm version and help commands work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->