### PR TITLE
chore: drop the diffcheck scratch task

### DIFF
--- a/minimal.toml
+++ b/minimal.toml
@@ -15,9 +15,3 @@ exec = "claude --dangerously-skip-permissions"
 interactive = true
 packages = ["base", "bash", "opencode", "curl"]
 exec = "opencode"
-
-# UNCOMMITTED test rig for the libarchive PR — discard before push.
-[tasks.diffcheck]
-description = "Prove diffoscope actually runs with the new libarchive dep"
-packages = ["base", "coreutils", "diffoscope"]
-bash = "diffoscope --version && echo 'diffcheck: ok'"


### PR DESCRIPTION
Removes the `diffcheck` task from `minimal.toml`.

It was added in #540 as a one-off rig to prove `diffoscope` actually ran once `libarchive` became its runtime dep. The comment above it, added in the same commit, reads:

```toml
# UNCOMMITTED test rig for the libarchive PR — discard before push.
```

It was pushed anyway, and has been in the repo-level config since 2026-07-30 (`97e04d287`). `minimal.toml` has had no commit since, so nothing has revisited it.

Nothing in the tree references `diffcheck`, and the `libarchive` runtime dep it was verifying is merged, so the rig has no remaining job. Six-line deletion, no package changes.

@bryan-minimal tagging you since it was your rig — shout if it's still load-bearing for something and I'll close this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMmt2g7Ume6R7QvEgYA5V