### PR TITLE
helix-grammars: read the version from helix, not the first grammar repo (pkgmgr#773)

### DIFF
--- a/packages/helix-grammars/build.ncl
+++ b/packages/helix-grammars/build.ncl
@@ -315,5 +315,17 @@ let version = "25.07.1" in
       license_spdx = "MIT AND Apache-2.0 AND WTFPL",
       # source_provenance is deliberately absent: there is no single upstream to
       # point at, the package aggregates the 43 repositories pinned above.
+      #
+      # The VERSION, though, is helix's (25.07.1 = the helix release whose
+      # grammar pin-set this is), so the version check must read helix — not
+      # the first grammar repo. Without this, pkgmgr fell back to the first
+      # build_dep's source (tree-sitter/tree-sitter-bash, v0.25.1), compared it
+      # against 25.07.1 and clamped it as a "downgrade" every day (pkgmgr#773):
+      # a real helix release would have been invisible.
+      version_check_url = "https://api.github.com/repos/helix-editor/helix/releases/latest",
+      # No quotes or backslashes in the pattern on purpose: they do not survive
+      # the Nickel → pkgmgr round trip intact (the pattern arrived as a lone
+      # backslash). `.` stands in for the JSON quote characters.
+      version_check_regex = "tag_name.: *.([0-9]+[.][0-9]+([.][0-9]+)?)",
     } | Attrs,
 } | BuildSpec


### PR DESCRIPTION
helix-grammars carries no `source_provenance` on purpose (it aggregates 43 grammar repos), so pkgmgr's version check fell back to the **first build_dep's** source — `tree-sitter/tree-sitter-bash`, v0.25.1 — and compared that against the package's helix-scheme version 25.07.1. The no-downgrade clamp rejected it every day and the package rendered as plain **"up to date"** (pkgmgr#773): a real helix release would have been invisible.

The version *is* helix's (25.07.1 = the helix release whose grammar pin-set this is), so the check now reads helix's latest release via `version_check_url` + `version_check_regex`. The regex deliberately contains no quotes or backslashes — they don't survive the Nickel → pkgmgr round trip (first attempt arrived as a lone `\`); `.` stands in for the JSON quote characters.

**Verified locally** with `pkgmgr check --package helix-grammars`: the custom tier resolves helix and the package reports up to date at 25.07.1 instead of a degraded tier / daily clamp.

Attrs-only; nothing about the build moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helix release version checks to use the latest published release information.
  * Improved semantic version extraction for more reliable version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->