### PR TITLE
jdk: 21.0.10 -> 21.0.12.1 (clears 2 HIGH + 5 other CVEs)

### DIFF
--- a/packages/jdk/build.ncl
+++ b/packages/jdk/build.ncl
@@ -5,13 +5,13 @@ let alsa-lib = import "../alsa-lib/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let zlib = import "../zlib/build.ncl" in
 
-let version = "21.0.10" in
-let build_num = "7" in
+let version = "21.0.12.1" in
+let build_num = "1" in
 let dl_base = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-%{version}+%{build_num}" in
 
 let { amd64_sha256, arm64_sha256 } = {
-  amd64_sha256 = "ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4",
-  arm64_sha256 = "357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad703ab27b9a",
+  amd64_sha256 = "ce79869e1307ed8ee1e2baa86a412b1eb5b75d10a01006d788a6f968bcfaee94",
+  arm64_sha256 = "23e37e026f12f3e706f18938ff611db3032d075b09d0879a25d06718c773e223",
 }
 in
 


### PR DESCRIPTION
## Why

Seven CVEs from Oracle's April 2026 CPU name our shipped **21.0.10** as the highest affected version:

| CVE | severity |
|---|---|
| CVE-2026-34282 | **HIGH** |
| CVE-2026-22016 | **HIGH** |
| CVE-2026-22021 | MEDIUM |
| CVE-2026-22013 | MEDIUM |
| CVE-2026-34268 / 22018 / 22007 | LOW |

Temurin shipped 21.0.11 **two days after** they were published. We are three releases behind:

| release | date | |
|---|---|---|
| `jdk-21.0.10+7` | 2026-01-21 | what we ship |
| `jdk-21.0.11+10` | 2026-04-23 | fixes all 7 |
| `jdk-21.0.12+8` | 2026-07-24 | |
| `jdk-21.0.12.1+1` | 2026-08-19 | **this PR** |

## Why we didn't know

jdk was failing in **two independent ways at once**, and each one hid the other.

**Vuln-blind** — `source_provenance` names `adoptium/temurin21-binaries`, the release-artifact mirror, which holds **zero** advisory rows in our database. The CVEs are filed under CPE `oracle:jdk`, which we never consult for a package that has GithubRepo provenance. The package rendered `0/0/0`. (pkgmgr-rs#740)

**Update-dark** — GitHub returns this repo's releases in arbitrary order (all 233 share a single `created_at`), and the resolver read only the first 5. It picked `21.0.9+10` — *older* than what we ship — so the no-downgrade clamp fired and `check` printed a confident **"up to date."** (pkgmgr-rs#773)

A working version check would have shown us three releases behind. A working scan would have shown 2 HIGH. Both broke, so the package looked healthy on every surface we have.

## How this was produced

Generated by **`pkgmgr update --package jdk`** — not hand-edited — using the resolver and build-metadata fixes in **supply-chain#426** and **pkgmgr-rs#774**. Producing this bump was the acceptance test for those two PRs; before them the tool could not express it, because jdk carries its upstream identity across two bindings (`version` + `build_num`) that the asset name rejoins.

**Checksums are double-sourced.** Both sha256s were computed by pkgmgr from the tarballs it downloaded, and both match Adoptium's published `.sha256.txt` sidecars, fetched independently:

```
x64      ce79869e1307ed8ee1e2baa86a412b1eb5b75d10a01006d788a6f968bcfaee94
aarch64  23e37e026f12f3e706f18938ff611db3032d075b09d0879a25d06718c773e223
```

## For the reviewer

- **`pkgscan` was skipped** on the run that produced this (`--skip-pkgscan`), to avoid re-downloading ~400 MB during tooling iteration. The artifacts are official Adoptium releases with upstream-matching checksums, but the content scan has not run — please let CI do it, or re-run without the flag before merging. Flagging rather than leaving it implicit.
- `21.0.12.1` is a **respin** of 21.0.12 (a `.1` build), not a feature release. Both per-arch assets exist and the tarball top-level directory is `jdk-21.0.12.1+1/`, matching what `build.sh` expects.
- Ordinary quarterly-CPU bump for a JDK runtime; no API break expected between 21.0.10 and 21.0.12.x within the same LTS line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled JDK to Temurin 21.0.12.1+1.
  * Refreshed archive integrity checks for AMD64 and ARM64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->