### PR TITLE
[no-op CI probe] discriminate res-server health from #631 content

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ This project is licensed under the [Apache License Version 2.0](LICENSE)
 
 The *packages built from these recipes* remain under their own upstream
 licenses — see [LICENSING.md](LICENSING.md) for how the two relate.
+


### PR DESCRIPTION
One whitespace byte. See commit message — this exists to answer one question: does CI pass when the build fetches nothing new? Result feeds the #631 res-server triage; will be closed unmerged either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added spacing at the end of the README’s License section for improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->