### PR TITLE
lean: ship the .olean.server/.olean.private sidecars — lean still compiled nothing after #605

### DIFF
--- a/packages/cadical/build.ncl
+++ b/packages/cadical/build.ncl
@@ -1,6 +1,7 @@
 let { subsetOf, Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
+let make = import "../make/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 
@@ -22,6 +23,7 @@ let version = "2.1.2" in
     } | Source,
     base,
     toolchain,
+    make,
   ],
 
   runtime_deps = [

--- a/packages/cadical/build.ncl
+++ b/packages/cadical/build.ncl
@@ -1,0 +1,64 @@
+let { subsetOf, Attrs, BuildSpec, Local, OutputBin, Source, Test, .. } = import "minimal.ncl" in
+let base = import "../base/build.ncl" in
+let toolchain = import "../toolchain/build.ncl" in
+let gcc = import "../gcc/build.ncl" in
+let glibc = import "../glibc/build.ncl" in
+
+# The release Lean 4.33 bundles as `bin/cadical` (lean4 CMake INSTALL_CADICAL).
+let version = "2.1.2" in
+{
+  name = "cadical",
+  # CaDiCaL, the SAT solver behind Lean's `bv_decide`. Official Lean releases
+  # ship it next to `lean`; a from-source lean build does not, and `bv_decide`
+  # then fails with "could not execute external process 'cadical'". It is found
+  # by name on PATH, so this package is enough.
+  build_deps = [
+    { file = "build.sh" } | Local,
+    {
+      url = "https://github.com/arminbiere/cadical/archive/refs/tags/rel-%{version}.tar.gz",
+      sha256 = "292c2bb8d712d6d05fce3d3df63b922b8fa45e03974a79f7bae5bf68c284f131",
+      extract = true,
+      strip_prefix = "cadical-rel-%{version}",
+    } | Source,
+    base,
+    toolchain,
+  ],
+
+  runtime_deps = [
+    glibc,
+    subsetOf gcc ["libgcc", "libstdcpp"],
+  ],
+
+  cmd = "./build.sh",
+  build_args = {
+    include version,
+  },
+
+  outputs = {
+    cadical = { glob = "usr/bin/cadical" } | OutputBin,
+  },
+
+  attrs =
+    {
+      upstream_version = version,
+      license_spdx = "MIT",
+      source_provenance = {
+        category = 'GithubRepo,
+        owner = "arminbiere",
+        repo = "cadical",
+      },
+    } | Attrs,
+
+  tests = {
+    smoke =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "cadical --version"],
+          # A two-clause satisfiable formula: exit code 10 is SAT by DIMACS convention.
+          ["/bin/bash", "-c", "printf 'p cnf 2 2\\n1 2 0\\n-1 0\\n' > /tmp/f.cnf; cadical -q /tmp/f.cnf; test $? -eq 10"],
+        ],
+      } | Test,
+  },
+} | BuildSpec

--- a/packages/cadical/build.sh
+++ b/packages/cadical/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+export CXX=g++
+export CXXFLAGS="-O2 -ffile-prefix-map=$(pwd)=/builddir -gno-record-gcc-switches"
+export LDFLAGS="-Wl,--build-id=none"
+./configure
+make -j"$(nproc)" cadical
+mkdir -p "$OUTPUT_DIR/usr/bin"
+cp build/cadical "$OUTPUT_DIR/usr/bin/cadical"

--- a/packages/lean/build.ncl
+++ b/packages/lean/build.ncl
@@ -5,6 +5,7 @@ let cmake = import "../cmake/build.ncl" in
 let make = import "../make/build.ncl" in
 let gmp = import "../gmp/build.ncl" in
 let libuv = import "../libuv/build.ncl" in
+let openssl = import "../openssl/build.ncl" in
 let pkgconf = import "../pkgconf/build.ncl" in
 let git = import "../git/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
@@ -33,6 +34,12 @@ let version = "4.33.0" in
     subsetOf gcc ["libgcc", "libstdcpp"],
     gmp,
     libuv,
+    # `lean` and `libleanshared.so` link libssl.so.3 / libcrypto.so.3 (lake's
+    # HTTP client). Without this the binary does not START in a closure that
+    # lacks openssl — `lean --version` exits 127 from the loader — which the
+    # standalone test below now catches. Every session that had run lean so
+    # far carried openssl through some other package, which is how it hid.
+    openssl,
   ],
 
   needs =

--- a/packages/lean/build.ncl
+++ b/packages/lean/build.ncl
@@ -68,6 +68,10 @@ let version = "4.33.0" in
     # `.ilean` is the language-server index (small; makes `lean --server` work).
     data = { glob = "usr/lib/lean/**/*.olean*" } | OutputData,
     ilean = { glob = "usr/lib/lean/**/*.ilean" } | OutputData,
+    # Compiled IR per module (`X.ir` + `X.ir.sig`). `lean` alone runs without
+    # them; `lake` cannot configure a project without them (see build.sh).
+    ir = { glob = "usr/lib/lean/**/*.ir" } | OutputData,
+    ir_sig = { glob = "usr/lib/lean/**/*.ir.sig" } | OutputData,
     # The MODULE ROOTS — `Init.olean`, `Std.olean`, `Lean.olean`, `Lake.olean`
     # — sit directly in `usr/lib/lean/`, and `**/` requires at least one
     # directory level, so the glob above matches `.../Init/Core.olean` but
@@ -84,6 +88,8 @@ let version = "4.33.0" in
     # module that makes the rest reachable.
     module_roots = { glob = "usr/lib/lean/*.olean*" } | OutputData,
     module_root_ileans = { glob = "usr/lib/lean/*.ilean" } | OutputData,
+    module_root_irs = { glob = "usr/lib/lean/*.ir" } | OutputData,
+    module_root_ir_sigs = { glob = "usr/lib/lean/*.ir.sig" } | OutputData,
   },
 
   # The check that has now failed twice for two different missing-file
@@ -98,6 +104,9 @@ let version = "4.33.0" in
         cmds = [
           ["/bin/bash", "-c", "printf '#eval 1+1\\n' > /tmp/t.lean && lean /tmp/t.lean"],
           ["/bin/bash", "-c", "printf 'theorem t : 1 + 1 = 2 := rfl\\n' > /tmp/u.lean && lean /tmp/u.lean"],
+          # `lake` must be able to configure and build a project: this is what
+          # the missing `.ir` files broke while `lean` itself still worked.
+          ["/bin/bash", "-c", "mkdir -p /tmp/lk && cd /tmp/lk && printf 'import Lake\\nopen Lake DSL\\npackage t\\n@[default_target] lean_lib T\\n' > lakefile.lean && mkdir -p T && printf 'def hello := 42\\n' > T.lean && LAKE_NO_CACHE=1 HOME=/tmp/lk lake build"],
         ],
       } | Test,
   },

--- a/packages/lean/build.ncl
+++ b/packages/lean/build.ncl
@@ -10,6 +10,7 @@ let pkgconf = import "../pkgconf/build.ncl" in
 let git = import "../git/build.ncl" in
 let glibc = import "../glibc/build.ncl" in
 let gcc = import "../gcc/build.ncl" in
+let cadical = import "../cadical/build.ncl" in
 
 let version = "4.33.0" in
 {
@@ -34,6 +35,11 @@ let version = "4.33.0" in
     subsetOf gcc ["libgcc", "libstdcpp"],
     gmp,
     libuv,
+    # `bv_decide` shells out to the `cadical` SAT solver by name on PATH. An
+    # official Lean release bundles it in `bin/`; built from source we don't
+    # get one, and `bv_decide` fails with "could not execute external process
+    # 'cadical'" (found building aeneas-latest). Same release Lean pins.
+    cadical,
     # `lean` and `libleanshared.so` link libssl.so.3 / libcrypto.so.3 (lake's
     # HTTP client). Without this the binary does not START in a closure that
     # lacks openssl — `lean --version` exits 127 from the loader — which the

--- a/packages/lean/build.ncl
+++ b/packages/lean/build.ncl
@@ -1,4 +1,4 @@
-let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, OutputLib, Source, .. } = import "minimal.ncl" in
+let { subsetOf, Attrs, BuildSpec, Local, Needs, OutputBin, OutputData, OutputLib, Source, Test, .. } = import "minimal.ncl" in
 let base = import "../base/build.ncl" in
 let toolchain = import "../toolchain/build.ncl" in
 let cmake = import "../cmake/build.ncl" in
@@ -54,7 +54,13 @@ let version = "4.33.0" in
     lean = { glob = "usr/bin/lean" } | OutputBin,
     libs = { glob = "usr/lib/lean/*.{a,so*}" } | OutputLib,
     includes = { glob = "usr/include/**" } | OutputData,
-    data = { glob = "usr/lib/lean/**/*.olean" } | OutputData,
+    # `*.olean*`: Lean >= 4.2x ships every module as `.olean` +
+    # `.olean.server` + `.olean.private`, and lean will not load a module whose
+    # sidecars are missing. The plain `*.olean` glob silently dropped the other
+    # two at packaging, so pkgs#605's root fix was necessary but not sufficient.
+    # `.ilean` is the language-server index (small; makes `lean --server` work).
+    data = { glob = "usr/lib/lean/**/*.olean*" } | OutputData,
+    ilean = { glob = "usr/lib/lean/**/*.ilean" } | OutputData,
     # The MODULE ROOTS — `Init.olean`, `Std.olean`, `Lean.olean`, `Lake.olean`
     # — sit directly in `usr/lib/lean/`, and `**/` requires at least one
     # directory level, so the glob above matches `.../Init/Core.olean` but
@@ -69,7 +75,24 @@ let version = "4.33.0" in
     # oleans ship under Init/ and Std/, and the root-level `.a`/`.so` arrive
     # via the `libs` glob above — the only absent class is the one file per
     # module that makes the rest reachable.
-    module_roots = { glob = "usr/lib/lean/*.olean" } | OutputData,
+    module_roots = { glob = "usr/lib/lean/*.olean*" } | OutputData,
+    module_root_ileans = { glob = "usr/lib/lean/*.ilean" } | OutputData,
+  },
+
+  # The check that has now failed twice for two different missing-file
+  # classes (pkgs#605: no roots; this PR: no sidecars). If lean cannot
+  # compile `#eval 1+1`, it cannot compile anything, and no other output of
+  # this package matters.
+  tests = {
+    compiles_hello =
+      {
+        class = 'Standalone,
+        test_deps = [base],
+        cmds = [
+          ["/bin/bash", "-c", "printf '#eval 1+1\\n' > /tmp/t.lean && lean /tmp/t.lean"],
+          ["/bin/bash", "-c", "printf 'theorem t : 1 + 1 = 2 := rfl\\n' > /tmp/u.lean && lean /tmp/u.lean"],
+        ],
+      } | Test,
   },
   attrs =
     {

--- a/packages/lean/build.sh
+++ b/packages/lean/build.sh
@@ -46,7 +46,14 @@ cp -a "$STAGE/lib/lean/"*.so* "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 # Init/ and Std/, and the root-level .a/.so came across in the two copies
 # above. The only missing class was the one file per module that makes all the
 # rest reachable.
-cp -a "$STAGE/lib/lean/"*.olean "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
+# `*.olean*`, not `*.olean`: since Lean 4.2x each module is THREE files —
+# `X.olean`, `X.olean.server`, `X.olean.private` — and lean refuses to load a
+# module whose sidecars are missing ("failed to open file
+# '/usr/lib/lean/Init.olean.server'"). `.ilean` is the language-server index;
+# small, and what makes `lean --server` usable. pkgs#605 shipped the roots'
+# `.olean` and lean STILL compiled nothing — this is the other half.
+cp -a "$STAGE/lib/lean/"*.olean* "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
+cp -a "$STAGE/lib/lean/"*.ilean "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 
 # Then ASSERT they arrived. The copy above swallows errors (the `|| true` is
 # there so a layout change upstream doesn't hard-fail the copy), and a glob
@@ -59,6 +66,12 @@ for m in Init Std Lean Lake; do
     echo "lean: module root $m.olean is MISSING from the install tree." >&2
     echo "  Without it, 'import $m' cannot resolve and lean compiles nothing." >&2
     echo "  Check whether upstream moved lib/lean/*.olean in this release." >&2
+    exit 1
+  fi
+  # The sidecars are load-bearing too; a root whose .olean.server is absent
+  # fails `import` exactly like a missing .olean (Lean >= 4.2x layout).
+  if [ ! -f "$OUTPUT_DIR/usr/lib/lean/$m.olean.server" ]; then
+    echo "lean: $m.olean.server is MISSING — Lean splits modules into .olean/.olean.server/.olean.private; lean cannot load $m without all three." >&2
     exit 1
   fi
 done

--- a/packages/lean/build.sh
+++ b/packages/lean/build.sh
@@ -54,6 +54,15 @@ cp -a "$STAGE/lib/lean/"*.so* "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 # `.olean` and lean STILL compiled nothing — this is the other half.
 cp -a "$STAGE/lib/lean/"*.olean* "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 cp -a "$STAGE/lib/lean/"*.ilean "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
+# `.ir` / `.ir.sig`: the compiled IR of each module, a separate file since
+# Lean 4.2x. `lean` elaborates and `#eval`s without them, so a compile test
+# passes — but `lake` COMPILES the definitions in a lakefile and fails its
+# "compiler IR check" on the first private `Init` declaration they touch:
+#   failed to compile definition, compiler IR check failed at `config…`:
+#   depends on declaration '_private.Init.Data.Array.Basic…'
+# so without these no Lake project can even be configured. (Found building
+# aeneas-latest; the reference toolchain ships 2,483 of them.)
+cp -a "$STAGE/lib/lean/"*.ir "$STAGE/lib/lean/"*.ir.sig "$OUTPUT_DIR/usr/lib/lean/" 2>/dev/null || true
 
 # Then ASSERT they arrived. The copy above swallows errors (the `|| true` is
 # there so a layout change upstream doesn't hard-fail the copy), and a glob
@@ -70,6 +79,10 @@ for m in Init Std Lean Lake; do
   fi
   # The sidecars are load-bearing too; a root whose .olean.server is absent
   # fails `import` exactly like a missing .olean (Lean >= 4.2x layout).
+  if [ ! -f "$OUTPUT_DIR/usr/lib/lean/$m.ir" ]; then
+    echo "lean: $m.ir is MISSING — lake needs each module's compiled IR to configure any project." >&2
+    exit 1
+  fi
   if [ ! -f "$OUTPUT_DIR/usr/lib/lean/$m.olean.server" ]; then
     echo "lean: $m.olean.server is MISSING — Lean splits modules into .olean/.olean.server/.olean.private; lean cannot load $m without all three." >&2
     exit 1


### PR DESCRIPTION
pkgs#605 shipped the module roots' `.olean`, and `lean` **still** cannot compile `#eval 1+1` (verified in a fresh session built from main today):

```
error: failed to open file '/usr/lib/lean/Init.olean.server': No such file or directory
```

Since Lean 4.2x every module is **three** files — `X.olean`, `X.olean.server`, `X.olean.private` — and lean refuses to load a module whose sidecars are missing. Both the install script (`cp *.olean`) and the output globs (`**/*.olean`, `*.olean`) carried only the first: the session's tree has **2,485 `.olean` and 0 sidecars**.

## Change
- `build.sh`: `cp *.olean*` (+ `*.ilean`, the language-server index) at the root; the root-module check now also demands `$m.olean.server`, so the next layout change fails the build instead of shipping a lean that compiles nothing.
- `build.ncl`: `**/*.olean*` / `*.olean*` globs, plus `.ilean` outputs.
- **New standalone test**: compiles `#eval 1+1` and `theorem t : 1 + 1 = 2 := rfl`. This exact check has now failed twice for two different missing-file classes; it belongs in the package.

## Why it matters
This is the last step of the aeneas verification bench (charon → aeneas → **lean**). The first two have worked since 2026-08-13; with this, `./verify` in the lab can actually check a model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the CaDiCaL 2.1.2 SAT solver package, including its command-line executable and runtime support.
  - Lean packages now include compiled module files, `.olean` sidecars, `.ilean` indexes, and intermediate representation artifacts.
  - Root-level compiled artifacts are included.
  - Lean runtime packaging includes required OpenSSL support.

- **Bug Fixes**
  - Lean installations now verify required server sidecars and report an error when one is missing.

- **Tests**
  - Added coverage for CaDiCaL version reporting and SAT formula solving.
  - Added validation for Lean compilation, Lake configuration, and builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->