### PR TITLE
ci: blast-radius report — leaf vs dependent classification per changed package

### DIFF
--- a/.github/scripts/blast_radius_report.py
+++ b/.github/scripts/blast_radius_report.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Blast-radius report for changed packages (report-only).
+
+For each changed package, answers: if this update is wrong, what breaks?
+
+- TRUE LEAF ......... no recipe imports it, no stack/profile/harness names it;
+                      the blast radius is the package itself.
+- LEAF, REFERENCED .. no recipe imports it, but a non-package .ncl (stack,
+                      profile, ...) references it by name — sessions/stacks
+                      built from those definitions are affected.
+- N DEPENDENTS ...... other recipes import it; both the direct importers and
+                      the full transitive dependent closure are reported,
+                      because "zlib: 62 direct" understates a rebuild that
+                      transitively reaches most of the catalog.
+
+Dependency edges come from two places, both computed from the checkout with
+no network and no `minimal dump`:
+
+1. Recipe imports: `import "../<pkg>/build.ncl"` in packages/*/build.ncl —
+   the real dependency graph as recipes express it (build and runtime deps
+   are both declared this way).
+2. Name references: any quoted string in a non-package .ncl (stacks/,
+   profiles/, ...) matching a package name. Stacks reference packages by
+   name (`build_packages = ["go", ...]`), not by import, so an import-only
+   scan silently misclassifies them as leaves. String matching over-demotes
+   (a quoted word that happens to equal a package name counts) — that is the
+   safe direction for a classifier whose consumers may one day fast-path
+   "leaf" updates; see inbox#20 for the #trivial fast-path this composes
+   with.
+
+The final summary line is stable and machine-readable on purpose:
+`blast-radius: ALL-TRUE-LEAVES` or `blast-radius: HAS-DEPENDENTS` — a future
+automation lane (auto-merge for trivial leaf bumps) can key on it without
+re-parsing the table.
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+IMPORT_RE = re.compile(r'import "\.\./([a-z0-9_.+-]+)/build\.ncl"')
+STRING_RE = re.compile(r'"([a-z0-9_.+-]+)"')
+
+
+def load_graph(root: Path):
+    pkg_dir = root / "packages"
+    pkgs = {p.name for p in pkg_dir.iterdir() if (p / "build.ncl").is_file()}
+    importers = {p: set() for p in pkgs}
+    for p in sorted(pkgs):
+        src = (pkg_dir / p / "build.ncl").read_text(encoding="utf-8", errors="replace")
+        for dep in set(IMPORT_RE.findall(src)):
+            if dep in pkgs and dep != p:
+                importers[dep].add(p)
+
+    name_refs = {}  # pkg -> sorted list of non-package .ncl files naming it
+    for f in sorted(root.rglob("*.ncl")):
+        rel = f.relative_to(root)
+        if rel.parts[0] in ("packages",) or ".git" in rel.parts:
+            continue
+        src = f.read_text(encoding="utf-8", errors="replace")
+        for s in set(STRING_RE.findall(src)):
+            if s in pkgs:
+                name_refs.setdefault(s, []).append(str(rel))
+    return pkgs, importers, name_refs
+
+
+def transitive_dependents(pkg, importers):
+    seen, stack = set(), [pkg]
+    while stack:
+        for d in importers.get(stack.pop(), ()):
+            if d not in seen:
+                seen.add(d)
+                stack.append(d)
+    seen.discard(pkg)  # a bootstrap cycle can reach back to the package itself
+    return seen
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--packages-file", required=True)
+    ap.add_argument("--root", default=".")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    changed = [
+        line.strip()
+        for line in Path(args.packages_file).read_text().splitlines()
+        if line.strip()
+    ]
+    pkgs, importers, name_refs = load_graph(root)
+
+    rows = []
+    all_true_leaves = True
+    for p in changed:
+        if p not in pkgs:
+            rows.append((p, "removed / not a package", "—", "n/a"))
+            continue
+        direct = sorted(importers[p])
+        refs = name_refs.get(p, [])
+        if not direct and not refs:
+            rows.append((p, "**TRUE LEAF**", "—", "itself only"))
+        elif not direct:
+            all_true_leaves = False
+            rows.append(
+                (p, "leaf, referenced by", ", ".join(f"`{r}`" for r in refs[:3]), "stack/profile sessions")
+            )
+        else:
+            all_true_leaves = False
+            trans = transitive_dependents(p, importers)
+            shown = ", ".join(f"`{d}`" for d in direct[:5]) + (" …" if len(direct) > 5 else "")
+            rows.append(
+                (p, f"{len(direct)} direct / {len(trans)} transitive", shown, f"{len(trans)} packages rebuild")
+            )
+
+    verdict = "ALL-TRUE-LEAVES" if (all_true_leaves and changed) else "HAS-DEPENDENTS"
+    lines = [
+        "## Blast radius",
+        "",
+        "_Report-only. \"If this update is wrong, what breaks?\" — computed from recipe",
+        "imports plus stack/profile name references, no network._",
+        "",
+        "| package | dependents | direct importers | blast radius |",
+        "|---|---|---|---|",
+    ]
+    for r in rows:
+        lines.append("| `%s` | %s | %s | %s |" % r)
+    lines += ["", f"`blast-radius: {verdict}`"]
+
+    out = "\n".join(lines) + "\n"
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(out)
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,0 +1,62 @@
+name: blast-radius
+
+# REPORT-ONLY, NON-BLOCKING. For each package a PR changes, reports its
+# blast radius: TRUE LEAF (nothing depends on it — the safest possible
+# update), leaf-but-referenced (a stack/profile names it), or its direct +
+# transitive dependent counts. Writes nothing, needs no secrets, and MUST
+# NOT be a branch-protection required check. Complements trivial-update.yml
+# (diff shape) — together they identify the "trivial bump to a true leaf"
+# class that inbox#20's fast path is about: a change whose worst case is
+# confined to the package itself.
+#
+# Pure checkout scan: recipe `import "../<pkg>/build.ncl"` edges plus
+# quoted name references in non-package .ncl files (stacks reference
+# packages by NAME, not import — an import-only scan would misclassify
+# every stack's tools as leaves). No `minimal dump`, no network.
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: blast-radius-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to a SHA (matches trivial-update.yml / dwell.yml).
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # base..head reachable for the changed-file diff
+
+      - name: Detect changed packages
+        id: changed
+        env:
+          # SHAs via env per repo convention (zizmor template-injection).
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'packages/' \
+            | cut -d/ -f2 | sort -u > pkgs.txt || : > pkgs.txt
+          echo "count=$(wc -l < pkgs.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Blast-radius report
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -uo pipefail
+          # Report-only: a genuine error is downgraded to a warning so the
+          # check never reds.
+          python3 .github/scripts/blast_radius_report.py \
+            --packages-file pkgs.txt \
+          || echo "::warning::blast-radius report hit an internal error; see logs (non-blocking)"
+
+      - name: No package changes
+        if: steps.changed.outputs.count == '0'
+        run: echo "No packages/ changes in this PR — nothing to report." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Phase 1 of the leaf-update idea: make blast radius visible on every PR before any policy changes. Report-only, joins the dwell/smoke/trivial suite; same conventions (pinned checkout, SHAs via env, never a required check, errors downgrade to warnings).

Catalog today: **472 packages, 195 true leaves (41%)**. Heaviest: base (419 direct), toolchain (382), glibc (354 — 471 transitive).

Sample output for a mixed PR:

| package | dependents | blast radius |
|---|---|---|
| bat | TRUE LEAF | itself only |
| ghidra | leaf, referenced by stacks/reveng | stack sessions |
| zlib | 62 direct / 471 transitive | 471 packages rebuild |

The final `blast-radius: ALL-TRUE-LEAVES|HAS-DEPENDENTS` line is deliberately machine-readable — phase 2 (auto-merge for trivial ∧ all-leaves ∧ green pkgmgr bumps, if we decide to) keys on it plus trivial-update.yml without re-parsing. Design + governance discussion before enabling anything automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)