### PR TITLE
add tuicr 0.25.0

### DIFF
--- a/packages/tuicr/build.ncl
+++ b/packages/tuicr/build.ncl
@@ -1,0 +1,66 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let rust = import "../rust/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+let version = "0.25.0" in
+{
+  name = "tuicr",
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/agavra/tuicr/archive/refs/tags/v%{version}.tar.gz",
+      sha256 = "e7553c629d89c3fae2845a21bddf365cc542e0d2f2eed01e2fb5ad7017bd81fc",
+      extract = true,
+      strip_prefix = "tuicr-%{version}",
+    } | Source,
+    base,
+    rust,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc"],
+  ],
+
+  needs = {
+    dns = {},
+    internet = {},
+  },
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    tuicr = { glob = "usr/bin/tuicr" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "agavra",
+        repo = "tuicr",
+      },
+    } | Attrs,
+
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "tuicr --version"],
+          ["/bin/bash", "-c", "tuicr --help"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/tuicr/build.sh
+++ b/packages/tuicr/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+export CARGO_INCREMENTAL=0
+export CC=gcc
+export LD=gcc
+export RUSTFLAGS="-C linker=gcc --remap-path-prefix=$(pwd)=/builddir --remap-path-prefix=$HOME/.cargo=/cargo"
+
+cargo build --release --locked
+
+mkdir -p $OUTPUT_DIR/usr/bin
+cp target/release/tuicr $OUTPUT_DIR/usr/bin


### PR DESCRIPTION
Adds `tuicr`, a terminal UI for code review: GitHub-style diffs, vim keybindings, line-level comments, and review export to GitHub, GitLab, Bitbucket, Azure DevOps, markdown, or stdout. Version 0.25.0 is the latest upstream release. The project site footer still advertises 0.10.0, but the site fetches the version from the GitHub API at load time and the API reports 0.25.0.

**Design notes:**

- No `ca-certificates` runtime dep. Self-update checks go through ureq's rustls with webpki-roots compiled into the binary, and `git2` is built with `default-features = false`, so libgit2 has no TLS backend. Forge pushes run through external CLIs (`gh`/`glab`/`bkt`) that tuicr expects the environment to provide.
- No `git` runtime dep either: tuicr auto-detects git/jj/hg, and a hard dep would over-constrain jj or hg users. Same approach as `tealdeer`, the closest existing package.

**Tested:** `min check --packages tuicr` passes all 15 checkers, including the post-build ones. Standalone smoke tests (`tuicr --version`, `tuicr --help`) pass. Two clean-room builds produced byte-identical output (same content-addressed cache hash).

**Risk:** low, purely additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the tuicr package at version 0.25.0.
  * Included a compiled command-line executable with support for version and help commands.
  * Added package metadata, runtime requirements, and build verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->