### PR TITLE
claude-code-minimal-plugin: move the skills pin to v0.4.0

### DIFF
--- a/packages/claude-code-minimal-plugin/build.ncl
+++ b/packages/claude-code-minimal-plugin/build.ncl
@@ -3,7 +3,7 @@ let base = import "../base/build.ncl" in
 let claude-code = import "../claude-code/build.ncl" in
 let jq = import "../jq/build.ncl" in
 
-let version = "0.3.0" in
+let version = "0.4.0" in
 {
   name = "claude-code-minimal-plugin",
 
@@ -11,7 +11,7 @@ let version = "0.3.0" in
     { file = "build.sh" } | Local,
     {
       url = "https://github.com/gominimal/minimal-skills/archive/refs/tags/v%{version}.tar.gz",
-      sha256 = "2d53812d0f4c3a04c466bb9f0f06eef1b7ab3c13127835e19e2d06f46341f19c",
+      sha256 = "9948b6bcf78cdf592ff204505bbbbc48016145b5ab8abbda84d169ac9b9a3320",
       extract = true,
       # GitHub drops the leading `v` from the tag when naming the archive's
       # top-level directory, so this is the bare version, not the tag.


### PR DESCRIPTION
Moves the pinned `minimal-skills` snapshot from v0.3.0 to
[v0.4.0](https://github.com/gominimal/minimal-skills/releases/tag/v0.4.0), the
first release verified against minimal 0.5.4.

## Why it matters here

`minimal-sandbox` is the only skill this package ships, and its attach-shell
paragraph was wrong on both counts in v0.3.0:

- the shell is `bash --noprofile --rcfile <daemon rc> -i`, not
  `bash --noprofile -l` (read from `/proc/$$/cmdline` inside a session)
- it is only bash at all when the session's composed `SHELL` does not name an
  installed known shell, so an agent in a fish session was being told the wrong
  thing outright

The wider release removed `min session exec` from the host-facing skills in
favour of declared tasks, after all three caveats those skills taught (empty
first stdout line, argv re-evaluation, a backgrounded grandchild holding the
call open) turned out to be fixed before 0.5.4. None of that guidance ships
here, but the pin keeps the sandbox skill in step with the release it was
verified against.

## Verification

- sha256 recomputed for the v0.4.0 tarball
- upstream `plugin.json` declares `0.4.0`, so `build.sh`'s version guard and
  the layout test's `"version": "0.4.0"` grep both still hold
- the tarball carries everything `build.sh` copies: `.claude-plugin/plugin.json`,
  `skills/minimal-sandbox/`, and `sandbox/{hooks.json,session-primer.sh,denial-triage.sh}`

Not built locally: `mip` is Linux-only and this was prepared on macOS, so the
build and its layout test run for the first time in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled plugin build to use minimal-skills version 0.4.0.
  * Refreshed the associated integrity verification for the updated version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->