### PR TITLE
Update chromium to 153.0.8010.12 (security update)

### DIFF
--- a/packages/chromium-bin/build.ncl
+++ b/packages/chromium-bin/build.ncl
@@ -71,7 +71,7 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 #     (Google publishes no linux-arm64; Playwright still builds arm64).
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1237 ↔ Chrome 152.0.7977.8
+# packages/playwright-core/browsers.json. Revision 1243 ↔ Chrome 153.0.8010.12
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with
 # chromium-headless-shell-bin.
@@ -86,9 +86,9 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # If it doesn't, pass `executablePath: '/bin/chromium'` (or
 # '/bin/chromium-headless-shell' from the headless-shell pkg) to
 # bypass the registry lookup. See packages/chromium-bin/README.md.
-let revision = "1237" in
-let browser_version = "152.0.7977.8" in
-let snapshot_position = "1669021" in
+let revision = "1243" in
+let browser_version = "153.0.8010.12" in
+let snapshot_position = "1681086" in
 {
   name = "chromium-bin",
   build_deps = [
@@ -97,12 +97,12 @@ let snapshot_position = "1669021" in
       { arch = 'Amd64, .. } =>
         {
           url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
-          sha256 = "89a52b393189c7ab7ee0f1ebdaf8279c2c97d0c0e83708abe84292b57337da19",
+          sha256 = "4cd65eb42af4eb7942b0af2a328af13b3808db672ad62b2d4af84e27aa17ba3b",
         } | Source,
       { arch = 'Arm64, .. } =>
         {
           url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-linux-arm64.zip",
-          sha256 = "a188a0c13a944da8eb9b327dd473bf0378a10e170b2729d75b7be4520a9cfa1a",
+          sha256 = "f144b7f58b61c6bea2c192c4c178faa9b606bdf758e2d47ca99fa03f759a13e4",
         } | Source,
     } target,
     base,

--- a/packages/chromium-headless-shell-bin/build.ncl
+++ b/packages/chromium-headless-shell-bin/build.ncl
@@ -61,12 +61,12 @@ let liberation-fonts = import "../liberation-fonts/build.ncl" in
 # branched from); arm64 from Playwright's own arm64 build.
 #
 # `revision` is the Playwright browser-revision number from
-# packages/playwright-core/browsers.json. Revision 1237 ↔ Chrome 152.0.7977.8
+# packages/playwright-core/browsers.json. Revision 1243 ↔ Chrome 153.0.8010.12
 # ↔ playwright-core ^1.59. `snapshot_position` must be re-derived whenever
 # `browser_version` bumps. Keep all three in lockstep with chromium-bin.
-let revision = "1237" in
-let browser_version = "152.0.7977.8" in
-let snapshot_position = "1669021" in
+let revision = "1243" in
+let browser_version = "153.0.8010.12" in
+let snapshot_position = "1681086" in
 {
   name = "chromium-headless-shell-bin",
   build_deps =
@@ -76,12 +76,12 @@ let snapshot_position = "1669021" in
         { arch = 'Amd64, .. } =>
           {
             url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/headless-shell.zip",
-            sha256 = "efd7bdeac429d8728e39eeb70b5de3355b276f134b159db61ffc7f6980e2b76c",
+            sha256 = "83bc994d5d08518718e3c1750190fbbba4fd4b4db027ad1540b2d7b681a8fbc7",
           } | Source,
         { arch = 'Arm64, .. } =>
           {
             url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-            sha256 = "b3daa6584a2fcf8349d096e4b6c0706652ef1f87afd209455de509f17e7094d8",
+            sha256 = "3a2bc2c354fb66615ee329c2ab13cd1312b40294798bea04c5dc0053caa6b881",
           } | Source,
       } target,
       base,
@@ -97,7 +97,7 @@ let snapshot_position = "1669021" in
           [
             {
               url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/%{snapshot_position}/chrome-linux.zip",
-              sha256 = "89a52b393189c7ab7ee0f1ebdaf8279c2c97d0c0e83708abe84292b57337da19",
+              sha256 = "4cd65eb42af4eb7942b0af2a328af13b3808db672ad62b2d4af84e27aa17ba3b",
             } | Source,
             # headless_command_resources.pak (the pak implementing --dump-dom &
             # friends in standalone headless) ships in NO snapshot artifact —
@@ -107,7 +107,7 @@ let snapshot_position = "1669021" in
             # artifact, same pin).
             {
               url = "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/%{revision}/chromium-headless-shell-linux-arm64.zip",
-              sha256 = "b3daa6584a2fcf8349d096e4b6c0706652ef1f87afd209455de509f17e7094d8",
+              sha256 = "3a2bc2c354fb66615ee329c2ab13cd1312b40294798bea04c5dc0053caa6b881",
             } | Source,
           ],
         # Playwright's arm64 bundle is already complete.


### PR DESCRIPTION
Updates **chromium-bin + chromium-headless-shell-bin** from **152.0.7977.8** to **153.0.8010.12** — a Chromium security update (each Chrome major carries Critical fixes).

**Channel context (#646):** `chromium-bin` tracks Playwright's pin, which is pre-stable by design; 153.0.8010.12 is ahead of current Linux stable (152.0.7977.75). CVEs publish only against stable, so a 0/0/0 scan for this package means "ahead of the published feed", not "audited clean".

chromium pins three interlocked identifiers, resolved from three sources:

| identifier | value | source |
|---|---|---|
| `browser_version` | 153.0.8010.12 | Playwright browsers.json |
| `revision` | 1243 | Playwright browsers.json (arm64 legs are Playwright-gated) |
| `snapshot_position` | 1681086 | chromiumdash branch position → nearest available amd64 snapshot |

Four artifacts fetched + `sha256`'d fresh (amd64 `chrome-linux.zip` + `headless-shell.zip` from the snapshot bucket; arm64 `chromium` / `headless-shell` builds at the Playwright revision). Resolved + rewritten by `pkgmgr` (gominimal/pkgmgr-rs#515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the bundled Chromium and headless-shell versions to Chrome 153.0.8010.12.
  - Refreshed platform-specific packages for improved compatibility across amd64 and arm64 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->