### PR TITLE
Point npm's global prefix at ~/.local instead of the read-only /usr

### DIFF
--- a/packages/node-lts/build.ncl
+++ b/packages/node-lts/build.ncl
@@ -103,5 +103,15 @@ let version = "24.19.0" in
           ["/bin/bash", "-c", "node -e 'console.log(10 * 5)' | grep -q '^50$'"],
         ],
       } | Test,
+    npm_global_prefix =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # The builtin npmrc must redirect npm's global prefix away from the
+          # read-only /usr store (gominimal/inbox#559).
+          ["/bin/bash", "-c", "npm config get prefix | grep -q '/.local$'"],
+        ],
+      } | Test,
   },
 } | BuildSpec

--- a/packages/node-lts/build.sh
+++ b/packages/node-lts/build.sh
@@ -21,3 +21,10 @@ export CXXFLAGS="${CFLAGS}"
     # Note: --shared-lief is omitted; that configure option was not added until Node.js v25.
 make -j$(nproc)
 make DESTDIR=$OUTPUT_DIR install
+
+# npm's compiled-in global prefix is /usr, which is the read-only package
+# store at session time, so every `npm i -g` fails with ENOENT. Ship a
+# builtin npmrc (npm's lowest-precedence config source, overridable by any
+# user config) pointing globals at ~/.local, whose bin/ is already on the
+# session PATH. See gominimal/inbox#559.
+printf 'prefix=~/.local\n' > "$OUTPUT_DIR/usr/lib/node_modules/npm/npmrc"

--- a/packages/node/build.ncl
+++ b/packages/node/build.ncl
@@ -103,5 +103,15 @@ let version = "25.8.2" in
           ["/bin/bash", "-c", "node -e 'console.log(10 * 5)' | grep -q '^50$'"],
         ],
       } | Test,
+    npm_global_prefix =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          # The builtin npmrc must redirect npm's global prefix away from the
+          # read-only /usr store (gominimal/inbox#559).
+          ["/bin/bash", "-c", "npm config get prefix | grep -q '/.local$'"],
+        ],
+      } | Test,
   },
 } | BuildSpec

--- a/packages/node/build.sh
+++ b/packages/node/build.sh
@@ -20,3 +20,10 @@ export CXXFLAGS="${CFLAGS}"
     --shared-nghttp2 --shared-nghttp3 --shared-ngtcp2 --shared-gtest  --shared-lief --shared-cares
 make -j$(nproc)
 make DESTDIR=$OUTPUT_DIR install
+
+# npm's compiled-in global prefix is /usr, which is the read-only package
+# store at session time, so every `npm i -g` fails with ENOENT. Ship a
+# builtin npmrc (npm's lowest-precedence config source, overridable by any
+# user config) pointing globals at ~/.local, whose bin/ is already on the
+# session PATH. See gominimal/inbox#559.
+printf 'prefix=~/.local\n' > "$OUTPUT_DIR/usr/lib/node_modules/npm/npmrc"


### PR DESCRIPTION
Fixes gominimal/inbox#559.

## What

`npm i -g` fails with `ENOENT ... mkdir '/usr/lib/node_modules/...'` in every session carrying `node` or `node-lts`: npm's compiled-in global prefix is `/usr`, which is the read-only package store at session time. This PR makes both packages ship a builtin npmrc (`usr/lib/node_modules/npm/npmrc`, npm's lowest-precedence config source) containing `prefix=~/.local`, and adds a `npm_global_prefix` regression test to each spec asserting the resolved prefix no longer points at the store.

Global installs then land in `~/.local/lib/node_modules` with executables in `~/.local/bin`, which is already on the session PATH (`crates/sandbox2/src/config.rs` in gominimal/minimal hardcodes it). Because builtin is the lowest-precedence source, any user `--prefix`, env var, or `.npmrc` still overrides it. The file is picked up by the existing `node_modules` output glob; no changes to outputs or to the CLI.

This matches the community workaround already circulating (varlock's sandbox guide hand-rolls `--prefix ~/.local`), so that documented quirk becomes deletable.

## Why not `env_state_wiring`

Adding `NPM_CONFIG_PREFIX` via `env_state_wiring` (the router's approach A on the issue) would put globals under `/state/npm-global`, but nothing puts a `/state/*/bin` on the session PATH and no wiring facility exists to do so — that would require new machinery in gominimal/minimal. The builtin npmrc needs neither. If persistent-across-recreate npm globals become a want later, the state-dir approach can still be layered on top; this change doesn't foreclose it.

## Verification

Verified empirically in a live session carrying `node-lts` (the packages weren't rebuilt locally — node is a 5x-cost build — so CI's package build + the new spec tests are the authoritative check):

- Reproduced the bug: `npm config get prefix` → `/usr`; `npm i -g` fails with the issue's exact ENOENT.
- Confirmed npm loads a builtin npmrc from its install dir using a writable copy of this package's npm: `npm config ls -l` reports `prefix = "/usr" ; overridden by builtin` and resolves `prefix` to `/home/.local` (`~` expands via npm's path-type config handling).
- With that prefix, `npm i -g nanoid` succeeds, the executable lands at `/home/.local/bin/nanoid`, resolves via PATH, and runs.

## Notes for the reviewer

- Task (non-session) sandboxes don't have `~/.local/bin` on PATH; a global install there now succeeds but its bins don't resolve. That is status-quo minus the ENOENT — tasks should declare packages rather than global-install.
- The issue also suggests auditing `pip`, `gem`, and `cargo install` for the same read-only-store failure mode. Left out deliberately: pip and gem have user-install fallbacks npm lacks, and cargo already defaults to `~/.cargo/bin`. Follow-up material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGTXbdK7hgDupktNZEkALY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated npm’s global installation location to use the user-writable `~/.local` directory.
  * Global npm package installations now avoid failures caused by the read-only system directory.

* **Tests**
  * Added coverage verifying that npm resolves its global package prefix to the expected user-writable location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->