### PR TITLE
claude: add a metapackage pairing the agent with its session plugin

### DIFF
--- a/packages/claude/build.ncl
+++ b/packages/claude/build.ncl
@@ -3,9 +3,10 @@ let base = import "../base/build.ncl" in
 let claude-code = import "../claude-code/build.ncl" in
 let claude-code-minimal-plugin = import "../claude-code-minimal-plugin/build.ncl" in
 
-# A metapackage: `min add claude` gets the agent *and* the Minimal session
-# plugin, which is the combination you almost always want in a sandbox. It
-# builds nothing and owns no files; the two deps below are its entire content.
+# A metapackage: `min add --session claude` gets the agent *and* the Minimal
+# session plugin, which is the combination you almost always want in a sandbox.
+# It builds nothing and owns no files; the two deps below are its entire
+# content.
 #
 # `claude-code-minimal-plugin` already depends on `claude-code`, so naming both
 # here is redundant today. It is deliberate: this package's meaning should not

--- a/packages/claude/build.ncl
+++ b/packages/claude/build.ncl
@@ -1,0 +1,36 @@
+let { BuildSpec, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let claude-code = import "../claude-code/build.ncl" in
+let claude-code-minimal-plugin = import "../claude-code-minimal-plugin/build.ncl" in
+
+# A metapackage: `min add claude` gets the agent *and* the Minimal session
+# plugin, which is the combination you almost always want in a sandbox. It
+# builds nothing and owns no files; the two deps below are its entire content.
+#
+# `claude-code-minimal-plugin` already depends on `claude-code`, so naming both
+# here is redundant today. It is deliberate: this package's meaning should not
+# be hostage to the plugin's internal dependency choices.
+{
+  name = "claude",
+  build_deps = [],
+  runtime_deps = [
+    claude-code,
+    claude-code-minimal-plugin,
+  ],
+  cmd = "",
+  outputs = {},
+
+  tests = {
+    # The whole point of the package is that both halves arrive together, so
+    # assert exactly that: the launcher, and the plugin tree its wrapper looks
+    # for at /usr/share/claude/plugins/minimal.
+    both_halves_present =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "set -e; test -x /usr/bin/claude; test -f /usr/share/claude/plugins/minimal/.claude-plugin/plugin.json"],
+        ],
+      } | Test,
+  },
+} | BuildSpec


### PR DESCRIPTION
## What

Adds `packages/claude` — a metapackage on the existing `packages/toolchain` pattern (`build_deps = []`, `cmd = \"\"`, `outputs = {}`). Its entire content is two `runtime_deps`: `claude-code` and `claude-code-minimal-plugin`.

`min add --session claude` now gets the agent together with the Minimal session plugin, which is the combination you almost always want inside a sandbox. Previously that meant naming both packages at every call site.

## What this is not

**This does not change default behaviour for existing users.** Anyone installing `claude-code` directly still gets vanilla claude with no plugin. This adds an opt-in name, nothing more.

Making the plugin universal would require inverting the plugin's dependency on `claude-code`. That was considered and rejected here:

- it pins the `claude-code` closure to the `minimal-skills` release cadence, so a bad plugin pin blocks claude-code installs;
- the plugin is deliberately sandbox-only (its `build.sh` drops the host-facing skills, which teach commands that do not exist inside a sandbox), so forcing it onto every consumer ships the wrong guidance to non-sandbox contexts;
- `/usr/bin/claude` already guards with `[ -d \"$min_plugin\" ]`, so a hard dep would duplicate a check that already works;
- both directions at once is a cycle.

The redundant `claude-code` dep (the plugin already depends on it) is intentional, so this package's meaning does not depend on the plugin's internal dependency choices.

## Verification

Run in a throwaway sandbox session, destroyed afterwards:

```
min check --packages claude        -> all Pass (test/output checkers Skip pre-build)
min package patched-build claude   -> cache hash 61427f8c57e0139a48940fe83bd026dbbfe88740fecb71315456a14178f22b3f
min check --packages claude        -> all 15 Pass, incl. standalone tests
```

The `both_halves_present` test asserts `/usr/bin/claude` is executable and `/usr/share/claude/plugins/minimal/.claude-plugin/plugin.json` exists — confirming the metapackage's `runtime_deps` reach the runtime environment and the wrapper's plugin probe finds its target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMmt2g7Ume6R7QvEgYA5V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude package that installs Claude Code together with the Minimal plugin.
  * The package can be added using the `min add --session claude` command.
* **Tests**
  * Added coverage verifying that the Claude launcher and Minimal plugin manifest are available after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->