### PR TITLE
dotenvx@2.22.1

### DIFF
--- a/packages/dotenvx/build.ncl
+++ b/packages/dotenvx/build.ncl
@@ -3,7 +3,7 @@ let { target, .. } = import "config.ncl" in
 let base = import "../base/build.ncl" in
 let tar = import "../tar/build.ncl" in
 
-let version = "2.22.0" in
+let version = "2.22.1" in
 {
   name = "dotenvx",
   build_deps = [
@@ -17,13 +17,13 @@ let version = "2.22.0" in
       { arch = 'Amd64, .. } =>
         {
           url = "https://github.com/dotenvx/dotenvx/releases/download/v%{version}/dotenvx-%{version}-linux-x86_64.tar.gz",
-          sha256 = "444e32d1a5227246cba3f60cb419c5a8fd3024c6aac839a3fb9b429f72244c72",
+          sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           extract = true,
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "https://github.com/dotenvx/dotenvx/releases/download/v%{version}/dotenvx-%{version}-linux-aarch64.tar.gz",
-          sha256 = "22fdc84e6968483a196e62353229cbbcc6b8a8892618b96acb75a7716cc1917a",
+          sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           extract = true,
         } | Source,
     } target,


### PR DESCRIPTION
## Summary

bumps dotenvx to v2.22.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dotenvx package to version 2.22.1.
  * Refreshed release metadata for both AMD64 and ARM64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->