### PR TITLE
fix: stamp Biome version at build time

### DIFF
--- a/packages/biome/build.ncl
+++ b/packages/biome/build.ncl
@@ -1,4 +1,4 @@
-let { standaloneTest, subsetOf, BuildSpec, Local, OutputBin, Source, .. } = import "minimal.ncl" in
+let { standaloneTest, subsetOf, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let make = import "../make/build.ncl" in
 let rust = import "../rust/build.ncl" in
@@ -31,6 +31,7 @@ let version = "2.5.8" in
   ],
 
   cmd = "./build.sh",
+  build_args = { include version },
 
   outputs = {
     bins = { glob = "usr/bin/biome" } | OutputBin,
@@ -52,5 +53,14 @@ let version = "2.5.8" in
 
   tests = {
     smoketest = standaloneTest "/usr/bin/biome --version",
+    version_is_exact =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "test \"$(/usr/bin/biome --version)\" = \"Version: %{version}\""],
+        ],
+      }
+        | Test,
   },
 } | BuildSpec

--- a/packages/biome/build.sh
+++ b/packages/biome/build.sh
@@ -3,6 +3,7 @@ set -ex
 
 export CC=gcc
 export LD=gcc
+export BIOME_VERSION="$MINIMAL_ARG_VERSION"
 export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
 
 cargo build --release -p biome_cli


### PR DESCRIPTION
## Summary

Stamp the catalog version into the Biome Rust build so `biome --version` reports the packaged version instead of `0.0.0`. This prevents Biome from warning that a valid configuration schema version does not match the CLI.

## Related issues

Closes #637

## Changes

- Forward the package version to `build.sh` through `build_args`.
- Export it as `BIOME_VERSION` for Biome's compile-time version constants.
- Add a standalone regression test that requires the exact `Version: 2.5.8` output.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/gominimal/pkgs/blob/main/CONTRIBUTING.md).
- [ ] I've accepted the [ICLA](https://github.com/gominimal/pkgs/blob/main/legal/ICLA.md) (and CCLA if contributing on my employer's time). CLA Assistant will prompt me on this PR if I haven't already.
- [ ] `min check` passes for the affected packages/harnesses.
- [ ] `min patched-build <name>` succeeds for any package I added or modified.
- [ ] For new packages: `source_provenance` points to the canonical upstream and the source builds from source (not a prebuilt release binary) where the required toolchain is available.
- [ ] For version bumps: I've verified the new `sha256` against the upstream archive.

## Notes for reviewers

Local checks completed: `sh -n packages/biome/build.sh` and `git diff --check`. The `min` helper, Cargo, and Nickel are not installed in this environment, so `min check` and a patched build could not be run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Biome package version handling during builds.
  * Added validation to ensure the installed Biome command reports the exact expected version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->