### PR TITLE
Update claude-code to 2.1.259 (Fable 5.1 support)

### DIFF
--- a/packages/claude-code/build.ncl
+++ b/packages/claude-code/build.ncl
@@ -11,9 +11,9 @@ let ripgrep = import "../ripgrep/build.ncl" in
 
 let { version, amd64_sha256, arm64_sha256, gcs_bucket } = {
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
-  version = "2.1.233",
-  amd64_sha256 = "55d281096f57d411ebbdd94dbf5e9ff3accb7c05713e37348c2c11d4b83bf9d9",
-  arm64_sha256 = "42df1841f74e9b2ac13f2c1a2a820ef6b9ac5b2efb8646bb25c9a92b8bd69194",
+  version = "2.1.259",
+  amd64_sha256 = "f7dd62ae415378018cd21dd950eb3bac174ab085830304d3b8b098146bfd47b6",
+  arm64_sha256 = "c6ff03c389ccdeae0f19e9dc32488eeba61fbef4796f531dbfba6c00f45040d0",
 }
 in
 


### PR DESCRIPTION
Bumps `claude-code` 2.1.233 → 2.1.259 so people can select **Fable 5.1**.

## Why this version

The tracked channel is **latest**, which is 2.1.259 (built 2026-09-02). Note the vendor's `$GCS_BUCKET/stable` pointer currently reads 2.1.236 — this deliberately tracks latest, not that.

## Verified, not assumed

**Fable 5.1 support confirmed in the actual binary**, not inferred from the version number:

```
$ strings claude-2.1.259-linux-x64 | grep -oE 'claude-fable-5[a-z0-9.-]*' | sort -u
claude-fable-5
claude-fable-5-1
claude-fable-5-mythos-5
```

**Both checksums verified by downloading the real artifacts** and hashing them, rather than copying the manifest:

```
linux-x64    f7dd62ae415378018cd21dd950eb3bac174ab085830304d3b8b098146bfd47b6
linux-arm64  c6ff03c389ccdeae0f19e9dc32488eeba61fbef4796f531dbfba6c00f45040d0
```

Both match `$GCS_BUCKET/2.1.259/manifest.json`.

**Local build:** `min package build --rebuild claude-code` → clean, and `min check --packages claude-code` → 15/15 Pass.

## One thing a reviewer should eyeball

The artifact is **35% smaller** than the version it replaces:

| | linux-x64 | linux-arm64 |
|---|---|---|
| 2.1.233 → 2.1.236 | ~334 MB | ~332 MB |
| **2.1.259** | **217 MB** | **216 MB** |

That is a big enough shape change to mention rather than let a reviewer discover. It is consistent across both arches and the checksums match the vendor manifest, so it looks like an intentional upstream slimming rather than a truncated or partial artifact — but it is exactly the kind of change worth a second pair of eyes on a proprietary prebuilt we cannot inspect the source of.

Nothing else in the spec changes: same GCS bucket, same per-arch `Source` shape, same `runtime_deps`, same `LicenseRef-Anthropic-Proprietary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Claude Code release to version 2.1.259.
  * Refreshed integrity checks for supported amd64 and arm64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->