### PR TITLE
kernel: virtio-linux + virtio-kernel-raw 6.12.94 -> 6.12.105

### DIFF
--- a/packages/virtio-kernel-raw/build.ncl
+++ b/packages/virtio-kernel-raw/build.ncl
@@ -3,7 +3,7 @@ let base = import "../base/build.ncl" in
 let virtio-linux = import "../virtio-linux/build.ncl" in
 
 # Tracks the virtio-linux kernel version; this package only decompresses it.
-let version = "6.12.94" in
+let version = "6.12.105" in
 {
   name = "virtio-kernel-raw",
 

--- a/packages/virtio-linux/build.ncl
+++ b/packages/virtio-linux/build.ncl
@@ -11,7 +11,7 @@ let perl = import "../perl/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 
-let version = "6.12.94" in
+let version = "6.12.105" in
 {
   name = "virtio-linux",
 
@@ -19,7 +19,7 @@ let version = "6.12.94" in
     { file = "build.sh" } | Local,
     {
       url = "gs://minimal-staging-archives/linux-%{version}.tar.xz",
-      sha256 = "e998a232b9418db3301cb58468e291a4f41d6ab8306029b30d991f56251dc8d2",
+      sha256 = "eb36801e119529b13513c3459dc20e2a32f7053629f3aabb63ea501a4d88f63d",
       extract = true,
       strip_prefix = "linux-%{version}",
     } | Source,


### PR DESCRIPTION
Both members of the kernel bundle, moved together. `virtio-kernel-raw` has no source of its own — it exists to decompress `virtio-linux`'s kernel — so its version binding must track it exactly, and the two cannot ship separately.

## These two were dropped from every bundle run

```
virtio-linux      6.12.94 → 6.12.105 — no upstream tarball URL available
virtio-kernel-raw 6.12.94 → 6.12.105 — package has no source_url in metadata
```

Neither was a misconfiguration in this repo, and they failed for **different** reasons:

- **virtio-linux** is provenance-less with a `gs://` mirror source, so `derive_update_plan` had nowhere to fetch *from*. Version discovery already worked — it found 6.12.105 fine. Only the "re-mirror origin" half of pkgmgr-rs#452 was missing.
- **virtio-kernel-raw**'s error text reads like a misconfiguration, but its shape is correct: no url, no provenance, no resolver, by design.

Both are fixed in **pkgmgr-rs#777**.

## Produced by the tool

Generated by `pkgmgr update`, not hand-edited — this bump was the acceptance test for #777.

**The checksum is independently verified.** `eb36801e119529b13513c3459dc20e2a32f7053629f3aabb63ea501a4d88f63d` was computed by pkgmgr from the tarball it downloaded, and matches kernel.org's published `sha256sums.asc` byte for byte. The tarball is mirrored to `gs://minimal-staging-archives/linux-6.12.105.tar.xz`.

## For the reviewer

- **The pkgscan diff did not run**, and the reason is macOS-specific rather than a problem with the tarball: extracting the *old* kernel tarball on a case-insensitive filesystem collides (`File exists (os error 17)` on `include/uapi/linux/netfilter/xt_connmark.h`), so the old-vs-new comparison was skipped. The new tarball downloaded, SHA-verified, and mirrored normally. CI on Linux has no such limitation — please let it do the diff.
- 6.12.94 → 6.12.105 is 11 stable point releases within the same LTS line.
- `virtio-kernel-raw`'s change is a single version literal; it has no checksum because it has no artifact of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
