### PR TITLE
jdtls: add source_provenance — stops the daily coverage-health failure

### DIFF
--- a/packages/jdtls/build.ncl
+++ b/packages/jdtls/build.ncl
@@ -44,5 +44,15 @@ let build_stamp = "202606262232" in
       upstream_version = version,
       license_spdx = "EPL-2.0",
       binary_from = "https://download.eclipse.org/jdtls/milestones/",
+      # Advisories for the JDT Language Server are filed against the SOURCE
+      # repo, not the download mirror the binary comes from. Without this the
+      # package is advisory-dark: no source can reach it, it scans 0/0/0 for an
+      # infrastructural reason, and `coverage-health` fails the 08:05 job every
+      # day (it did, 2026-09-02 through 09-11). Same class as jdk in pkgmgr#740.
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "eclipse-jdtls",
+        repo = "eclipse.jdt.ls",
+      },
     } | Attrs,
 } | BuildSpec


### PR DESCRIPTION
Stops the `pkgmgr-runner` 08:05 job failing every day, which it has done from 2026-09-02 through 09-11 on:

```
↑ NEW dark since baseline: jdtls
```

## Root cause

`jdtls` had **no `source_provenance` block at all** — just a version, a `download.eclipse.org` URL and `EPL-2.0`. No advisory source could reach it, so it scanned `0/0/0` for an infrastructural reason. That is precisely the class the coverage-health guard exists to catch, and it caught it — every day, with nobody to act on it.

## The fix, and why it points where it does

The binary is a prebuilt from `download.eclipse.org`, but **advisories are filed against the source repo**, `eclipse-jdtls/eclipse.jdt.ls` (EPL-2.0, actively pushed). So that is what the provenance names. Naming the download mirror instead is the exact mislabel that left `jdk` blind to 79 advisories in pkgmgr#740.

## Verified

- `pkgmgr check-onboarding --package jdtls` — the PR-time static gate for advisory-trackability — now reports **every package can be version-tracked and advisory-tracked**
- `min check`: parse / imports / fmt / source urls all Pass

Attrs-only change; nothing about the build moves.

This is the coverage-restoring fix the alert asks for, as opposed to `--update-baseline`, which would only record the blindness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub source provenance metadata to JDTLS security advisories, identifying the Eclipse JDT Language Server repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->