### PR TITLE
fix: fix zsh modules not being installed

### DIFF
--- a/packages/zsh/build.ncl
+++ b/packages/zsh/build.ncl
@@ -1,4 +1,4 @@
-let { Attrs, BuildSpec, Local, OutputBin, OutputData, Source, Test, .. } = import "minimal.ncl" in
+let { Attrs, BuildSpec, Local, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let make = import "../make/build.ncl" in
@@ -47,6 +47,16 @@ let version = "5.9.2" in
   outputs = {
     zsh = { glob = "usr/bin/zsh" } | OutputBin,
 
+    # zsh is modular: the line editor (`zsh/zle`), the completion system
+    # (`zsh/complete`, `zsh/computil`) and the rest are dlopened at run
+    # time from here, not linked into the binary. Without them an
+    # interactive shell starts and then fails at its first prompt with
+    # `failed to load module 'zsh/zle'`, which no non-interactive test
+    # catches. Recursive because some modules are namespaced into
+    # subdirectories — `zsh/db/gdbm` (this build passes `--enable-gdbm`)
+    # installs at `zsh/db/gdbm.so`.
+    modules = { glob = "usr/lib/zsh/%{version}/**" } | OutputLib,
+
     functions = { glob = "usr/share/zsh/%{version}/functions/**" } | OutputData,
     help = { glob = "usr/share/zsh/%{version}/help/**" } | OutputData,
     mans = { glob = "usr/share/man/**" } | OutputData,
@@ -81,6 +91,30 @@ let version = "5.9.2" in
         test_deps = [coreutils, grep],
         cmds = [
           ["/usr/bin/zsh", "-c", "echo $((2 + 2))"],
+        ],
+      } | Test,
+    # The tests above all passed while the package shipped no modules at
+    # all: `--version`, `-c` and arithmetic are built in, so none of them
+    # touches `usr/lib/zsh`. These two do. `zmodload` exits non-zero when
+    # it cannot find a module, so the load is the assertion.
+    modules_load =
+      {
+        class = 'Standalone,
+        test_deps = [coreutils, grep],
+        cmds = [
+          ["/usr/bin/zsh", "-c", "zmodload zsh/complete zsh/parameter zsh/zutil"],
+        ],
+      } | Test,
+    # `zsh/zle` by path rather than by load: it is the module an
+    # interactive shell reaches for first, and the one whose absence was
+    # the visible break, but it is the line editor — asserting it is
+    # installed does not depend on how it behaves without a terminal.
+    zle_module_installed =
+      {
+        class = 'Standalone,
+        test_deps = [coreutils, grep],
+        cmds = [
+          ["/usr/bin/zsh", "-c", "test -e /usr/lib/zsh/%{version}/zsh/zle.so"],
         ],
       } | Test,
   },


### PR DESCRIPTION
 ## Summary

  An interactive zsh was unusable: it started, then failed at its first prompt with

  zsh: failed to load module `zsh/zle': /usr/lib/zsh/5.9.2/zsh/zle.so: cannot open shared object file: No such file or directory

  zsh is modular — the line editor (`zsh/zle`), the completion system
  (`zsh/complete`, `zsh/computil`) and the rest are dlopened at run time rather
  than linked into the binary. `outputs` is an explicit allowlist of globs, and
  this package had no glob under `usr/lib`, so `make install` produced the modules
  and packaging dropped every one of them. The binary shipped; its internals
  didn't.

  Nothing caught it because all three existing tests (`--version`, `-c echo`,
  arithmetic) only exercise builtins, and none of them is interactive — `zle` is
  the first module an interactive shell reaches for, so the gap was invisible
  until someone started zsh as a session shell.

  ## Changes

  - Add a `modules` output capturing `usr/lib/zsh/%{version}/**` as `OutputLib`.
    Recursive rather than `*.so` because some modules are namespaced into
    subdirectories — this build passes `--enable-gdbm`, so `zsh/db/gdbm` installs
    at `zsh/db/gdbm.so`, which a single `*` would not match. `OutputLib` rather
    than `OutputData` because these are ELF objects, which also gets them
    arch-checked.
  - Add two tests that fail against the old package:
    - `modules_load` — `zmodload zsh/complete zsh/parameter zsh/zutil`. `zmodload`
      exits non-zero when it cannot find a module, so the load is the assertion.
      These three are deliberately tty-independent.
    - `zle_module_installed` — asserts `usr/lib/zsh/%{version}/zsh/zle.so` exists.
      `zle` is the module that actually broke, but it is the line editor, so this
      checks installation rather than betting on how it loads without a terminal.

  ## Checklist

  - [x] I've read CONTRIBUTING.md.
  - [x] I've accepted the ICLA.
  - [x] `min check` passes for the affected packages.
  - [x] The package builds and the outputs are correct — see verification below.
  - [ ] For new packages: … (n/a — existing package)
  - [ ] For version bumps: … (n/a — no version change)

  ## Notes for reviewers

  Verified end to end against this commit, rather than by inspection:

  - Materialized straight out of the built artifact —
    `Found usr/lib/zsh/5.9.2/zsh/zle.so in zsh` → 392 KiB. So the modules are in
    the package, not just in the build tree.
  - A sandbox composed from that artifact has the full module directory,
    including the nested `db/`, and `zmodload zsh/zle` returns `ZLE_LOADS_OK`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for packaging Zsh runtime modules.
  * Ensured Zsh modules are installed and available for loading at runtime.

* **Tests**
  * Added coverage for loading runtime modules.
  * Added verification that the Zsh line editor module installs correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->