### PR TITLE
feat: added package for ols

### DIFF
--- a/packages/odin/build.ncl
+++ b/packages/odin/build.ncl
@@ -10,9 +10,11 @@ let lua52 = import "../lua52/build.ncl" in
 let lua53 = import "../lua53/build.ncl" in
 let lua54 = import "../lua54/build.ncl" in
 let make = import "../make/build.ncl" in
+let patch = import "../patch/build.ncl" in
 let raygui = import "../raygui/build.ncl" in
 let raylib = import "../raylib/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
+let util-linux = import "../util-linux/build.ncl" in
 
 let version = "dev-2026-07a" in
 # Odin stamps its own `ODIN_VERSION` from the month of the release commit.
@@ -25,6 +27,7 @@ let box2d_version = "3.1.1" in
 
   build_deps = [
     { file = "build.sh" } | Local,
+    { file = "odin-deterministic-serial-thread-pool.patch" } | Local,
     {
       url = "https://github.com/odin-lang/Odin/archive/refs/tags/%{version}.tar.gz",
       sha256 = "8f4f02fd9a3426b441cd0dfbe0aca1b95fd93c95d86940fcb4417ef6044c83cd",
@@ -42,6 +45,7 @@ let box2d_version = "3.1.1" in
     cmake, # box2d
     llvm,
     make, # vendor/{stb,cgltf}/src ship Makefiles we build the bindings' C libs with
+    patch,
     # vendor/raylib carries bindings and checked-in binaries but no C source at
     # all, so unlike the other vendor libraries there is nothing to compile in
     # place -- the libraries come from these packages instead.
@@ -119,6 +123,27 @@ let box2d_version = "3.1.1" in
         cmds = [
           ["/bin/bash", "-c", "printf 'package main\\nimport \"core:fmt\"\\nmain :: proc() { fmt.println(\"ok\") }\\n' > hellope.odin"],
           ["/bin/odin", "run", "hellope.odin", "-file"],
+        ],
+      } | Test,
+
+    # Every Odin package in this registry gets its reproducibility from
+    # `-no-threaded-checker`, which the patch above turns into a full
+    # serialisation of the compiler. Upstream's flag only covers the
+    # procedure-body pass; the parser and entity-collection phases keep racing
+    # for entity ids, and those ids order the emitted module -- so the same
+    # source produces a differently laid out binary each run. `setarch -R` is
+    # the other half: codegen also walks pointer-keyed maps, so the order
+    # follows heap addresses too. Compile twice, require a byte-identical
+    # result, and this stops being something a consumer has to rediscover.
+    # Both compilations have to write to the same `-out:` path, which odin bakes
+    # into the binary -- two names, two different results, determinism or not.
+    deterministic_output =
+      {
+        class = 'Standalone,
+        test_deps = [base, glibc, util-linux],
+        cmds = [
+          ["/bin/bash", "-c", "printf 'package main\\nimport \"core:fmt\"\\nmain :: proc() { fmt.println(\"ok\") }\\n' > det.odin"],
+          ["/bin/bash", "-c", "set -eu; build() { setarch --addr-no-randomize /bin/odin build det.odin -file -out:det -o:speed -no-threaded-checker -extra-linker-flags:'-Wl,--build-id=none'; }; build; cp det det.first; build; test \"$(sha256sum < det)\" = \"$(sha256sum < det.first)\""],
         ],
       } | Test,
 

--- a/packages/odin/build.sh
+++ b/packages/odin/build.sh
@@ -3,6 +3,11 @@ set -ex
 
 BUILD_ROOT="$PWD"
 
+# Makes `-no-threaded-checker` serialise every compiler phase, not just the
+# procedure-body pass, so that odin can emit byte-identical binaries. Nothing in
+# the default build path changes; see the patch header for the full reasoning.
+patch -Np1 -i "$BUILD_ROOT/odin-deterministic-serial-thread-pool.patch"
+
 # build_odin.sh bakes ODIN_VERSION into the compiler. Without a .git directory
 # it falls back to `date +%Y-%m`, which reads the wall clock and would make the
 # build non-reproducible; pin it to the month of the release instead. Fail loudly

--- a/packages/odin/odin-deterministic-serial-thread-pool.patch
+++ b/packages/odin/odin-deterministic-serial-thread-pool.patch
@@ -1,0 +1,30 @@
+Make -no-threaded-checker produce reproducible output.
+
+Odin numbers entities from a global counter as it parses and checks, and those
+ids decide the order procedures and globals are emitted into the LLVM module.
+Every phase that hands out ids runs on the thread pool, so the numbering -- and
+with it the layout of the final binary -- is a race: building the same source
+twice gives two different binaries.
+
+-no-threaded-checker already exists and already serialises check_procedure_bodies,
+but the parser, entity collection and export phases keep using the pool
+regardless, so the flag alone is not enough. Drop the pool to zero workers when
+it is set: thread_pool_wait then drains the queue on the main thread in push
+order, which serialises every phase at once rather than each of them needing its
+own opt-out.
+
+This is inert unless -no-threaded-checker is passed; the default build is
+untouched.
+
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -16,6 +16,9 @@
+ gb_internal void init_global_thread_pool(void) {
+ 	isize thread_count = gb_max(build_context.thread_count, 1);
+ 	isize worker_count = thread_count; // +1
++	if (build_context.no_threaded_checker) {
++		worker_count = 0;
++	}
+ 	thread_pool_init(&global_thread_pool, worker_count, "ThreadPoolWorker");
+ }
+ gb_internal bool thread_pool_add_task(WorkerTaskProc *proc, void *data) {

--- a/packages/ols/build.ncl
+++ b/packages/ols/build.ncl
@@ -1,0 +1,120 @@
+let { standaloneTest, Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let odin = import "../odin/build.ncl" in
+let util-linux = import "../util-linux/build.ncl" in
+
+let version = "dev-2026-06" in
+{
+  name = "ols",
+
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/DanielGavin/ols/archive/refs/tags/%{version}.tar.gz",
+      sha256 = "f8055ff723994dc4debc02817c230d0173c43a23df4a9d6a7104fea69bfeeb79",
+      extract = true,
+    } | Source,
+    base,
+    util-linux,
+  ],
+
+  runtime_deps = [
+    # ols is an Odin program, but odin is a runtime dep rather than a build-only
+    # one: the server shells out to `odin root` on initialize to locate the
+    # base/core/vendor collections it indexes, and falls back to $ODIN_ROOT or
+    # the directory of the `odin` binary on PATH. Without odin present it comes
+    # up with no standard library at all.
+    odin,
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    ols = { glob = "usr/bin/ols" } | OutputBin,
+    odinfmt = { glob = "usr/bin/odinfmt" } | OutputBin,
+    # ols cannot resolve `builtin`/`intrinsics` declarations without these two
+    # source files. It looks for them next to the binary first, then at this
+    # fixed path -- which is the one it is packaged at, since /usr/bin/builtin
+    # is not somewhere a directory belongs.
+    builtin = { glob = "usr/share/ols/builtin/*" } | OutputData,
+    license = { glob = "usr/share/ols/LICENSE" } | OutputData,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "DanielGavin",
+        repo = "ols",
+      },
+    } | Attrs,
+
+  tests = {
+    smoketest = standaloneTest "/bin/ols version",
+
+    odinfmt =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "printf 'package main\\nmain::proc(){x:=1;_=x}\\n' > f.odin"],
+          ["/bin/odinfmt", "-w", "f.odin"],
+          ["/bin/bash", "-c", "grep -q 'main :: proc() {' f.odin"],
+        ],
+      } | Test,
+
+    # Drives a real LSP session over stdio and asks for hover twice, because the
+    # two answers fail for different reasons:
+    #
+    #   len          resolves out of the `builtin` output above. ols logs an
+    #                error and answers everything else normally if that
+    #                directory is missing, so nothing but a builtin lookup
+    #                notices.
+    #   fmt.println  resolves out of the core collection, which ols finds by
+    #                running `odin root`. With odin absent from PATH this hover
+    #                comes back null while the `len` one still succeeds -- so it
+    #                is the half that pins the runtime dep.
+    lsp_hover =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          [
+            "/bin/bash",
+            "-c",
+            m%"
+          set -eu
+          P=/tmp/olsproj
+          mkdir -p $P
+          SRC='package main\n\nimport "core:fmt"\n\nmain :: proc() {\n\tn := len([]int{1})\n\tfmt.println(n)\n}\n'
+          printf '%b' "$SRC" > $P/main.odin
+          # The same text has to go over the wire as a JSON string literal.
+          JSON_SRC=${SRC//\"/\\\"}
+
+          send() { printf 'Content-Length: %d\r\n\r\n%s' "${#1}" "$1"; }
+          hover() { send "{\"jsonrpc\":\"2.0\",\"id\":$1,\"method\":\"textDocument/hover\",\"params\":{\"textDocument\":{\"uri\":\"file://$P/main.odin\"},\"position\":{\"line\":$2,\"character\":$3}}}"; }
+
+          OUT=$({
+            send "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"processId\":null,\"rootUri\":\"file://$P\",\"capabilities\":{}}}"
+            send '{"jsonrpc":"2.0","method":"initialized","params":{}}'
+            send "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file://$P/main.odin\",\"languageId\":\"odin\",\"version\":1,\"text\":\"$JSON_SRC\"}}}"
+            hover 2 5 7
+            hover 3 6 8
+            send '{"jsonrpc":"2.0","id":4,"method":"shutdown","params":null}'
+            send '{"jsonrpc":"2.0","method":"exit","params":null}'
+          } | /bin/ols)
+
+          check() { printf '%s' "$OUT" | grep -q "$1" || { printf '%s\n' "$OUT" >&2; exit 1; }; }
+          check 'len :: proc(array: Array_Type)'
+          check 'fmt.println :: proc'
+          "%,
+          ],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/ols/build.sh
+++ b/packages/ols/build.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -ex
+
+# The upstream tarball ships its own build.sh at the repo root, so it is left
+# packed under its own directory rather than extracted over ours.
+cd "ols-$MINIMAL_ARG_VERSION"
+
+# Upstream's build.sh is not usable as-is: it stamps VERSION from `date -u` plus
+# `git rev-parse HEAD` (no wall clock in a reproducible build, and no .git here)
+# and compiles with -microarch:native, which bakes the builder's CPU into the
+# binary. Everything else below matches the flags it and ci.sh use.
+#
+# Two more things are needed to make odin's own output reproducible, and both
+# have to be right or the binaries differ between builds:
+#
+#   -no-threaded-checker  The compiler assigns entity ids from a global counter
+#                         as it checks, and those ids order the procedures in
+#                         the emitted module. Off the flag, the work is spread
+#                         over a thread pool and the order is a race. The odin
+#                         package patches this flag to drop the pool to zero
+#                         workers so parsing and codegen serialise with it.
+#   setarch -R            Odin walks pointer-keyed hash maps during codegen, so
+#                         the emitted order also follows heap addresses. With
+#                         ASLR on those move every run; disabling it for the
+#                         compiler process pins them.
+#
+# --build-id=none: odin links through clang, whose default build-id is derived
+# from the output hash and so differs whenever anything else does.
+LINK_FLAGS='-Wl,--build-id=none'
+
+odin_build() {
+  setarch --addr-no-randomize odin build "$@" \
+    -collection:src=src \
+    -o:speed \
+    -no-bounds-check \
+    -no-threaded-checker \
+    -extra-linker-flags:"$LINK_FLAGS"
+}
+
+odin_build src/ -out:ols -define:VERSION="$MINIMAL_ARG_VERSION"
+
+# odinfmt is the formatter half of the project; upstream's release archives ship
+# it alongside ols, and the LSP's formatting request is a thin wrapper over the
+# same code, so users configuring format-on-save want the CLI too.
+odin_build tools/odinfmt/main.odin -file -out:odinfmt
+
+install -D -m 0755 ols      "$OUTPUT_DIR/usr/bin/ols"
+install -D -m 0755 odinfmt  "$OUTPUT_DIR/usr/bin/odinfmt"
+
+# ols searches for the builtin declarations next to its own binary first and
+# then at this fixed path. The former would mean a directory in /usr/bin, so
+# install to the latter -- it is exactly the packaging case it exists for.
+install -D -m 0644 builtin/builtin.odin    "$OUTPUT_DIR/usr/share/ols/builtin/builtin.odin"
+install -D -m 0644 builtin/intrinsics.odin "$OUTPUT_DIR/usr/share/ols/builtin/intrinsics.odin"
+install -D -m 0644 LICENSE                 "$OUTPUT_DIR/usr/share/ols/LICENSE"


### PR DESCRIPTION
## Summary

Adds `ols`, the Odin Language Server, so Odin projects in the registry have editor support.

It's the first Odin-built package here, which surfaced that the `odin` compiler can't emit
reproducible binaries: three identical `odin build` runs produce three different binaries.
Entity ids come from a global counter handed out across the thread pool, and those ids order
procedures in the emitted module. `-no-threaded-checker` already exists but only serialises the
procedure-body pass — parsing, entity collection and export keep racing. Codegen also walks
pointer-keyed maps, so heap addresses feed in too. Since every future Odin package inherits
this, `odin` is patched here rather than working around it in `ols`.

## Changes

- **New package `ols`** — upstream `dev-2026-06` from
  `https://github.com/DanielGavin/ols/archive/refs/tags/dev-2026-06.tar.gz`, built from source
  with the packaged Odin compiler (upstream also publishes prebuilt zips; not used). Installs
  `ols` and `odinfmt` — both are in upstream's release archives, and the LSP formatting request
  is a thin wrapper over odinfmt — plus the `builtin`/`intrinsics` declarations at
  `/usr/share/ols/builtin`, which is the packaging path ols searches after "next to the binary"
  (that would mean a directory inside `/usr/bin`).
- `odin` is a **runtime** dep of `ols`, not build-only: the server runs `odin root` on
  initialize to locate the base/core/vendor collections it indexes.
- Tests for `ols`: `ols version`, an `odinfmt -w` reformat, and an LSP session over stdio that
  hovers twice — `len` (answerable only from the `builtin` output) and `fmt.println`
  (answerable only if `odin root` resolved), so the data output and the runtime dep are each
  pinned by a hover that fails on its own.
- **`packages/odin`: `odin-deterministic-serial-thread-pool.patch`** — 3 lines, drops the
  thread pool to zero workers when `-no-threaded-checker` is set, so `thread_pool_wait` drains
  every phase on the main thread in push order. Inert unless the flag is passed; the default
  build path is untouched.
- `ols` compiles under `setarch --addr-no-randomize` with `-no-threaded-checker` (also
  `-trimpath`-equivalent flags: `--build-id=none`, pinned `-define:VERSION`, and upstream's
  non-reproducible `-microarch:native` dropped).
- **New test `deterministic_output` on `odin`** — compiles the same program twice and requires
  byte-identical output, so this can't silently regress.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [x] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [x] `min check` passes for the affected packages/harnesses.
- [x] `min patched-build <name>` succeeds for any package I added or modified.
- [x] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [x] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

**The odin patch is the part worth scrutiny.** It changes a shipped toolchain package for a
consumer's benefit. Mitigating factors: nothing currently passes `-no-threaded-checker`, so the
default path is bit-for-bit unchanged, and `odin`'s existing tests plus the new one all pass.

**Reproducibility verified by hand**, since `min check` has no repro checker: `ols` and
`odinfmt` each built 3× byte-identically with the patched compiler. Both conditions are load-
bearing — patched compiler *and* `setarch -R`; drop either and the binaries diverge. Also note
both builds must write to the same `-out:` path, which odin bakes into the binary.

**Perf of the serial path:** no measurable cost at `-o:speed` (9.60s → 9.66s on ols; parse and
check are ~1% of a release build, and codegen is single-module there regardless).
`-o:none` is 2× slower serial (0.7s → 1.4s) — that's the interactive path, and nothing passes
the flag by default.

**Known limitation:** reproducibility depends on `setarch` being able to disable ASLR in the
build sandbox. It works today; if it's ever blocked, output silently goes non-deterministic and
the `deterministic_output` test is what catches it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OLS language-server tooling, including `ols` and `odinfmt` executables.
  * Added support files for built-in declarations and compiler intrinsics.
  * Added validation for version reporting, formatting, and language-server hover information.

* **Bug Fixes**
  * Improved deterministic compiler behavior when serialized checking is enabled.

* **Tests**
  * Added reproducibility checks to ensure identical builds produce byte-for-byte matching binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->