### PR TITLE
feat: tune emacs for use with a Loadout

### DIFF
--- a/packages/dev-language-servers/build.ncl
+++ b/packages/dev-language-servers/build.ncl
@@ -1,0 +1,64 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputData, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let bash-language-server = import "../bash-language-server/build.ncl" in
+let eslint = import "../eslint/build.ncl" in
+let ghc = import "../ghc/build.ncl" in
+let gopls = import "../gopls/build.ncl" in
+let haskell-language-server = import "../haskell-language-server/build.ncl" in
+let jdtls = import "../jdtls/build.ncl" in
+let llvm = import "../llvm/build.ncl" in
+let lua-language-server = import "../lua-language-server/build.ncl" in
+let nickel-lsp = import "../nickel-lsp/build.ncl" in
+let pyright = import "../pyright/build.ncl" in
+let ruby-lsp = import "../ruby-lsp/build.ncl" in
+let ruff = import "../ruff/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let typescript-language-server = import "../typescript-language-server/build.ncl" in
+let zig = import "../zig/build.ncl" in
+let zls = import "../zls/build.ncl" in
+{
+  name = "dev-language-servers",
+  # Meta-package: a batteries-included language-server roster for
+  # editor-agnostic LSP setups (emacs/eglot, helix, neovim, ...).
+  # Twelve languages: Go, Rust, Python (pyright + ruff), TypeScript/JS
+  # (+ eslint), Bash, C/C++, Nickel, Java, Ruby, Lua, Zig, Haskell.
+  #
+  # The emacs-site-lisp can use these packages
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+  ],
+
+  runtime_deps = [
+    bash-language-server,
+    eslint,
+    ghc,
+    gopls,
+    haskell-language-server,
+    jdtls,
+    # Only clangd from llvm (the full package is a whole compiler suite),
+    # plus the two shared libraries it links (`ldd clangd`): libLLVM.so
+    # (llvm is built with LLVM_LINK_LLVM_DYLIB=ON) and libclang-cpp.so.
+    subsetOf llvm ["clangd", "libclang", "libllvm"],
+    lua-language-server,
+    nickel-lsp,
+    pyright,
+    ruby-lsp,
+    ruff,
+    rust,
+    typescript-language-server,
+    zig,
+    zls,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    doc = { glob = "usr/share/doc/dev-language-servers/**" } | OutputData,
+  },
+
+  attrs =
+    {
+      license_spdx = "MIT",
+    } | Attrs,
+} | BuildSpec

--- a/packages/dev-language-servers/build.sh
+++ b/packages/dev-language-servers/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+# Meta-package: the payload is the runtime_deps roster.
+mkdir -p "$OUTPUT_DIR/usr/share/doc/dev-language-servers"
+cat > "$OUTPUT_DIR/usr/share/doc/dev-language-servers/README" << 'EOF'
+Meta-package carrying a language-server roster as runtime dependencies:
+gopls, rust (rust-analyzer), pyright + ruff, typescript-language-server
++ eslint, bash-language-server, clangd, nickel-lsp (nls), jdtls,
+ruby-lsp, lua-language-server, zls (+ zig), haskell-language-server
+(+ ghc).
+EOF

--- a/packages/dev-language-servers/build.sh
+++ b/packages/dev-language-servers/build.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -euo pipefail
 
 # Meta-package: the payload is the runtime_deps roster.
 mkdir -p "$OUTPUT_DIR/usr/share/doc/dev-language-servers"

--- a/packages/emacs-site-lisp/build.ncl
+++ b/packages/emacs-site-lisp/build.ncl
@@ -1,0 +1,298 @@
+let { Attrs, BuildSpec, Local, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let emacs = import "../emacs/build.ncl" in
+let git = import "../git/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+{
+  name = "emacs-site-lisp",
+  # Library-only elisp + tree-sitter grammars for the MPR emacs package.
+  #
+  # Successor to the library half of emacs-config-dev1: every elisp package
+  # and grammar is a sha256-pinned release tarball, byte-compiled at build
+  # time. Unlike emacs-config-dev1 this package ships NO minimal-init-*
+  # fragment: installing it only extends load-path (via the emacs package's
+  # site-start.el). Nothing is enabled until a user's own init requires it,
+  # so it composes with any personal config without forcing behavior.
+  build_deps = [
+    { file = "build.sh" } | Local,
+
+    # ── Completion framework ───────────────────────────────────────────
+    {
+      url = "https://github.com/minad/vertico/archive/refs/tags/2.12.tar.gz",
+      sha256 = "fc7f2a3a9935088579d60dacdb5e598d2410b18a6bacebea19d39c695d0d0163",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/oantolin/orderless/archive/refs/tags/1.7.tar.gz",
+      sha256 = "5b6d24c8a863073d1922908e6f2f9a92bad73bee8fb2c2a813ea1fc64d3eb5c7",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/minad/marginalia/archive/refs/tags/2.11.tar.gz",
+      sha256 = "705ca7aa21706e0e78e1d7e8afed566f322f4bc0c7d305e2a2839558efdb5dc2",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/minad/consult/archive/refs/tags/3.7.tar.gz",
+      sha256 = "497aa8dcdca0fb8ce4ac0838d13ddc667dd4902be5802937f97c29e0a74c5793",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/minad/corfu/archive/refs/tags/2.13.tar.gz",
+      sha256 = "9789fa4f223bd75f518f33ef0ee05990b010724966e19004896f2b07e302e166",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/minad/cape/archive/refs/tags/2.8.tar.gz",
+      sha256 = "9c6022851de1163abbd05904d2925b63de5313a0e94f1379cd78f64eb484db29",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/oantolin/embark/archive/refs/tags/1.2.tar.gz",
+      sha256 = "6a9ba6c7adddbf2c2e92dec7026cfc25b179d50f10418d5de8e7f4c72be4548b",
+      extract = true,
+    } | Source,
+
+    # ── Corfu terminal rendering (emacs is built --without-x) ──────────
+    {
+      url = "https://codeberg.org/akib/emacs-corfu-terminal/archive/v0.7.tar.gz",
+      sha256 = "88402635bf4d967dba0238baed5a2a6a370591c730d6ba05de2be4680d33e334",
+      extract = true,
+    } | Source,
+    {
+      url = "https://codeberg.org/akib/emacs-popon/archive/v0.13.tar.gz",
+      sha256 = "5f7c3d31dd69370db031ebacb45432daa3dcce7827d9a77783772ed1d94c5978",
+      extract = true,
+    } | Source,
+
+    # ── Editable grep buffers ──────────────────────────────────────────
+    {
+      url = "https://github.com/mhayashi1120/Emacs-wgrep/archive/refs/tags/3.0.0.tar.gz",
+      sha256 = "034d5ceeff43ffe30a556f922232f356355e0bf9b89126ff218c1893bb0dd1d0",
+      extract = true,
+    } | Source,
+
+    # ── Magit and dependencies ─────────────────────────────────────────
+    {
+      url = "https://github.com/emacs-compat/compat/archive/refs/tags/31.0.0.2.tar.gz",
+      sha256 = "bbbf48ac8964425c09a6d3b7abe2ae9ff95fb9e43154f252977290f1de79aab9",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tarsius/llama/archive/refs/tags/v1.0.5.tar.gz",
+      sha256 = "7194b803d05cc1b260fcae932b1884a06c61dc327a92d4986a1f91f35b08abdb",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tarsius/cond-let/archive/refs/tags/v1.1.3.tar.gz",
+      sha256 = "ce631fbd9a0f16d00db54e6cb13b77f1fb9a423cc37e1aba6339d7dfc630e7fe",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/magit/transient/archive/refs/tags/v0.13.7.tar.gz",
+      sha256 = "7ae2bbfd073a34d8d8a0510473d55f917529ec5c13b86da5318b22e485c31555",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/magit/with-editor/archive/refs/tags/v3.5.3.tar.gz",
+      sha256 = "12f30b6356235962e91f38897413f0c65a981cfbf6b9f699efa3aa2636443adc",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/magit/magit/archive/refs/tags/v4.7.0.tar.gz",
+      sha256 = "9baddf75339eeccce22dae0cd59c43bbdfc0b2e5745422063858492f341ecb75",
+      extract = true,
+    } | Source,
+
+    # ── Language modes without a built-in ts-mode ──────────────────────
+    {
+      url = "https://github.com/jrblevin/markdown-mode/archive/refs/tags/v2.8.tar.gz",
+      sha256 = "8252904252f771019c0b17e38be07cc8893e39da50e58dc5142dca50b0dd2dee",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/nickel-lang/nickel-mode/archive/e2dcd6cf66d9b5bcde3e3cd69efe053f73b081ab.tar.gz",
+      sha256 = "209d5129ea006d0a335fbf82221878a6aa4796d18b048ce895d18473bc7d65a4",
+      extract = true,
+    } | Source,
+    # reformatter is a hard dependency of zig-mode ((require 'reformatter)
+    # at load time, for zig-format); it only needs the built-in ansi-color.
+    {
+      url = "https://github.com/purcell/emacs-reformatter/archive/refs/tags/0.7.tar.gz",
+      sha256 = "dc5b0a569840e9c132d4f05421aef820bb5ec19b3457d3be3461c8c64137b7bc",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/ziglang/zig-mode/archive/66490933a468b5d55a90645c4c87067c508ccd04.tar.gz",
+      sha256 = "c69cc953292f029924a007738bcf56a0d8e729e42b4274182cb70c804e876f5b",
+      extract = true,
+    } | Source,
+    {
+      url = "https://codeberg.org/pranshu/haskell-ts-mode/archive/bf143ee8382f09e0a68d775d80445065f32929c3.tar.gz",
+      sha256 = "7e6bf2e4039a5b66ccfac8f7f3c010ade7d193caf8fd8568c26d1d9e2c629465",
+      extract = true,
+    } | Source,
+
+    # ── Extra flymake backends ─────────────────────────────────────────
+    {
+      url = "https://github.com/erickgnavar/flymake-ruff/archive/ef4a6caed72bce77a27bda54ffb30e3fdb0e7d76.tar.gz",
+      sha256 = "8302058f4f5609769244e36f2c9b8d31a119d117a1d20d7fb933a2ed46e0c117",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/orzechowskid/flymake-eslint/archive/refs/tags/1.5.0.tar.gz",
+      sha256 = "c7bee8fadaea088fc2d3bf7ec91bbd79116fbbf111e06d1e013284a5819c9667",
+      extract = true,
+    } | Source,
+
+    # ── Tree-sitter grammars ───────────────────────────────────────────
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-rust/archive/refs/tags/v0.23.2.tar.gz",
+      sha256 = "71ce61738f8aff4531afed443572ca68aa74a66a07569a1d50863eb34787c782",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-go/archive/refs/tags/v0.23.4.tar.gz",
+      sha256 = "967870d7d120e9b760e538aeb8331a72f70ffcca4f1eaf1e1dea5375886d25d2",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-typescript/archive/refs/tags/v0.23.2.tar.gz",
+      sha256 = "2c4ce711ae8d1218a3b2f899189298159d672870b5b34dff5d937bed2f3e8983",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-python/archive/refs/tags/v0.23.6.tar.gz",
+      sha256 = "630a0f45eccd9b69a66a07bf47d1568e96a9c855a2f30e0921c8af7121e8af96",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-bash/archive/refs/tags/v0.23.3.tar.gz",
+      sha256 = "c682b81d0fe953d19f6632db3ba6e4f2db1efe1784f7a28bc5fcf6355d67335b",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.23.4.tar.gz",
+      sha256 = "b66c5043e26d84e5f17a059af71b157bcf202221069ed220aa1696d7d1d28a7a",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-cpp/archive/refs/tags/v0.23.4.tar.gz",
+      sha256 = "7a2c55afe3028f4105f25762ea58cc16537d1f5a1dcd9cca90410b3cd5d46051",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-json/archive/refs/tags/v0.24.8.tar.gz",
+      sha256 = "acf6e8362457e819ed8b613f2ad9a0e1b621a77556c296f3abea58f7880a9213",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-yaml/archive/refs/tags/v0.7.2.tar.gz",
+      sha256 = "aeaff5731bb8b66c7054c8aed33cd5edea5f4cd2ac71654f3f6c2ba2073d8fac",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-toml/archive/refs/tags/v0.7.0.tar.gz",
+      sha256 = "7d52a7d4884f307aabc872867c69084d94456d8afcdc63b0a73031a8b29036dc",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/camdencheek/tree-sitter-go-mod/archive/refs/tags/v1.1.0.tar.gz",
+      sha256 = "66f55e0dfa9d654484146c405261d667196d3b20872fa3f7813d5125a82d6de8",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-java/archive/refs/tags/v0.23.5.tar.gz",
+      sha256 = "cb199e0faae4b2c08425f88cbb51c1a9319612e7b96315a174a624db9bf3d9f0",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-ruby/archive/refs/tags/v0.23.1.tar.gz",
+      sha256 = "e7e49577ddc1f2de8e42d42353b477e338c15bbb95b2558e123ddc13d88789f0",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/refs/tags/v0.5.0.tar.gz",
+      sha256 = "cf01b93f4b61b96a6d27942cf28eeda4cbce7d503c3bef773a8930b3d778a2d9",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter-grammars/tree-sitter-zig/archive/refs/tags/v1.1.2.tar.gz",
+      sha256 = "612d67059faa90ec7691e5d786d70d8f7c2c8b15b83de901b9b801122ad4cf25",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/tree-sitter/tree-sitter-haskell/archive/refs/tags/v0.23.1.tar.gz",
+      sha256 = "bac7d0a37730af62d883e2bdbafb68f47e7ab4f5e744c7586bffc589906a8cc2",
+      extract = true,
+    } | Source,
+    {
+      url = "https://github.com/camdencheek/tree-sitter-dockerfile/archive/refs/tags/v0.2.0.tar.gz",
+      sha256 = "8cbdf50838cc55e841aa9585a1a09e5b8c41454ae30ce0a93a7bd71adb140818",
+      extract = true,
+    } | Source,
+    base,
+    emacs,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    emacs,
+  ],
+
+  cmd = "./build.sh",
+
+  outputs = {
+    site-lisp = { glob = "usr/share/emacs/site-lisp/**" } | OutputData,
+    grammars = { glob = "usr/lib/emacs/tree-sitter/*.so" } | OutputLib,
+  },
+
+  tests = {
+    # git: magit runs `git version` from its startup assert as soon as it is
+    # required in batch mode (after-init-time is set by then), so loading it
+    # needs a git on PATH. base: coreutils for the emacs wrapper's mkdir.
+    libs-loadable =
+      {
+        class = 'Standalone,
+        test_deps = [base, git],
+        cmds = [
+          ["emacs", "--batch", "--eval", "(progn (require 'vertico) (require 'orderless) (require 'marginalia) (require 'consult) (require 'corfu) (require 'corfu-terminal) (require 'cape) (require 'embark) (require 'wgrep) (require 'magit) (require 'markdown-mode) (require 'nickel-mode) (require 'zig-mode) (require 'haskell-ts-mode) (require 'flymake-ruff) (require 'flymake-eslint))"],
+        ],
+      } | Test,
+
+    # Guards the build.sh patch that defines corfu-terminal-mode early:
+    # loading corfu-terminal must not emit a byte-compiler warning (the
+    # "Source file ... newer than byte-compiled file" notes come from the
+    # emacs package itself and are filtered out), and the early defvar
+    # must not stop define-minor-mode's defcustom from working, so the
+    # mode must still switch on.
+    corfu-terminal-loads-cleanly =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "out=$(emacs --batch --eval \"(progn (require 'corfu-terminal) (corfu-terminal-mode 1) (message \\\"corfu-terminal-mode=%s\\\" corfu-terminal-mode))\" 2>&1 | grep -v 'newer than byte-compiled'); echo \"$out\"; echo \"$out\" | grep -q 'corfu-terminal-mode=t' && ! echo \"$out\" | grep -qi warning"],
+        ],
+      } | Test,
+
+    # End-to-end font-lock through a bundled grammar: go-ts-mode's builtin
+    # feature uses a :match predicate, which libtree-sitter >= 0.26 only
+    # accepts in the form the emacs package's treesit-predicates-0.26.patch
+    # emits. Fontify a sample at level 4 and require real faces and no
+    # treesit-query-error.
+    go-ts-font-lock =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "printf 'package main\\n\\nimport \"fmt\"\\n\\nfunc main() {\\n\\tx := append([]int{}, 1)\\n\\tfmt.Println(\"hi\", x)\\n}\\n' > /tmp/t.go; out=$(emacs --batch --eval '(progn (add-to-list (quote treesit-extra-load-path) \"/usr/lib/emacs/tree-sitter\") (setq treesit-font-lock-level 4) (find-file \"/tmp/t.go\") (go-ts-mode) (font-lock-ensure) (let (faces) (goto-char (point-min)) (while (not (eobp)) (let ((f (get-text-property (point) (quote face)))) (when f (push f faces))) (forward-char)) (princ (format \"faces=%S\" (delete-dups faces)))))' 2>&1 | grep -v 'newer than byte-compiled'); echo \"$out\"; echo \"$out\" | grep -q 'font-lock-builtin-face' && echo \"$out\" | grep -q 'font-lock-keyword-face' && ! echo \"$out\" | grep -q 'treesit-query-error'"],
+        ],
+      } | Test,
+  },
+
+  attrs =
+    {
+      # Aggregate: elisp is GPL-3.0-or-later; bundled tree-sitter grammars are MIT.
+      license_spdx = "GPL-3.0-or-later",
+    } | Attrs,
+} | BuildSpec

--- a/packages/emacs-site-lisp/build.sh
+++ b/packages/emacs-site-lisp/build.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -euo pipefail
 
 SITE_LISP="$OUTPUT_DIR/usr/share/emacs/site-lisp"
 mkdir -p "$SITE_LISP"
@@ -98,13 +98,21 @@ done
 # Ensure .elc files are newer than .el files.  Reproducible-build
 # settings (SOURCE_DATE_EPOCH=0) can cause byte-compiled files to
 # carry an epoch-0 timestamp, making Emacs think they are stale.
-find "$SITE_LISP" -name '*.elc' -exec touch {} +
+# A fixed instant (any date later than the newest upstream tarball
+# mtime) instead of the build clock, so nothing in the output depends
+# on when the build ran. Note the capture layer currently re-stamps
+# all output files with one uniform mtime anyway — verified by
+# comparing two independent builds (byte-identical content, single
+# uniform stamp) — so this is belt-and-braces for if that changes.
+find "$SITE_LISP" -name '*.elc' -exec touch --date=@2000000000 {} +
 
 # ── Tree-sitter grammars ─────────────────────────────────────────────
 TS_DIR="$OUTPUT_DIR/usr/lib/emacs/tree-sitter"
 mkdir -p "$TS_DIR"
 
-CFLAGS="-O2 -fPIC"
+# Deterministic compile/link settings per the repo reproducibility recipe.
+CFLAGS="-O2 -fPIC -gno-record-gcc-switches -ffile-prefix-map=$(pwd)=/builddir"
+LDFLAGS="-Wl,--build-id=none"
 
 build_grammar() {
   name="$1"
@@ -114,7 +122,7 @@ build_grammar() {
   if [ -n "$scanner" ] && [ -f "$src_dir/src/$scanner" ]; then
     files="$files $src_dir/src/$scanner"
   fi
-  gcc $CFLAGS -shared -o "$TS_DIR/libtree-sitter-${name}.so" \
+  gcc $CFLAGS $LDFLAGS -shared -o "$TS_DIR/libtree-sitter-${name}.so" \
     -I "$src_dir/src" $files
 }
 
@@ -136,12 +144,12 @@ build_grammar haskell    tree-sitter-haskell-0.23.1      scanner.c
 build_grammar dockerfile tree-sitter-dockerfile-0.2.0    scanner.c
 
 # TypeScript repo has typescript and tsx in separate directories
-gcc $CFLAGS -shared -o "$TS_DIR/libtree-sitter-typescript.so" \
+gcc $CFLAGS $LDFLAGS -shared -o "$TS_DIR/libtree-sitter-typescript.so" \
   -I tree-sitter-typescript-0.23.2/typescript/src \
   tree-sitter-typescript-0.23.2/typescript/src/parser.c \
   tree-sitter-typescript-0.23.2/typescript/src/scanner.c
 
-gcc $CFLAGS -shared -o "$TS_DIR/libtree-sitter-tsx.so" \
+gcc $CFLAGS $LDFLAGS -shared -o "$TS_DIR/libtree-sitter-tsx.so" \
   -I tree-sitter-typescript-0.23.2/tsx/src \
   tree-sitter-typescript-0.23.2/tsx/src/parser.c \
   tree-sitter-typescript-0.23.2/tsx/src/scanner.c

--- a/packages/emacs-site-lisp/build.sh
+++ b/packages/emacs-site-lisp/build.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+set -ex
+
+SITE_LISP="$OUTPUT_DIR/usr/share/emacs/site-lisp"
+mkdir -p "$SITE_LISP"
+
+# Install each elisp package into its own directory under site-lisp.
+# The emacs package's site-start.el adds every site-lisp subdirectory
+# (and its lisp/ and extensions/ children) to load-path.
+install_pkg() {
+  name="$1"
+  src_dir="$2"
+  dest="$SITE_LISP/$name"
+  mkdir -p "$dest"
+  cp "$src_dir"/*.el "$dest/" 2>/dev/null || true
+  for subdir in lisp extensions; do
+    if [ -d "$src_dir/$subdir" ]; then
+      mkdir -p "$dest/$subdir"
+      cp "$src_dir/$subdir/"*.el "$dest/$subdir/" 2>/dev/null || true
+    fi
+  done
+}
+
+# Completion framework
+install_pkg vertico vertico-2.12
+install_pkg orderless orderless-1.7
+install_pkg marginalia marginalia-2.11
+install_pkg consult consult-3.7
+install_pkg corfu corfu-2.13
+install_pkg cape cape-2.8
+install_pkg embark embark-1.2
+# avy is not packaged here; drop the one embark file that needs it.
+rm -f "$SITE_LISP/embark/avy-embark-collect.el"
+
+# Corfu terminal rendering (codeberg archives extract to the repo name)
+install_pkg popon emacs-popon
+install_pkg corfu-terminal emacs-corfu-terminal
+# corfu-terminal.el's `cl-defmethod ... &context (corfu-terminal-mode ...)'
+# forms come before the define-minor-mode that declares the variable.
+# cl-generic byte-compiles the &context dispatcher at *load* time, so every
+# load of the .elc prints "reference to free variable 'corfu-terminal-mode'"
+# in *Messages*. Define the variable ahead of the first method. It must be
+# a defvar WITH a value: a bare (defvar sym) only affects the compilation
+# unit it appears in, whereas (defvar sym nil) marks the symbol special
+# globally when it executes, which is what the runtime dispatcher compile
+# checks. nil is the same initial value define-minor-mode sets, so the
+# later definition is unaffected. (Upstream is archived, so the patch is
+# carried here rather than sent upstream.)
+sed -i '/^(cl-defmethod corfu--popup-support-p/i (defvar corfu-terminal-mode nil) ; defined early for the \&context dispatchers below (minimal patch)' \
+  "$SITE_LISP/corfu-terminal/corfu-terminal.el"
+grep -q '^(defvar corfu-terminal-mode nil)' "$SITE_LISP/corfu-terminal/corfu-terminal.el"
+
+# Editable grep buffers
+install_pkg wgrep Emacs-wgrep-3.0.0
+
+# Magit dependencies (must be installed before magit)
+install_pkg compat compat-31.0.0.2
+install_pkg llama llama-1.0.5
+install_pkg cond-let cond-let-1.1.3
+install_pkg transient transient-0.13.7/lisp
+install_pkg with-editor with-editor-3.5.3/lisp
+
+# Magit itself (lisp/ also carries magit-section, git-commit, git-rebase)
+install_pkg magit magit-4.7.0/lisp
+
+# Language modes without a built-in ts-mode
+install_pkg markdown-mode markdown-mode-2.8
+install_pkg nickel-mode nickel-mode-e2dcd6cf66d9b5bcde3e3cd69efe053f73b081ab
+# zig-mode requires reformatter at load time; drop its ert test file.
+install_pkg reformatter emacs-reformatter-0.7
+rm -f "$SITE_LISP/reformatter/reformatter-tests.el"
+install_pkg zig-mode zig-mode-66490933a468b5d55a90645c4c87067c508ccd04
+install_pkg haskell-ts-mode haskell-ts-mode
+
+# Extra flymake backends
+install_pkg flymake-ruff flymake-ruff-ef4a6caed72bce77a27bda54ffb30e3fdb0e7d76
+install_pkg flymake-eslint flymake-eslint-1.5.0
+
+# Build load-path arguments for byte-compilation
+LOAD_PATH=""
+for dir in "$SITE_LISP"/*/; do
+  LOAD_PATH="$LOAD_PATH -L $dir"
+  for subdir in lisp extensions; do
+    if [ -d "${dir}${subdir}" ]; then
+      LOAD_PATH="$LOAD_PATH -L ${dir}${subdir}"
+    fi
+  done
+done
+
+# Byte-compile all .el files
+for dir in "$SITE_LISP"/*/; do
+  for el in "$dir"*.el "$dir"lisp/*.el "$dir"extensions/*.el; do
+    [ -f "$el" ] || continue
+    emacs --batch $LOAD_PATH -f batch-byte-compile "$el" 2>&1 || true
+  done
+done
+
+# Ensure .elc files are newer than .el files.  Reproducible-build
+# settings (SOURCE_DATE_EPOCH=0) can cause byte-compiled files to
+# carry an epoch-0 timestamp, making Emacs think they are stale.
+find "$SITE_LISP" -name '*.elc' -exec touch {} +
+
+# ── Tree-sitter grammars ─────────────────────────────────────────────
+TS_DIR="$OUTPUT_DIR/usr/lib/emacs/tree-sitter"
+mkdir -p "$TS_DIR"
+
+CFLAGS="-O2 -fPIC"
+
+build_grammar() {
+  name="$1"
+  src_dir="$2"
+  scanner="$3"
+  files="$src_dir/src/parser.c"
+  if [ -n "$scanner" ] && [ -f "$src_dir/src/$scanner" ]; then
+    files="$files $src_dir/src/$scanner"
+  fi
+  gcc $CFLAGS -shared -o "$TS_DIR/libtree-sitter-${name}.so" \
+    -I "$src_dir/src" $files
+}
+
+build_grammar rust       tree-sitter-rust-0.23.2         scanner.c
+build_grammar go         tree-sitter-go-0.23.4           ""
+build_grammar python     tree-sitter-python-0.23.6       scanner.c
+build_grammar bash       tree-sitter-bash-0.23.3         scanner.c
+build_grammar c          tree-sitter-c-0.23.4            ""
+build_grammar cpp        tree-sitter-cpp-0.23.4          scanner.c
+build_grammar json       tree-sitter-json-0.24.8         ""
+build_grammar yaml       tree-sitter-yaml-0.7.2          scanner.c
+build_grammar toml       tree-sitter-toml-0.7.0          scanner.c
+build_grammar gomod      tree-sitter-go-mod-1.1.0        ""
+build_grammar java       tree-sitter-java-0.23.5         ""
+build_grammar ruby       tree-sitter-ruby-0.23.1         scanner.c
+build_grammar lua        tree-sitter-lua-0.5.0           scanner.c
+build_grammar zig        tree-sitter-zig-1.1.2           ""
+build_grammar haskell    tree-sitter-haskell-0.23.1      scanner.c
+build_grammar dockerfile tree-sitter-dockerfile-0.2.0    scanner.c
+
+# TypeScript repo has typescript and tsx in separate directories
+gcc $CFLAGS -shared -o "$TS_DIR/libtree-sitter-typescript.so" \
+  -I tree-sitter-typescript-0.23.2/typescript/src \
+  tree-sitter-typescript-0.23.2/typescript/src/parser.c \
+  tree-sitter-typescript-0.23.2/typescript/src/scanner.c
+
+gcc $CFLAGS -shared -o "$TS_DIR/libtree-sitter-tsx.so" \
+  -I tree-sitter-typescript-0.23.2/tsx/src \
+  tree-sitter-typescript-0.23.2/tsx/src/parser.c \
+  tree-sitter-typescript-0.23.2/tsx/src/scanner.c

--- a/packages/emacs/build.ncl
+++ b/packages/emacs/build.ncl
@@ -10,6 +10,7 @@ let jansson = import "../jansson/build.ncl" in
 let libxml2 = import "../libxml2/build.ncl" in
 let make = import "../make/build.ncl" in
 let ncurses = import "../ncurses/build.ncl" in
+let patch = import "../patch/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let tree-sitter = import "../tree-sitter/build.ncl" in
@@ -20,6 +21,9 @@ let version = "30.2" in
   build_deps = [
     { file = "build.sh" } | Local,
     { file = "fixrand.c" } | Local,
+    # Backport of Emacs master b0143530 (bug#79687): tree-sitter >= 0.26
+    # rejects the bare #match/#equal predicate names Emacs 30.2 emits.
+    { file = "treesit-predicates-0.26.patch" } | Local,
     {
       url = "https://ftpmirror.gnu.org/emacs/emacs-%{version}.tar.xz",
       sha256 = "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9",
@@ -29,6 +33,7 @@ let version = "30.2" in
     autoconf,
     base,
     make,
+    patch,
     pkgconf,
     toolchain,
   ],
@@ -94,6 +99,18 @@ let version = "30.2" in
         test_deps = [base],
         cmds = [
           ["/bin/bash", "-c", "emacs --batch --eval '(message \"%s\" (treesit-available-p))' 2>&1 | grep -q t"],
+        ],
+      } | Test,
+
+    # Guards treesit-predicates-0.26.patch: sexp predicates must serialise
+    # with the ? suffix that libtree-sitter >= 0.26 requires, for both
+    # the legacy keywords and the new aliases.
+    treesit_predicate_syntax =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "out=$(emacs --batch --eval '(princ (treesit-query-expand (quote ((a) @x (:match \"^a\" @x) (:equal @x \"a\") (:match? @x \"^a\") (:eq? @x \"a\")))))' 2>/dev/null); echo \"$out\"; echo \"$out\" | grep -q '(#match? \"^a\" @x) (#eq? @x \"a\") (#match? @x \"^a\") (#eq? @x \"a\")'"],
         ],
       } | Test,
   },

--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -23,6 +23,14 @@ export ARFLAGS=Drc
 # in a later version bump.
 sed -i 's/\bts_language_version\b/ts_language_abi_version/g' src/treesit.c
 
+# tree-sitter >= 0.26 also rejects query predicates without a ?/! suffix,
+# but Emacs 30.2 emits "#match"/"#equal"/"#pred" and only accepts those
+# names back, so every :match font-lock rule (go-ts-mode, python-ts-mode,
+# typescript-ts-mode, ...) dies with treesit-query-error and the buffer
+# loses highlighting. Backport of the upstream fix (master b0143530,
+# bug#79687); see the patch header. Drop once an Emacs release has it.
+patch -Np1 -i treesit-predicates-0.26.patch
+
 # Build LD_PRELOAD shim that makes getrandom() and /dev/urandom reads
 # deterministic, fixing Emacs hash table seeding and thus .elc/.pdmp output.
 gcc -shared -fPIC -O2 -ldl -o fixrand.so fixrand.c
@@ -45,24 +53,33 @@ gcc -shared -fPIC -O2 -ldl -o fixrand.so fixrand.c
 LD_PRELOAD=$(pwd)/fixrand.so make MAKEINFO=true -j$(nproc)
 LD_PRELOAD=$(pwd)/fixrand.so make MAKEINFO=true DESTDIR=$OUTPUT_DIR install
 
-# Replace the emacs symlink with a wrapper that redirects user-emacs-directory
-# to an ephemeral /tmp path, avoiding the need for a writable ~/.emacs.d
+# Replace the emacs symlink with a wrapper that picks user-emacs-directory:
+# the personal config dir $XDG_CONFIG_HOME/emacs (Emacs's own XDG location,
+# and where a loadout's patched init.el lands) when it holds an init file,
+# otherwise an ephemeral /tmp path so no writable ~/.emacs.d is needed.
+# Passing --init-directory explicitly in both cases keeps the choice
+# independent of Emacs's own ~/.emacs.d-vs-XDG fallback rules.
 rm "$OUTPUT_DIR/usr/bin/emacs"
 cat > "$OUTPUT_DIR/usr/bin/emacs" <<'WRAPPER'
 #!/bin/sh
-dir="/tmp/emacs.d"
-mkdir -p "$dir"
+dir="${XDG_CONFIG_HOME:-$HOME/.config}/emacs"
+if [ ! -f "$dir/init.el" ] && [ ! -f "$dir/early-init.el" ]; then
+  dir="/tmp/emacs.d"
+  mkdir -p "$dir"
+fi
 exec emacs-30.2 --init-directory "$dir" "$@"
 WRAPPER
 chmod +x "$OUTPUT_DIR/usr/bin/emacs"
 
 # Install site-start.el: sets up load-path for site-lisp subdirectories and
-# discovers/loads all minimal-init-*.el config fragments from emacs-config-* packages.
+# discovers/loads all minimal-init-*.el config fragments from emacs-config-*
+# packages -- unless the user has an init file of their own, which wins.
 cat > "$OUTPUT_DIR/usr/share/emacs/site-lisp/site-start.el" <<'SITESTART'
 ;;; site-start.el --- Minimal composable config loader -*- lexical-binding: t; -*-
 
 ;; Add site-lisp subdirectories (and their lisp/extensions children) to load-path.
-;; This ensures elisp packages from any emacs-config-* package are loadable.
+;; This ensures elisp packages from any emacs-config-* or emacs-site-lisp
+;; package are loadable.
 (let ((site-lisp-dir (file-name-directory (or load-file-name buffer-file-name))))
   (dolist (dir (directory-files site-lisp-dir t "\\`[^.]"))
     (when (file-directory-p dir)
@@ -71,11 +88,18 @@ cat > "$OUTPUT_DIR/usr/share/emacs/site-lisp/site-start.el" <<'SITESTART'
         (let ((subdir (expand-file-name sub dir)))
           (when (file-directory-p subdir)
             (add-to-list 'load-path subdir))))))
-  ;; Load all minimal-init-*.el config fragments in sorted order.
-  (dolist (init-file (sort (file-expand-wildcards
-                            (expand-file-name "minimal-init-*.el" site-lisp-dir))
-                           #'string<))
-    (load init-file t t)))
+  ;; Load all minimal-init-*.el config fragments in sorted order -- unless
+  ;; user-emacs-directory (chosen by the /usr/bin/emacs wrapper, which
+  ;; prefers $XDG_CONFIG_HOME/emacs when it holds an init file) already
+  ;; carries a personal init file: that takes precedence over packaged
+  ;; fragments. A personal init that wants a fragment anyway can load it
+  ;; explicitly, e.g. (load "minimal-init-dev1").
+  (unless (or (file-exists-p (expand-file-name "init.el" user-emacs-directory))
+              (file-exists-p (expand-file-name "init.elc" user-emacs-directory)))
+    (dolist (init-file (sort (file-expand-wildcards
+                              (expand-file-name "minimal-init-*.el" site-lisp-dir))
+                             #'string<))
+      (load init-file t t))))
 
 ;;; site-start.el ends here
 SITESTART

--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -63,9 +63,12 @@ rm "$OUTPUT_DIR/usr/bin/emacs"
 cat > "$OUTPUT_DIR/usr/bin/emacs" <<'WRAPPER'
 #!/bin/sh
 dir="${XDG_CONFIG_HOME:-$HOME/.config}/emacs"
-if [ ! -f "$dir/init.el" ] && [ ! -f "$dir/early-init.el" ]; then
-  dir="/tmp/emacs.d"
-  mkdir -p "$dir"
+if [ ! -f "$dir/init.el" ] && [ ! -f "$dir/init.elc" ] && [ ! -f "$dir/early-init.el" ]; then
+  # Ephemeral fallback. Per-user under XDG_CACHE_HOME rather than a
+  # shared, predictable /tmp path that another user could pre-seed with
+  # an init.el; a throwaway dir if even the cache isn't writable.
+  dir="${XDG_CACHE_HOME:-$HOME/.cache}/emacs.d"
+  mkdir -p "$dir" 2>/dev/null || dir="$(mktemp -d /tmp/emacs.d.XXXXXX)"
 fi
 exec emacs-30.2 --init-directory "$dir" "$@"
 WRAPPER

--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -62,13 +62,18 @@ LD_PRELOAD=$(pwd)/fixrand.so make MAKEINFO=true DESTDIR=$OUTPUT_DIR install
 rm "$OUTPUT_DIR/usr/bin/emacs"
 cat > "$OUTPUT_DIR/usr/bin/emacs" <<'WRAPPER'
 #!/bin/sh
+# .elc variants count as personal config: startup--load-user-init-file
+# strips the .el extension before `load', so Emacs picks up init.elc /
+# early-init.elc even without sources.
 dir="${XDG_CONFIG_HOME:-$HOME/.config}/emacs"
-if [ ! -f "$dir/init.el" ] && [ ! -f "$dir/init.elc" ] && [ ! -f "$dir/early-init.el" ]; then
+if [ ! -f "$dir/init.el" ] && [ ! -f "$dir/init.elc" ] \
+   && [ ! -f "$dir/early-init.el" ] && [ ! -f "$dir/early-init.elc" ]; then
   # Ephemeral fallback. Per-user under XDG_CACHE_HOME rather than a
   # shared, predictable /tmp path that another user could pre-seed with
-  # an init.el; a throwaway dir if even the cache isn't writable.
+  # an init.el; a throwaway dir if the cache is missing or not writable
+  # (mkdir -p succeeds on an existing read-only dir, hence the -w test).
   dir="${XDG_CACHE_HOME:-$HOME/.cache}/emacs.d"
-  mkdir -p "$dir" 2>/dev/null || dir="$(mktemp -d /tmp/emacs.d.XXXXXX)"
+  mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ] || dir="$(mktemp -d /tmp/emacs.d.XXXXXX)"
 fi
 exec emacs-30.2 --init-directory "$dir" "$@"
 WRAPPER

--- a/packages/emacs/treesit-predicates-0.26.patch
+++ b/packages/emacs/treesit-predicates-0.26.patch
@@ -1,0 +1,150 @@
+Backport of Emacs master commit b0143530 ("Use ? suffix for tree-sitter
+query predicates", bug#79687) to Emacs 30.2.
+
+tree-sitter >= 0.26 rejects query predicates whose names lack a ?/!
+suffix: "(#match ...)" is a syntax error.  Emacs 30.2 serialises the
+sexp predicates :equal/:match/:pred as #equal/#match/#pred and only
+accepts those bare names back from the library, so with libtree-sitter
+0.26 every font-lock rule using :match (go-ts-mode's builtin feature,
+typescript/python-ts-mode, ...) fails with treesit-query-error and the
+buffer loses all highlighting.
+
+Changes, mirroring upstream:
+  * serialise :equal/:match/:pred (and the new aliases :eq?/:match?/:pred?)
+    as #eq?/#match?/#pred?, which every tree-sitter version accepts;
+  * accept eq?/match?/pred? as the predicate names handed back by the
+    library;
+  * let match? take its regexp and capture in either order (tree-sitter
+    convention is capture first, Emacs convention regexp first).
+Docs/NEWS/test hunks of the upstream commit are omitted.  Drop this
+patch when bumping to an Emacs release that contains the fix.
+
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -2584,7 +2584,9 @@
+     :*
+     :+
+     :equal
++    :eq?
+     :match
++    :match?
+     (TYPE PATTERN...)
+     [PATTERN...]
+     FIELD-NAME:
+@@ -2604,11 +2606,11 @@
+     return Vtreesit_str_star;
+   if (BASE_EQ (pattern, QCplus))
+     return Vtreesit_str_plus;
+-  if (BASE_EQ (pattern, QCequal))
+-    return Vtreesit_str_pound_equal;
+-  if (BASE_EQ (pattern, QCmatch))
++  if (BASE_EQ (pattern, QCequal) || BASE_EQ (pattern, QCeq_q))
++    return Vtreesit_str_pound_equal;
++  if (BASE_EQ (pattern, QCmatch) || BASE_EQ (pattern, QCmatch_q))
+     return Vtreesit_str_pound_match;
+-  if (BASE_EQ (pattern, QCpred))
++  if (BASE_EQ (pattern, QCpred) || BASE_EQ (pattern, QCpred_q))
+     return Vtreesit_str_pound_pred;
+   Lisp_Object opening_delimeter
+     = VECTORP (pattern)
+@@ -2640,7 +2642,9 @@
+     :*
+     :+
+     :equal
++    :eq?
+     :match
++    :match?
+     (TYPE PATTERN...)
+     [PATTERN...]
+     FIELD-NAME:
+@@ -2803,7 +2807,7 @@
+   return !NILP (Fstring_equal (text1, text2));
+ }
+ 
+-/* Handles predicate (#match "regexp" @node).  Return true if "regexp"
++/* Handles predicate (#match? "regexp" @node).  Return true if "regexp"
+    matches the text spanned by @node; return false otherwise.
+    Matching is case-sensitive.  If everything goes fine, don't touch
+    SIGNAL_DATA; if error occurs, set it to a suitable signal data.  */
+@@ -2813,26 +2817,24 @@
+ {
+   if (list_length (args) != 2)
+     {
+-      *signal_data = list2 (build_string ("Predicate `match' requires two "
++      *signal_data = list2 (build_string ("Predicate `match?' requires two "
+ 					  "arguments but got"),
+ 			    Flength (args));
+       return false;
+     }
+-  Lisp_Object regexp = XCAR (args);
+-  Lisp_Object capture_name = XCAR (XCDR (args));
++  Lisp_Object arg1 = XCAR (args);
++  Lisp_Object arg2 = XCAR (XCDR (args));
++  Lisp_Object regexp = SYMBOLP (arg2) ? arg1 : arg2;
++  Lisp_Object capture_name = SYMBOLP (arg2) ? arg2 : arg1;
+ 
+-  /* It's probably common to get the argument order backwards.  Catch
+-     this mistake early and show helpful explanation, because Emacs
+-     loves you.  (We put the regexp first because that's what
+-     string-match does.)  */
+-  if (!STRINGP (regexp))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The first argument to `match' should "
+-		            "be a regexp string, not a capture name"));
+-  if (!SYMBOLP (capture_name))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The second argument to `match' should "
+-		            "be a capture name, not a string"));
++  if (!STRINGP (regexp) || !SYMBOLP (capture_name))
++    {
++      *signal_data = list2 (build_string ("Predicate `match?' takes a regexp "
++	                                  "and a node capture (order doesn't "
++					  "matter), but got"),
++			    Flength (args));
++      return false;
++    }
+ 
+   Lisp_Object node = Qnil;
+   if (!treesit_predicate_capture_name_to_node (capture_name, captures, &node,
+@@ -4192,8 +4194,11 @@
+   DEFSYM (QCstar, ":*");
+   DEFSYM (QCplus, ":+");
+   DEFSYM (QCequal, ":equal");
++  DEFSYM (QCeq_q, ":eq?");
+   DEFSYM (QCmatch, ":match");
++  DEFSYM (QCmatch_q, ":match?");
+   DEFSYM (QCpred, ":pred");
++  DEFSYM (QCpred_q, ":pred?");
+ 
+   DEFSYM (Qnot_found, "not-found");
+   DEFSYM (Qsymbol_error, "symbol-error");
+@@ -4325,11 +4330,11 @@
+   staticpro (&Vtreesit_str_plus);
+   Vtreesit_str_plus = build_pure_c_string ("+");
+   staticpro (&Vtreesit_str_pound_equal);
+-  Vtreesit_str_pound_equal = build_pure_c_string ("#equal");
++  Vtreesit_str_pound_equal = build_pure_c_string ("#eq?");
+   staticpro (&Vtreesit_str_pound_match);
+-  Vtreesit_str_pound_match = build_pure_c_string ("#match");
++  Vtreesit_str_pound_match = build_pure_c_string ("#match?");
+   staticpro (&Vtreesit_str_pound_pred);
+-  Vtreesit_str_pound_pred = build_pure_c_string ("#pred");
++  Vtreesit_str_pound_pred = build_pure_c_string ("#pred?");
+   staticpro (&Vtreesit_str_open_bracket);
+   Vtreesit_str_open_bracket = build_pure_c_string ("[");
+   staticpro (&Vtreesit_str_close_bracket);
+@@ -4341,11 +4346,11 @@
+   staticpro (&Vtreesit_str_space);
+   Vtreesit_str_space = build_pure_c_string (" ");
+   staticpro (&Vtreesit_str_equal);
+-  Vtreesit_str_equal = build_pure_c_string ("equal");
++  Vtreesit_str_equal = build_pure_c_string ("eq?");
+   staticpro (&Vtreesit_str_match);
+-  Vtreesit_str_match = build_pure_c_string ("match");
++  Vtreesit_str_match = build_pure_c_string ("match?");
+   staticpro (&Vtreesit_str_pred);
+-  Vtreesit_str_pred = build_pure_c_string ("pred");
++  Vtreesit_str_pred = build_pure_c_string ("pred?");
+   staticpro (&Vtreesit_str_empty);
+   Vtreesit_str_empty = build_pure_c_string ("");
+ 

--- a/packages/jdtls/build.ncl
+++ b/packages/jdtls/build.ncl
@@ -1,0 +1,48 @@
+let { Attrs, BuildSpec, Local, OutputBin, OutputLib, Source, .. } = import "minimal.ncl" in
+
+let base = import "../base/build.ncl" in
+let jdk = import "../jdk/build.ncl" in
+let python = import "../python/build.ncl" in
+let tar = import "../tar/build.ncl" in
+
+let version = "1.60.0" in
+let build_stamp = "202606262232" in
+{
+  name = "jdtls",
+  # Eclipse JDT Language Server (Java). Universal jar distribution;
+  # launched through the upstream bin/jdtls wrapper, which needs python
+  # and a JDK (17+) at runtime.
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://download.eclipse.org/jdtls/milestones/%{version}/jdt-language-server-%{version}-%{build_stamp}.tar.gz",
+      sha256 = "e94c303d8198f977930803582738771fd18c52c5492878410bf222b1aa81ef1d",
+    } | Source,
+    base,
+    tar,
+  ],
+
+  runtime_deps = [
+    base,
+    jdk,
+    python,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+    include build_stamp,
+  },
+
+  outputs = {
+    jdtls = { glob = "usr/bin/jdtls" } | OutputBin,
+    install = { glob = "usr/share/jdtls/**", allow_data = true } | OutputLib,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "EPL-2.0",
+      binary_from = "https://download.eclipse.org/jdtls/milestones/",
+    } | Attrs,
+} | BuildSpec

--- a/packages/jdtls/build.sh
+++ b/packages/jdtls/build.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -euo pipefail
 
 # The distribution is a tarbomb (bin/, plugins/, features/, config_*/);
 # unpack it under /usr/share/jdtls.
@@ -13,15 +13,16 @@ tar xzf "jdt-language-server-${MINIMAL_ARG_VERSION}-${MINIMAL_ARG_BUILD_STAMP}.t
 # area, leaving the writable cascaded one to default to ~/.eclipse. With
 # /usr read-only and $HOME not necessarily writable (sessions run as
 # `build` with HOME=/), neither default works, so point both at a cache
-# dir. The -data key mirrors upstream's sha1(basename(cwd)) scheme so the
-# workspace dir is the same one the bare launcher would pick. Caller
-# supplied -data / -configuration still win: argparse and the Equinox
-# launcher both take the last occurrence.
+# dir. The -data key hashes the full canonical workspace path (upstream
+# hashes only basename(cwd), which collides for same-named projects and
+# trips Eclipse's workspace lock). Caller-supplied -data /
+# -configuration still win: argparse and the Equinox launcher both take
+# the last occurrence.
 mkdir -p "$OUTPUT_DIR/usr/bin"
 cat > "$OUTPUT_DIR/usr/bin/jdtls" << 'EOF'
 #!/bin/sh
 CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/jdtls"
-DATA="$CACHE/jdtls-$(printf '%s' "$(basename "$PWD")" | sha1sum | cut -c1-40)"
+DATA="$CACHE/jdtls-$(pwd -P | sha1sum | cut -c1-40)"
 exec python3 /usr/share/jdtls/bin/jdtls -configuration "$CACHE/config" -data "$DATA" "$@"
 EOF
 chmod +x "$OUTPUT_DIR/usr/bin/jdtls"

--- a/packages/jdtls/build.sh
+++ b/packages/jdtls/build.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -ex
+
+# The distribution is a tarbomb (bin/, plugins/, features/, config_*/);
+# unpack it under /usr/share/jdtls.
+INSTALL="$OUTPUT_DIR/usr/share/jdtls"
+mkdir -p "$INSTALL"
+tar xzf "jdt-language-server-${MINIMAL_ARG_VERSION}-${MINIMAL_ARG_BUILD_STAMP}.tar.gz" -C "$INSTALL"
+
+# Wrapper: the upstream bin/jdtls python launcher only knows $HOME/.cache
+# for its per-workspace -data dir (it ignores XDG_CACHE_HOME), and hands
+# Equinox the shipped config_linux as a *read-only shared* configuration
+# area, leaving the writable cascaded one to default to ~/.eclipse. With
+# /usr read-only and $HOME not necessarily writable (sessions run as
+# `build` with HOME=/), neither default works, so point both at a cache
+# dir. The -data key mirrors upstream's sha1(basename(cwd)) scheme so the
+# workspace dir is the same one the bare launcher would pick. Caller
+# supplied -data / -configuration still win: argparse and the Equinox
+# launcher both take the last occurrence.
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cat > "$OUTPUT_DIR/usr/bin/jdtls" << 'EOF'
+#!/bin/sh
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/jdtls"
+DATA="$CACHE/jdtls-$(printf '%s' "$(basename "$PWD")" | sha1sum | cut -c1-40)"
+exec python3 /usr/share/jdtls/bin/jdtls -configuration "$CACHE/config" -data "$DATA" "$@"
+EOF
+chmod +x "$OUTPUT_DIR/usr/bin/jdtls"

--- a/packages/lua-language-server/build.ncl
+++ b/packages/lua-language-server/build.ncl
@@ -1,0 +1,57 @@
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, OutputLib, Source, Test, .. } = import "minimal.ncl" in
+
+let { target, .. } = import "config.ncl" in
+
+let base = import "../base/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+let tar = import "../tar/build.ncl" in
+
+let version = "3.19.1" in
+{
+  name = "lua-language-server",
+  # LuaLS (sumneko) language server, repackaged from the official
+  # prebuilt Linux release tarballs.
+  build_deps = [
+    { file = "build.sh" } | Local,
+    match {
+      { arch = 'Amd64, .. } =>
+        {
+          url = "https://github.com/LuaLS/lua-language-server/releases/download/%{version}/lua-language-server-%{version}-linux-x64.tar.gz",
+          sha256 = "e9235d2d72ef55bc41cf8c99cda2ed64777682024b4bb81f5dea425060c5cbb8",
+        } | Source,
+      { arch = 'Arm64, .. } =>
+        {
+          url = "https://github.com/LuaLS/lua-language-server/releases/download/%{version}/lua-language-server-%{version}-linux-arm64.tar.gz",
+          sha256 = "abd2572e8fc929dc838a81ffb8473c5bce0bf39bfe8edb4b120b3b623176ce83",
+        } | Source,
+    } target,
+    base,
+    tar,
+  ],
+
+  runtime_deps = [
+    base,
+    glibc,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    lua-language-server = { glob = "usr/bin/lua-language-server" } | OutputBin,
+    install = { glob = "usr/share/lua-language-server/**", allow_data = true } | OutputLib,
+  },
+
+  tests = {
+    version = standaloneTest "lua-language-server --version",
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      binary_from = "https://github.com/LuaLS/lua-language-server/releases",
+    } | Attrs,
+} | BuildSpec

--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -euo pipefail
 
 # The release is a tarbomb (bin/, script/, meta/, locale/, main.lua, ...);
 # unpack it under /usr/share/lua-language-server.

--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -ex
+
+# The release is a tarbomb (bin/, script/, meta/, locale/, main.lua, ...);
+# unpack it under /usr/share/lua-language-server.
+INSTALL="$OUTPUT_DIR/usr/share/lua-language-server"
+mkdir -p "$INSTALL"
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  SUFFIX="linux-x64" ;;
+  aarch64) SUFFIX="linux-arm64" ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+tar xzf "lua-language-server-${MINIMAL_ARG_VERSION}-${SUFFIX}.tar.gz" -C "$INSTALL"
+
+# Wrapper: the server resolves its resources relative to the real binary,
+# but by default also writes logs and generated meta files next to the
+# install root, which is read-only here — point those at writable paths.
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cat > "$OUTPUT_DIR/usr/bin/lua-language-server" << 'EOF'
+#!/bin/sh
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/lua-language-server"
+mkdir -p "$CACHE/log" "$CACHE/meta"
+exec /usr/share/lua-language-server/bin/lua-language-server \
+  --logpath="$CACHE/log" --metapath="$CACHE/meta" "$@"
+EOF
+chmod +x "$OUTPUT_DIR/usr/bin/lua-language-server"

--- a/packages/ruby-lsp/build.ncl
+++ b/packages/ruby-lsp/build.ncl
@@ -1,4 +1,4 @@
-let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Test, .. } = import "minimal.ncl" in
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
 
 let base = import "../base/build.ncl" in
 let make = import "../make/build.ncl" in
@@ -8,14 +8,35 @@ let toolchain = import "../toolchain/build.ncl" in
 let version = "0.26.10" in
 {
   name = "ruby-lsp",
-  # Shopify's Ruby language server, vendored into its own GEM_HOME at
-  # build time (same needs-internet pattern as mermaid-cli's npm
-  # install; the version is pinned here and passed to `gem install`).
-  # `make` is needed because the prism and rbs dependencies compile
-  # native extensions via mkmf, and neither base nor toolchain carries
-  # make as a runtime dep.
+  # Shopify's Ruby language server, vendored into its own gem dir at
+  # build time. The complete RubyGems closure is pinned below as .gem
+  # Sources and installed offline with `gem install --local`: a bare
+  # `gem install ruby-lsp` would resolve its floating version ranges
+  # (language_server-protocol ~> 3.17.0, rbs >= 3 < 5, ...) against
+  # rubygems.org at build time, so two builds of the same spec could
+  # pick different inputs. rbs's prism/tsort deps are satisfied by Ruby
+  # 4.0's default gems and its jar-dependencies dep is JRuby-only, so
+  # none of those need vendoring. `make` is needed because the rbs
+  # dependency compiles a native extension via mkmf, and neither base
+  # nor toolchain carries make.
   build_deps = [
     { file = "build.sh" } | Local,
+    {
+      url = "https://rubygems.org/downloads/ruby-lsp-%{version}.gem",
+      sha256 = "e67284af94423531f6b9a583350596421b5a6a4dd93083f1c2ba03da7c23bbed",
+    } | Source,
+    {
+      url = "https://rubygems.org/downloads/language_server-protocol-3.17.0.6.gem",
+      sha256 = "5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0",
+    } | Source,
+    {
+      url = "https://rubygems.org/downloads/logger-1.7.0.gem",
+      sha256 = "196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203",
+    } | Source,
+    {
+      url = "https://rubygems.org/downloads/rbs-4.1.3.gem",
+      sha256 = "0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4",
+    } | Source,
     base,
     make,
     ruby,
@@ -33,12 +54,6 @@ let version = "0.26.10" in
     ruby,
     toolchain,
   ],
-
-  needs =
-    {
-      dns = {},
-      internet = {},
-    } | Needs,
 
   cmd = "./build.sh",
   build_args = {

--- a/packages/ruby-lsp/build.ncl
+++ b/packages/ruby-lsp/build.ncl
@@ -1,0 +1,85 @@
+let { standaloneTest, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Test, .. } = import "minimal.ncl" in
+
+let base = import "../base/build.ncl" in
+let make = import "../make/build.ncl" in
+let ruby = import "../ruby/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let version = "0.26.10" in
+{
+  name = "ruby-lsp",
+  # Shopify's Ruby language server, vendored into its own GEM_HOME at
+  # build time (same needs-internet pattern as mermaid-cli's npm
+  # install; the version is pinned here and passed to `gem install`).
+  # `make` is needed because the prism and rbs dependencies compile
+  # native extensions via mkmf, and neither base nor toolchain carries
+  # make as a runtime dep.
+  build_deps = [
+    { file = "build.sh" } | Local,
+    base,
+    make,
+    ruby,
+    toolchain,
+  ],
+
+  # make + toolchain at *runtime* as well: ruby-lsp always starts through a
+  # per-project composed bundle (`bundle install` at launch, see build.sh),
+  # and that bundle contains native-extension gems (prism, rbs, debug,
+  # io-console, ...) that mkmf must be able to compile in the session.
+  # Without a compiler the install fails and eglot reports "server died".
+  runtime_deps = [
+    base,
+    make,
+    ruby,
+    toolchain,
+  ],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    ruby-lsp = { glob = "usr/bin/ruby-lsp" } | OutputBin,
+    gems = { glob = "usr/lib/ruby-lsp/**", allow_executable = true } | OutputData,
+  },
+
+  tests = {
+    version = standaloneTest "ruby-lsp --version",
+
+    # Guards the two regressions behind eglot's "server died": ruby-lsp
+    # composes a per-project bundle at launch and runs `bundle install`,
+    # which requires (1) the wrapper to select a writable GEM_HOME under
+    # XDG_CACHE_HOME rather than the read-only vendored store, and (2) a
+    # runtime env that can compile native-extension gems (prism, debug,
+    # io-console, ...). The full composed startup needs rubygems.org and
+    # floats to the newest release, so it is deliberately not tested here;
+    # these two offline checks cover the failure modes we actually hit.
+    composed_bundle_prereqs =
+      {
+        class = 'Standalone,
+        test_deps = [],
+        cmds = [
+          ["/bin/bash", "-c", "export XDG_CACHE_HOME=/tmp/xdg; ruby-lsp --version && test -d /tmp/xdg/ruby-lsp/gems"],
+          ["/bin/bash", "-c", "cd $(mktemp -d) && printf 'void Init_t(void) {}\\n' > t.c && printf 'require \"mkmf\"\\ncreate_makefile(\"t\")\\n' > extconf.rb && ruby extconf.rb && make && test -f t.so"],
+        ],
+      } | Test,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "Shopify",
+        repo = "ruby-lsp",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/ruby-lsp/build.sh
+++ b/packages/ruby-lsp/build.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -ex
+
+# Vendor the gem (and its dependencies, e.g. prism) into a dedicated
+# GEM_HOME under the package's own prefix.
+GEMS="$OUTPUT_DIR/usr/lib/ruby-lsp/gems"
+mkdir -p "$GEMS"
+export GEM_HOME="$GEMS"
+export GEM_PATH="$GEMS"
+gem install ruby-lsp -v "$MINIMAL_ARG_VERSION" --no-document
+
+# Drop install residue that is either non-reproducible (gem_make.out and
+# mkmf.log record a per-run temp dir name like .gem.20260823-3-k0190w)
+# or dead weight at runtime (the downloaded .gem archives and the native
+# extensions' intermediate objects). The built .so files live in both
+# extensions/ and the gem's lib/ dir, so nothing needed survives only
+# under ext/.
+rm -rf "$GEMS/cache"
+find "$GEMS" \( -name gem_make.out -o -name mkmf.log \) -delete
+find "$GEMS/gems" -path '*/ext/*' -name '*.o' -delete
+
+# Wrapper: keep the vendored gems on GEM_PATH so the launcher bootstraps
+# without a network, but point GEM_HOME at a writable per-user dir.
+# ruby-lsp always starts through a per-project "composed bundle"
+# (ruby-lsp-launcher writes a private Gemfile and runs `bundle install`,
+# pulling the project's gems plus the newest ruby-lsp), and bundler's
+# default install target is GEM_HOME — with the read-only vendored store
+# there it dies at startup with Bundler::ReadOnlyFileSystemError, which
+# eglot reports as "server died". Composed installs land in the cache
+# instead and are reused across projects.
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cat > "$OUTPUT_DIR/usr/bin/ruby-lsp" << 'EOF'
+#!/bin/sh
+GEM_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/ruby-lsp/gems"
+mkdir -p "$GEM_CACHE"
+export GEM_HOME="$GEM_CACHE"
+export GEM_PATH="$GEM_CACHE:/usr/lib/ruby-lsp/gems"
+exec /usr/lib/ruby-lsp/gems/bin/ruby-lsp "$@"
+EOF
+chmod +x "$OUTPUT_DIR/usr/bin/ruby-lsp"

--- a/packages/ruby-lsp/build.sh
+++ b/packages/ruby-lsp/build.sh
@@ -1,13 +1,15 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -euo pipefail
 
-# Vendor the gem (and its dependencies, e.g. prism) into a dedicated
-# GEM_HOME under the package's own prefix.
+# Vendor the gem and its pinned dependency closure (the .gem Sources
+# fetched into the cwd) into a dedicated GEM_HOME under the package's
+# own prefix. --local resolves dependencies from the .gem files in the
+# working directory only — no rubygems.org access at build time.
 GEMS="$OUTPUT_DIR/usr/lib/ruby-lsp/gems"
 mkdir -p "$GEMS"
 export GEM_HOME="$GEMS"
 export GEM_PATH="$GEMS"
-gem install ruby-lsp -v "$MINIMAL_ARG_VERSION" --no-document
+gem install --local --no-document "ruby-lsp-$MINIMAL_ARG_VERSION.gem"
 
 # Drop install residue that is either non-reproducible (gem_make.out and
 # mkmf.log record a per-run temp dir name like .gem.20260823-3-k0190w)

--- a/packages/zls/build.ncl
+++ b/packages/zls/build.ncl
@@ -1,0 +1,58 @@
+let { standaloneTest, upstream, Attrs, BuildSpec, Local, Needs, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+
+let base = import "../base/build.ncl" in
+let zig = import "../zig/build.ncl" in
+
+let version = "0.16.0" in
+{
+  name = "zls",
+  # Zig language server, built from source with the zig package.
+  # zls versions track zig minor versions; keep this in lockstep with
+  # the upstream zig package (currently 0.16.0).
+  #
+  # Needs network: `zig build` fetches the dependencies declared in
+  # build.zig.zon (known_folders, diffz, lsp_kit, ...), each verified
+  # against the content hash pinned in that file.
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/zigtools/zls/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "e7c5936f5b3a057ce851be0876e4e259b5c4d02f9aae038cd24a5d6b586b029f",
+      extract = true,
+      strip_prefix = "zls-%{version}",
+    } | Source,
+    base,
+    zig,
+  ],
+
+  # No runtime deps: zls does not link libc, so the pinned-target build
+  # in build.sh yields a fully static executable.
+  runtime_deps = [],
+
+  needs =
+    {
+      dns = {},
+      internet = {},
+    } | Needs,
+
+  cmd = "./build.sh",
+
+  outputs = {
+    zls = { glob = "usr/bin/zls" } | OutputBin,
+  },
+
+  tests = {
+    version = standaloneTest "zls --version",
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "zigtools",
+        repo = "zls",
+      },
+    } | Attrs,
+} | BuildSpec

--- a/packages/zls/build.sh
+++ b/packages/zls/build.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -ex
+
+# Keep zig's caches inside the build tree: hermetic (no $HOME dependency)
+# and reproducible. The dependencies declared in build.zig.zon are fetched
+# into the global cache and verified against the content hashes pinned
+# there.
+export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="$PWD/.zig-local-cache"
+
+# Pin the target the way upstream's own release step does (build.zig's
+# release_targets are bare `{ .cpu_arch = .aarch64/.x86_64, .os_tag =
+# .linux }` queries): an explicit arch selects the *baseline* CPU model,
+# whereas a bare `zig build` tunes the code to the native CPU of whichever
+# machine ran the build, making the output host-dependent and not
+# reproducible across builders. zls does not link libc, so the result is
+# a fully static executable with no runtime deps; there is no glibc
+# version to pin (cf. fx, which does link libc and pins gnu.2.43).
+case "$(uname -m)" in
+  x86_64)  ZTARGET="x86_64-linux" ;;
+  aarch64) ZTARGET="aarch64-linux" ;;
+  *)       echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# ReleaseSafe is what upstream ships (.github/workflows/artifacts.yml);
+# keep its debug info so a server panic reports source locations.
+zig build -Doptimize=ReleaseSafe -Dtarget="$ZTARGET" --prefix "$OUTPUT_DIR/usr"

--- a/packages/zls/build.sh
+++ b/packages/zls/build.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -euo pipefail
 
 # Keep zig's caches inside the build tree: hermetic (no $HOME dependency)
 # and reproducible. The dependencies declared in build.zig.zon are fetched


### PR DESCRIPTION
## Summary

- tune emacs to use ~/.config/emacs/init.el (e.g. from a loadout)
- add emacs-site-lisp with treesitter to replace emacs-config-dev1
- add some new LSP servers (ruby, zig, java)
- add dev-language-servers as a convenience meta package to pull in LSP servers for many languages (simpler deps for loadouts)

<!--
Thanks for the contribution! A few quick notes:

- For anything non-trivial, please open an issue first so we can align on approach.
- Before we can merge, you'll need to accept our Contributor License Agreement.
  CLA Assistant will prompt you automatically on this PR — see CONTRIBUTING.md
  for details.
- Small, focused PRs are easier to review and faster to merge.
-->



<!-- What does this PR do, and why? "Why" is more useful than "what". -->

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Optional but appreciated. -->

## Changes

<!-- High-level list of what changed. For a new package, mention upstream version and source URL. For an update, the old → new version. -->

-

## Checklist

- [ ] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [ ] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [ ] `min check` passes for the affected packages/harnesses.
- [ ] `min patched-build <name>` succeeds for any package I added or modified.
- [ ] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [ ] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to, known limitations, follow-up work, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development language-server bundle covering Bash, ESLint, Go, Java, Lua, Python, Ruby, Rust, TypeScript, Zig, and more.
  * Added packages for JDTLS, Lua Language Server, Ruby LSP, and ZLS.
  * Added an Emacs site-lisp package with language modes, libraries, Flymake backends, and Tree-sitter grammars.

* **Bug Fixes**
  * Improved Emacs compatibility with Tree-sitter 0.26.
  * Enhanced Emacs configuration and cache handling for standalone use.
  * Improved language-server launchers with writable, isolated cache handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->