### PR TITLE
feat(completions): batch 2 — bottom, delta, just, procs, ripgrep (inbox#470)

### DIFF
--- a/packages/bottom/build.ncl
+++ b/packages/bottom/build.ncl
@@ -31,7 +31,9 @@ let version = "0.14.8" in
 
   outputs = {
     btm = { glob = "usr/bin/btm" } | OutputLib,
-    completions = { glob = "usr/share/bash-completion/completions/*" } | OutputData,
+    bash_completion = { glob = "usr/share/bash-completion/completions/btm" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/btm.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_btm" } | OutputData,
   },
 
   attrs =

--- a/packages/bottom/build.sh
+++ b/packages/bottom/build.sh
@@ -10,3 +10,17 @@ cargo build --release
 mkdir -p $OUTPUT_DIR/usr/bin
 cp target/release/btm $OUTPUT_DIR/usr/bin
 install -D -m 0755 target/tmp/bottom/completion/btm.bash "$OUTPUT_DIR/usr/share/bash-completion/completions/btm"
+
+# zsh + fish completions (gominimal/inbox#470). bottom's build.rs generates
+# bash, zsh, fish (and 4 more) into target/tmp/bottom/completion/ on every
+# build via clap_complete; only bash was being installed, and the outputs glob
+# only covered bash, so the rest were discarded twice over.
+# clap_complete names the zsh file `_btm` already — the command is `btm`, not
+# `bottom`, and the completion must be named for the COMMAND.
+C=target/tmp/bottom/completion
+install -D -m 0644 "$C/_btm"     "$OUTPUT_DIR/usr/share/zsh/site-functions/_btm"
+install -D -m 0644 "$C/btm.fish" "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/btm.fish"
+[ -s "$OUTPUT_DIR/usr/share/zsh/site-functions/_btm" ]
+[ -s "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/btm.fish" ]
+head -1 "$OUTPUT_DIR/usr/share/zsh/site-functions/_btm" | grep -qx '#compdef btm'
+grep -q 'complete -c' "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/btm.fish"

--- a/packages/delta/build.ncl
+++ b/packages/delta/build.ncl
@@ -39,7 +39,9 @@ let version = "0.19.2" in
 
   outputs = {
     delta = { glob = "usr/bin/delta" } | OutputBin,
-    completions = { glob = "usr/share/bash-completion/completions/*" } | OutputData,
+    bash_completion = { glob = "usr/share/bash-completion/completions/delta" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/delta.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_delta" } | OutputData,
   },
   attrs =
     {

--- a/packages/delta/build.sh
+++ b/packages/delta/build.sh
@@ -8,3 +8,14 @@ RUSTONIG_DYNAMIC_LIBONIG=1 cargo build --release
 
 install -D -m 0755 target/release/delta $OUTPUT_DIR/usr/bin/delta
 install -D -m 0755 etc/completion/completion.bash "$OUTPUT_DIR/usr/share/bash-completion/completions/delta"
+
+# zsh + fish completions (gominimal/inbox#470). Upstream ships all three at
+# etc/completion/ (completion.bash, completion.fish, completion.zsh); only bash
+# was installed. Upstream's names are generic, so they are renamed to the
+# command on install.
+install -D -m 0644 etc/completion/completion.fish "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/delta.fish"
+install -D -m 0644 etc/completion/completion.zsh  "$OUTPUT_DIR/usr/share/zsh/site-functions/_delta"
+[ -s "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/delta.fish" ]
+[ -s "$OUTPUT_DIR/usr/share/zsh/site-functions/_delta" ]
+head -1 "$OUTPUT_DIR/usr/share/zsh/site-functions/_delta" | grep -qx '#compdef delta'
+grep -q 'complete -c' "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/delta.fish"

--- a/packages/just/build.ncl
+++ b/packages/just/build.ncl
@@ -32,7 +32,9 @@ let version = "1.58.0" in
   outputs = {
     just = { glob = "usr/bin/just" } | OutputBin,
 
-    completions = { glob = "usr/share/bash-completion/completions/*" } | OutputData,
+    bash_completion = { glob = "usr/share/bash-completion/completions/just" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/just.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_just" } | OutputData,
   },
   attrs =
     {

--- a/packages/just/build.sh
+++ b/packages/just/build.sh
@@ -11,3 +11,21 @@ install -m 755 target/release/just $OUTPUT_DIR/usr/bin/just
 
 mkdir -p $OUTPUT_DIR/usr/share/bash-completion/completions
 target/release/just --completions bash > $OUTPUT_DIR/usr/share/bash-completion/completions/just
+
+# zsh + fish completions (gominimal/inbox#470).
+#
+# just's bash and fish outputs are DYNAMIC one-liners, not static scripts:
+#   bash -> eval "$(JUST_COMPLETE=bash just)"
+#   fish -> JUST_COMPLETE=fish just | source
+# Both work, because bash-completion sources files from its completions dir and
+# fish sources vendor_completions.d/<cmd>.fish when completing <cmd>. Only the
+# zsh output is a conventional `#compdef` file. The assertions below are
+# therefore per-shell rather than the usual shared pair — do not "normalise"
+# them to `complete -c` or the build will fail.
+mkdir -p "$OUTPUT_DIR/usr/share/zsh/site-functions" "$OUTPUT_DIR/usr/share/fish/vendor_completions.d"
+target/release/just --completions zsh  > "$OUTPUT_DIR/usr/share/zsh/site-functions/_just"
+target/release/just --completions fish > "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/just.fish"
+[ -s "$OUTPUT_DIR/usr/share/zsh/site-functions/_just" ]
+[ -s "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/just.fish" ]
+head -1 "$OUTPUT_DIR/usr/share/zsh/site-functions/_just" | grep -qx '#compdef just'
+grep -q 'JUST_COMPLETE=fish' "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/just.fish"

--- a/packages/procs/build.ncl
+++ b/packages/procs/build.ncl
@@ -31,7 +31,9 @@ let version = "0.14.12" in
 
   outputs = {
     procs = { glob = "usr/bin/procs" } | OutputBin,
-    completions = { glob = "usr/share/bash-completion/completions/*" } | OutputData,
+    bash_completion = { glob = "usr/share/bash-completion/completions/procs" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/procs.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_procs" } | OutputData,
   },
   attrs =
     {

--- a/packages/procs/build.sh
+++ b/packages/procs/build.sh
@@ -10,3 +10,13 @@ install -D -m 0755 target/release/procs $OUTPUT_DIR/usr/bin/procs
 
 mkdir -p $OUTPUT_DIR/usr/share/bash-completion/completions
 target/release/procs --gen-completion-out bash > $OUTPUT_DIR/usr/share/bash-completion/completions/procs
+
+# zsh + fish completions (gominimal/inbox#470). procs uses --gen-completion-out
+# (not --completions); verified all three shells emit correct content.
+mkdir -p "$OUTPUT_DIR/usr/share/zsh/site-functions" "$OUTPUT_DIR/usr/share/fish/vendor_completions.d"
+target/release/procs --gen-completion-out zsh  > "$OUTPUT_DIR/usr/share/zsh/site-functions/_procs"
+target/release/procs --gen-completion-out fish > "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/procs.fish"
+[ -s "$OUTPUT_DIR/usr/share/zsh/site-functions/_procs" ]
+[ -s "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/procs.fish" ]
+head -1 "$OUTPUT_DIR/usr/share/zsh/site-functions/_procs" | grep -qx '#compdef procs'
+grep -q 'complete -c' "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/procs.fish"

--- a/packages/ripgrep/build.ncl
+++ b/packages/ripgrep/build.ncl
@@ -32,7 +32,9 @@ let version = "15.2.0" in
   outputs = {
     rg = { glob = "usr/bin/rg" } | OutputBin,
 
-    completions = { glob = "usr/share/bash-completion/completions/*" } | OutputData,
+    bash_completion = { glob = "usr/share/bash-completion/completions/rg" } | OutputData,
+    fish_completion = { glob = "usr/share/fish/vendor_completions.d/rg.fish" } | OutputData,
+    zsh_completion = { glob = "usr/share/zsh/site-functions/_rg" } | OutputData,
   },
   attrs =
     {

--- a/packages/ripgrep/build.sh
+++ b/packages/ripgrep/build.sh
@@ -11,3 +11,14 @@ cp target/release/rg $OUTPUT_DIR/usr/bin
 
 mkdir -p $OUTPUT_DIR/usr/share/bash-completion/completions
 target/release/rg --generate complete-bash > $OUTPUT_DIR/usr/share/bash-completion/completions/rg
+
+# zsh + fish completions (gominimal/inbox#470). rg's generator takes
+# `complete-<shell>`, not a bare shell name. The command is `rg`, not
+# `ripgrep`, and the completion must be named for the COMMAND.
+mkdir -p "$OUTPUT_DIR/usr/share/zsh/site-functions" "$OUTPUT_DIR/usr/share/fish/vendor_completions.d"
+target/release/rg --generate complete-zsh  > "$OUTPUT_DIR/usr/share/zsh/site-functions/_rg"
+target/release/rg --generate complete-fish > "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/rg.fish"
+[ -s "$OUTPUT_DIR/usr/share/zsh/site-functions/_rg" ]
+[ -s "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/rg.fish" ]
+head -1 "$OUTPUT_DIR/usr/share/zsh/site-functions/_rg" | grep -qx '#compdef rg'
+grep -q '__rg' "$OUTPUT_DIR/usr/share/fish/vendor_completions.d/rg.fish"


### PR DESCRIPTION
Batch 2 of gominimal/inbox#470, following the tester in #672 (which is green).

Completes the highest-value tier: packages that **already generate all three
shells on every build and install only bash**. #672 did `bat` and `skopeo`;
this does the remaining five. No new upstream dependency, no new build step —
these files are being produced today and thrown away.

**All-three-shells coverage: 4 → 16** across the fleet (was 4 before #672).

| package | command | mechanism |
|---|---|---|
| bottom | **btm** | build-output — clap_complete `build.rs` |
| delta | delta | source-file — `etc/completion/completion.{bash,fish,zsh}` |
| just | just | runtime-flag — `--completions <shell>` |
| procs | procs | runtime-flag — `--gen-completion-out <shell>` |
| ripgrep | **rg** | runtime-flag — `--generate complete-<shell>` |

## Evidence

All five build `--rebuild` clean and pass `min check` **15/15**. Verified in a
composed session rootfs — post-`outputs`-glob, which is where the silent
discard is visible:

```
zsh fpath includes site-functions               PASS
fish complete_path includes vendor_completions  PASS
btm    bash PASS  zsh #compdef btm    PASS  fish PASS
delta  bash PASS  zsh #compdef delta  PASS  fish PASS
just   bash PASS  zsh #compdef just   PASS  fish PASS
procs  bash PASS  zsh #compdef procs  PASS  fish PASS
rg     bash PASS  zsh #compdef rg     PASS  fish PASS
ALL CHECKS PASSED
```

## Four different generator syntaxes across five packages

Worth recording, because it is the argument against a mechanical sweep:

```
just     --completions <shell>
procs    --gen-completion-out <shell>
ripgrep  --generate complete-<shell>     <- not a bare shell name
bottom   build.rs -> target/tmp/bottom/completion/
delta    etc/completion/completion.{bash,fish,zsh}
```

Each was confirmed by running the real binary or reading the pinned source
before writing the install line — not inferred.

## Two traps handled

**Command name != package name.** `bottom` installs as `btm`, `ripgrep` as
`rg`. A completion named for the package installs cleanly, passes every
existence check, and never fires.

**`just` emits DYNAMIC completions for bash and fish**, not static scripts:

```
bash -> eval "$(JUST_COMPLETE=bash just)"
fish -> JUST_COMPLETE=fish just | source
```

Both work — bash-completion sources files from its completions dir, and fish
sources `vendor_completions.d/<cmd>.fish` when completing `<cmd>` — but the
usual `complete -c` / `_init_completion` assertions reject them. `just` has
per-shell assertions and a comment saying explicitly not to normalise them.
Only its zsh output is a conventional `#compdef` file. (The bash line is
pre-existing behaviour on main, not introduced here.)

## Conventions

Unchanged from #672 and applied identically: exact-path `OutputData` globs
replacing the `completions/*` wildcard, so an upstream rename fails loudly;
content assertions rather than `test -f`, since a wrong-shell file passes
existence checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zsh and Fish shell completion support for bottom, delta, just, procs, and ripgrep.
  * Shell completions are now provided as separate Bash, Fish, and Zsh outputs.
* **Bug Fixes**
  * Improved completion installation and validation to ensure generated files are available and contain the expected shell-specific content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->