### PR TITLE
fix(pnpm): depend on node, not node-lts — two npms in one sandbox break each other

### DIFF
--- a/packages/pnpm/build.ncl
+++ b/packages/pnpm/build.ncl
@@ -3,7 +3,7 @@ let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let tar = import "../tar/build.ncl" in
 
-let node-lts = import "../node-lts/build.ncl" in
+let node = import "../node/build.ncl" in
 
 let version = "11.21.0" in
 {
@@ -18,8 +18,19 @@ let version = "11.21.0" in
     tar,
   ],
   runtime_deps = [
-    node-lts,
-    coreutils, # pnpm is a sheband script that invokes node like `#!/usr/bin/env node`
+    # `node`, NOT `node-lts`. pnpm only needs *a* node for its
+    # `#!/usr/bin/env node` shebang, but whichever one it names lands in the
+    # closure of every package that builds with pnpm. `next` and
+    # `agent-browser` both declare `node` themselves, so naming `node-lts` here
+    # put TWO npm installs in one sandbox — and since the sandbox hardlinks
+    # closure members first-writer-wins PER FILE, the resulting
+    # /usr/lib/node_modules/npm was a blend of both versions:
+    # minipass-flush/index.js from npm 11.17.0 (named `{ Minipass }` import)
+    # beside a nested minipass@3.3.6 from npm 11.11.1 (default export only).
+    # That tree has never existed upstream and cannot load — every
+    # `npm install` died, which broke `next` for two days. See pkgs#665/#670.
+    node,
+    coreutils,
   ],
   needs =
     {

--- a/packages/pnpm/build.ncl
+++ b/packages/pnpm/build.ncl
@@ -1,4 +1,4 @@
-let { Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, Source, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let coreutils = import "../coreutils/build.ncl" in
 let tar = import "../tar/build.ncl" in
@@ -29,7 +29,17 @@ let version = "11.21.0" in
     # beside a nested minipass@3.3.6 from npm 11.11.1 (default export only).
     # That tree has never existed upstream and cannot load — every
     # `npm install` died, which broke `next` for two days. See pkgs#665/#670.
-    node,
+    # ONLY the `node` binary — deliberately NOT npm/npx/node_modules.
+    #
+    # pnpm needs a node to interpret its `#!/usr/bin/env node` shebang and
+    # nothing else. Depending on the whole package dragged a SECOND npm into
+    # the closure of everything built with pnpm, and since the sandbox
+    # hardlinks closure members first-writer-wins PER FILE, the resulting
+    # /usr/lib/node_modules/npm was a blend of two npm versions that cannot
+    # load (see the commit message and pkgs#665). Taking the subset means pnpm
+    # can never contribute an npm tree at all, so that class is closed even if
+    # a consumer later picks a different node.
+    subsetOf node ["node"],
     coreutils,
   ],
   needs =


### PR DESCRIPTION
Fixes the `next` build failure that has blocked #665, #667, #669 and #659 since
2026-08-27. Supersedes #670, whose diagnosis was wrong (details below).

## The bug

`pnpm` names `node-lts` in `runtime_deps` — it only needs *a* node for its
`#!/usr/bin/env node` shebang. But whichever node it names lands in the closure
of every package that builds with pnpm, and both `next` and `agent-browser`
declare `node` themselves. So each of their sandboxes contained **two** npm
installs at the same paths.

The sandbox hardlinks closure members **first-writer-wins per file**
(`common::hardlink_dir_contents`, `AlreadyExists => warn!`), so
`/usr/lib/node_modules/npm/` came out as a blend of both:

| tree | `minipass-flush` | import style | nested `minipass` |
|---|---|---|---|
| node-lts npm 11.17.0 | 1.0.6 | `const { Minipass } = require(…)` | none — uses hoisted 7.1.3 |
| node 25.8.2 npm 11.11.1 | 1.0.5 | `const Minipass = require(…)` | 3.3.6 |
| **the failing `next` rootfs** | — | `const { Minipass } =` | **3.3.6** |

Both packages are internally consistent and work standalone. The merged tree
pairs 1.0.6's *named* import with 1.0.5's nested minipass@3.3.6, which has no
named export — so `class Flush extends undefined` throws and **every**
`npm install` dies, global or local, prefix or not.

It presented as a network fault because with `--prefix` on the command line npm
dies during config resolution before it can print anything: the whole stderr is
a pointer to a debug log that is itself empty of errors. It reproduces offline
with a dependency-free `package.json`.

## The fix

Point `pnpm` at `node` instead of `node-lts`, so only one npm is ever in the
closure. One line, plus a comment recording the failure mode so nobody
re-points it at LTS later.

## Verification

**Deterministic** — dependency closure, which does not depend on the
content-hash ordering that decides the link race:

| package | before | after |
|---|---|---|
| next | node + **node-lts** (via pnpm), 75 pkgs | **node only**, 74 |
| agent-browser | node + **node-lts** (via pnpm), 114 pkgs | **node only**, 113 |
| capy | node-lts only, 72 | unchanged, 72 |

`capy` is the only other `node-lts` consumer and does not use pnpm, so it is
untouched. After this change no package in the fleet carries both.

**End-to-end**, in the Linux sandbox from a clean `origin/main` worktree:

- `min package build --rebuild next` → exit 0 (rebuilding `pnpm` against `node` first)
- `min check --packages next` → **15/15 Pass**
- `min check --packages pnpm` → **15/15 Pass**
- `min package build --rebuild agent-browser` → exit 0
- `min check --packages agent-browser` → **15/15 Pass**

`pnpm`'s `missing runtime_deps` check passing is worth noting: it independently
confirms `node` satisfies the shebang, so nothing is lost by dropping LTS.

One honest limit: a local `next` build also succeeded on *unmodified* main,
because this machine's store happened to order the hashes favourably. The local
build is corroboration, not the argument — the closure change is what makes the
conflict impossible rather than merely unlikely.

## Why #670 was wrong

#670 deleted a nested `minipass` from node-lts's own output. node-lts's tree
does not contain one, so the guard never fired — which is exactly why `next`
still failed on arm64 with that branch. Its amd64 leg went green because the
link race landed differently on that arch, not because of the change. The
mistake was A/B-ing on a *merged sandbox rootfs* and attributing the result to a
package.

## Not fixed here

Two packages owning the same paths is still silent. `res-server-amd64` logged
**4,010** `Not linking … already exists` warnings in one day; this was one of
them becoming a two-day outage. A same-path collision between different
packages should be an error, not a `warn!` — filing separately against
`minimal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Reduced the pnpm build’s runtime footprint by including only the required Node.js executable.
  - Prevented unnecessary npm, npx, and package files from being included in the build environment, resulting in a leaner and more focused runtime package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->